### PR TITLE
오픈마켓[Step1-1] Jost, Jamking

### DIFF
--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFCFB26C2440F00B338E0 /* MarketItem.swift */; };
+		797C878726C249700088062F /* MarketItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878626C249700088062F /* MarketItems.swift */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
 		C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */; };
 		C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FE25BEF61C00C9924E /* ViewController.swift */; };
@@ -18,6 +19,7 @@
 
 /* Begin PBXFileReference section */
 		273CFCFB26C2440F00B338E0 /* MarketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItem.swift; sourceTree = "<group>"; };
+		797C878626C249700088062F /* MarketItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItems.swift; sourceTree = "<group>"; };
 		C70FB0F725BEF61C00C9924E /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -43,6 +45,7 @@
 			isa = PBXGroup;
 			children = (
 				273CFCFB26C2440F00B338E0 /* MarketItem.swift */,
+				797C878626C249700088062F /* MarketItems.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -151,6 +154,7 @@
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
 				273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */,
+				797C878726C249700088062F /* MarketItems.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFCFB26C2440F00B338E0 /* MarketItem.swift */; };
 		273CFD0126C24F0C00B338E0 /* Items.json in Resources */ = {isa = PBXBuildFile; fileRef = 273CFD0026C24F0C00B338E0 /* Items.json */; };
+		273CFD0326C29B2600B338E0 /* Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFD0226C29B2600B338E0 /* Api.swift */; };
+		273CFD0626C29D6800B338E0 /* MockApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFD0526C29D6800B338E0 /* MockApiClient.swift */; };
 		797C878726C249700088062F /* MarketItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878626C249700088062F /* MarketItems.swift */; };
 		797C878926C258610088062F /* JSONDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878826C258610088062F /* JSONDecodable.swift */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
@@ -22,6 +24,8 @@
 /* Begin PBXFileReference section */
 		273CFCFB26C2440F00B338E0 /* MarketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItem.swift; sourceTree = "<group>"; };
 		273CFD0026C24F0C00B338E0 /* Items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Items.json; sourceTree = "<group>"; };
+		273CFD0226C29B2600B338E0 /* Api.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Api.swift; sourceTree = "<group>"; };
+		273CFD0526C29D6800B338E0 /* MockApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApiClient.swift; sourceTree = "<group>"; };
 		797C878626C249700088062F /* MarketItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItems.swift; sourceTree = "<group>"; };
 		797C878826C258610088062F /* JSONDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodable.swift; sourceTree = "<group>"; };
 		C70FB0F725BEF61C00C9924E /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -62,10 +66,19 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+		273CFD0426C29B9E00B338E0 /* ApiClients */ = {
+			isa = PBXGroup;
+			children = (
+				273CFD0526C29D6800B338E0 /* MockApiClient.swift */,
+			);
+			path = ApiClients;
+			sourceTree = "<group>";
+		};
 		797C878A26C26BB20088062F /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
 				797C878826C258610088062F /* JSONDecodable.swift */,
+				273CFD0226C29B2600B338E0 /* Api.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -89,6 +102,7 @@
 		C70FB0F925BEF61C00C9924E /* OpenMarket */ = {
 			isa = PBXGroup;
 			children = (
+				273CFD0426C29B9E00B338E0 /* ApiClients */,
 				797C878A26C26BB20088062F /* Protocols */,
 				273CFCFD26C24BEE00B338E0 /* Mocks */,
 				273CFCFA26C2439700B338E0 /* Models */,
@@ -175,11 +189,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				797C878926C258610088062F /* JSONDecodable.swift in Sources */,
+				273CFD0626C29D6800B338E0 /* MockApiClient.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
 				273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */,
 				797C878726C249700088062F /* MarketItems.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,
+				273CFD0326C29B2600B338E0 /* Api.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFCFB26C2440F00B338E0 /* MarketItem.swift */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
 		C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */; };
 		C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FE25BEF61C00C9924E /* ViewController.swift */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		273CFCFB26C2440F00B338E0 /* MarketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItem.swift; sourceTree = "<group>"; };
 		C70FB0F725BEF61C00C9924E /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -37,6 +39,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		273CFCFA26C2439700B338E0 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				273CFCFB26C2440F00B338E0 /* MarketItem.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		C70FB0EE25BEF61C00C9924E = {
 			isa = PBXGroup;
 			children = (
@@ -56,6 +66,7 @@
 		C70FB0F925BEF61C00C9924E /* OpenMarket */ = {
 			isa = PBXGroup;
 			children = (
+				273CFCFA26C2439700B338E0 /* Models */,
 				C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */,
 				C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */,
 				C70FB0FE25BEF61C00C9924E /* ViewController.swift */,
@@ -139,6 +150,7 @@
 			files = (
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
+				273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFCFB26C2440F00B338E0 /* MarketItem.swift */; };
+		273CFD0126C24F0C00B338E0 /* Items.json in Resources */ = {isa = PBXBuildFile; fileRef = 273CFD0026C24F0C00B338E0 /* Items.json */; };
 		797C878726C249700088062F /* MarketItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878626C249700088062F /* MarketItems.swift */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
 		C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */; };
@@ -19,6 +20,7 @@
 
 /* Begin PBXFileReference section */
 		273CFCFB26C2440F00B338E0 /* MarketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItem.swift; sourceTree = "<group>"; };
+		273CFD0026C24F0C00B338E0 /* Items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Items.json; sourceTree = "<group>"; };
 		797C878626C249700088062F /* MarketItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItems.swift; sourceTree = "<group>"; };
 		C70FB0F725BEF61C00C9924E /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -50,6 +52,14 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		273CFCFD26C24BEE00B338E0 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				273CFD0026C24F0C00B338E0 /* Items.json */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		C70FB0EE25BEF61C00C9924E = {
 			isa = PBXGroup;
 			children = (
@@ -69,6 +79,7 @@
 		C70FB0F925BEF61C00C9924E /* OpenMarket */ = {
 			isa = PBXGroup;
 			children = (
+				273CFCFD26C24BEE00B338E0 /* Mocks */,
 				273CFCFA26C2439700B338E0 /* Models */,
 				C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */,
 				C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */,
@@ -138,6 +149,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				273CFD0126C24F0C00B338E0 /* Items.json in Resources */,
 				C70FB10725BEF61D00C9924E /* LaunchScreen.storyboard in Resources */,
 				C70FB10425BEF61D00C9924E /* Assets.xcassets in Resources */,
 				C70FB10225BEF61C00C9924E /* Main.storyboard in Resources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		797C878726C249700088062F /* MarketItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878626C249700088062F /* MarketItems.swift */; };
 		797C878926C258610088062F /* JSONDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878826C258610088062F /* JSONDecodable.swift */; };
 		797C879626C2A7D80088062F /* OpenMarketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C879526C2A7D80088062F /* OpenMarketTests.swift */; };
+		797C879E26C2D2C30088062F /* MarketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C879D26C2D2C30088062F /* MarketItem.swift */; };
+		797C87A226C2D41A0088062F /* RequestMarketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C87A126C2D41A0088062F /* RequestMarketItem.swift */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
 		C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */; };
 		C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FE25BEF61C00C9924E /* ViewController.swift */; };
@@ -44,6 +46,8 @@
 		797C879326C2A7D80088062F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		797C879526C2A7D80088062F /* OpenMarketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenMarketTests.swift; sourceTree = "<group>"; };
 		797C879726C2A7D80088062F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		797C879D26C2D2C30088062F /* MarketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItem.swift; sourceTree = "<group>"; };
+		797C87A126C2D41A0088062F /* RequestMarketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMarketItem.swift; sourceTree = "<group>"; };
 		C70FB0F725BEF61C00C9924E /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -77,6 +81,8 @@
 			children = (
 				273CFCFB26C2440F00B338E0 /* MarketPageItem.swift */,
 				797C878626C249700088062F /* MarketItems.swift */,
+				797C879D26C2D2C30088062F /* MarketItem.swift */,
+				797C87A126C2D41A0088062F /* RequestMarketItem.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -266,10 +272,12 @@
 				273CFD0626C29D6800B338E0 /* MockApiClient.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
+				797C879E26C2D2C30088062F /* MarketItem.swift in Sources */,
 				273CFCFC26C2440F00B338E0 /* MarketPageItem.swift in Sources */,
 				797C878726C249700088062F /* MarketItems.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,
 				273CFD0326C29B2600B338E0 /* Api.swift in Sources */,
+				797C87A226C2D41A0088062F /* RequestMarketItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFCFB26C2440F00B338E0 /* MarketItem.swift */; };
 		273CFD0126C24F0C00B338E0 /* Items.json in Resources */ = {isa = PBXBuildFile; fileRef = 273CFD0026C24F0C00B338E0 /* Items.json */; };
 		797C878726C249700088062F /* MarketItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878626C249700088062F /* MarketItems.swift */; };
+		797C878926C258610088062F /* JSONDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878826C258610088062F /* JSONDecodable.swift */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
 		C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */; };
 		C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FE25BEF61C00C9924E /* ViewController.swift */; };
@@ -22,6 +23,7 @@
 		273CFCFB26C2440F00B338E0 /* MarketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItem.swift; sourceTree = "<group>"; };
 		273CFD0026C24F0C00B338E0 /* Items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Items.json; sourceTree = "<group>"; };
 		797C878626C249700088062F /* MarketItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItems.swift; sourceTree = "<group>"; };
+		797C878826C258610088062F /* JSONDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodable.swift; sourceTree = "<group>"; };
 		C70FB0F725BEF61C00C9924E /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -60,6 +62,14 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+		797C878A26C26BB20088062F /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				797C878826C258610088062F /* JSONDecodable.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
 		C70FB0EE25BEF61C00C9924E = {
 			isa = PBXGroup;
 			children = (
@@ -79,6 +89,7 @@
 		C70FB0F925BEF61C00C9924E /* OpenMarket */ = {
 			isa = PBXGroup;
 			children = (
+				797C878A26C26BB20088062F /* Protocols */,
 				273CFCFD26C24BEE00B338E0 /* Mocks */,
 				273CFCFA26C2439700B338E0 /* Models */,
 				C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */,
@@ -163,6 +174,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				797C878926C258610088062F /* JSONDecodable.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
 				273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -7,10 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFCFB26C2440F00B338E0 /* MarketItem.swift */; };
+		273CFCFC26C2440F00B338E0 /* MarketPageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFCFB26C2440F00B338E0 /* MarketPageItem.swift */; };
 		273CFD0126C24F0C00B338E0 /* Items.json in Resources */ = {isa = PBXBuildFile; fileRef = 273CFD0026C24F0C00B338E0 /* Items.json */; };
 		273CFD0326C29B2600B338E0 /* Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFD0226C29B2600B338E0 /* Api.swift */; };
 		273CFD0626C29D6800B338E0 /* MockApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFD0526C29D6800B338E0 /* MockApiClient.swift */; };
+		273CFD0826C2C74400B338E0 /* Item.json in Resources */ = {isa = PBXBuildFile; fileRef = 273CFD0726C2C74400B338E0 /* Item.json */; };
 		797C878726C249700088062F /* MarketItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878626C249700088062F /* MarketItems.swift */; };
 		797C878926C258610088062F /* JSONDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878826C258610088062F /* JSONDecodable.swift */; };
 		797C879626C2A7D80088062F /* OpenMarketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C879526C2A7D80088062F /* OpenMarketTests.swift */; };
@@ -33,10 +34,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		273CFCFB26C2440F00B338E0 /* MarketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItem.swift; sourceTree = "<group>"; };
+		273CFCFB26C2440F00B338E0 /* MarketPageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketPageItem.swift; sourceTree = "<group>"; };
 		273CFD0026C24F0C00B338E0 /* Items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Items.json; sourceTree = "<group>"; };
 		273CFD0226C29B2600B338E0 /* Api.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Api.swift; sourceTree = "<group>"; };
 		273CFD0526C29D6800B338E0 /* MockApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApiClient.swift; sourceTree = "<group>"; };
+		273CFD0726C2C74400B338E0 /* Item.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Item.json; sourceTree = "<group>"; };
 		797C878626C249700088062F /* MarketItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItems.swift; sourceTree = "<group>"; };
 		797C878826C258610088062F /* JSONDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodable.swift; sourceTree = "<group>"; };
 		797C879326C2A7D80088062F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -73,7 +75,7 @@
 		273CFCFA26C2439700B338E0 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				273CFCFB26C2440F00B338E0 /* MarketItem.swift */,
+				273CFCFB26C2440F00B338E0 /* MarketPageItem.swift */,
 				797C878626C249700088062F /* MarketItems.swift */,
 			);
 			path = Models;
@@ -83,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				273CFD0026C24F0C00B338E0 /* Items.json */,
+				273CFD0726C2C74400B338E0 /* Item.json */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -240,6 +243,7 @@
 				C70FB10725BEF61D00C9924E /* LaunchScreen.storyboard in Resources */,
 				C70FB10425BEF61D00C9924E /* Assets.xcassets in Resources */,
 				C70FB10225BEF61C00C9924E /* Main.storyboard in Resources */,
+				273CFD0826C2C74400B338E0 /* Item.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,7 +266,7 @@
 				273CFD0626C29D6800B338E0 /* MockApiClient.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
-				273CFCFC26C2440F00B338E0 /* MarketItem.swift in Sources */,
+				273CFCFC26C2440F00B338E0 /* MarketPageItem.swift in Sources */,
 				797C878726C249700088062F /* MarketItems.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,
 				273CFD0326C29B2600B338E0 /* Api.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		273CFD0626C29D6800B338E0 /* MockApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFD0526C29D6800B338E0 /* MockApiClient.swift */; };
 		797C878726C249700088062F /* MarketItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878626C249700088062F /* MarketItems.swift */; };
 		797C878926C258610088062F /* JSONDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878826C258610088062F /* JSONDecodable.swift */; };
+		797C879626C2A7D80088062F /* OpenMarketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C879526C2A7D80088062F /* OpenMarketTests.swift */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
 		C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */; };
 		C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FE25BEF61C00C9924E /* ViewController.swift */; };
@@ -21,6 +22,16 @@
 		C70FB10725BEF61D00C9924E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C70FB10525BEF61D00C9924E /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		797C879826C2A7D80088062F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C70FB0EF25BEF61C00C9924E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C70FB0F625BEF61C00C9924E;
+			remoteInfo = OpenMarket;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		273CFCFB26C2440F00B338E0 /* MarketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItem.swift; sourceTree = "<group>"; };
 		273CFD0026C24F0C00B338E0 /* Items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Items.json; sourceTree = "<group>"; };
@@ -28,6 +39,9 @@
 		273CFD0526C29D6800B338E0 /* MockApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApiClient.swift; sourceTree = "<group>"; };
 		797C878626C249700088062F /* MarketItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItems.swift; sourceTree = "<group>"; };
 		797C878826C258610088062F /* JSONDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodable.swift; sourceTree = "<group>"; };
+		797C879326C2A7D80088062F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		797C879526C2A7D80088062F /* OpenMarketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenMarketTests.swift; sourceTree = "<group>"; };
+		797C879726C2A7D80088062F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C70FB0F725BEF61C00C9924E /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -39,6 +53,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		797C879026C2A7D80088062F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C70FB0F425BEF61C00C9924E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -83,10 +104,20 @@
 			path = Protocols;
 			sourceTree = "<group>";
 		};
+		797C879426C2A7D80088062F /* OpenMarketTests */ = {
+			isa = PBXGroup;
+			children = (
+				797C879526C2A7D80088062F /* OpenMarketTests.swift */,
+				797C879726C2A7D80088062F /* Info.plist */,
+			);
+			path = OpenMarketTests;
+			sourceTree = "<group>";
+		};
 		C70FB0EE25BEF61C00C9924E = {
 			isa = PBXGroup;
 			children = (
 				C70FB0F925BEF61C00C9924E /* OpenMarket */,
+				797C879426C2A7D80088062F /* OpenMarketTests */,
 				C70FB0F825BEF61C00C9924E /* Products */,
 			);
 			sourceTree = "<group>";
@@ -95,6 +126,7 @@
 			isa = PBXGroup;
 			children = (
 				C70FB0F725BEF61C00C9924E /* OpenMarket.app */,
+				797C879326C2A7D80088062F /* OpenMarketTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -120,6 +152,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		797C879226C2A7D80088062F /* OpenMarketTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 797C879C26C2A7D80088062F /* Build configuration list for PBXNativeTarget "OpenMarketTests" */;
+			buildPhases = (
+				797C878F26C2A7D80088062F /* Sources */,
+				797C879026C2A7D80088062F /* Frameworks */,
+				797C879126C2A7D80088062F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				797C879926C2A7D80088062F /* PBXTargetDependency */,
+			);
+			name = OpenMarketTests;
+			productName = OpenMarketTests;
+			productReference = 797C879326C2A7D80088062F /* OpenMarketTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C70FB0F625BEF61C00C9924E /* OpenMarket */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C70FB10B25BEF61D00C9924E /* Build configuration list for PBXNativeTarget "OpenMarket" */;
@@ -143,9 +193,13 @@
 		C70FB0EF25BEF61C00C9924E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1230;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1230;
 				TargetAttributes = {
+					797C879226C2A7D80088062F = {
+						CreatedOnToolsVersion = 12.5;
+						TestTargetID = C70FB0F625BEF61C00C9924E;
+					};
 					C70FB0F625BEF61C00C9924E = {
 						CreatedOnToolsVersion = 12.3;
 					};
@@ -165,11 +219,19 @@
 			projectRoot = "";
 			targets = (
 				C70FB0F625BEF61C00C9924E /* OpenMarket */,
+				797C879226C2A7D80088062F /* OpenMarketTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		797C879126C2A7D80088062F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C70FB0F525BEF61C00C9924E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -184,6 +246,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		797C878F26C2A7D80088062F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				797C879626C2A7D80088062F /* OpenMarketTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C70FB0F325BEF61C00C9924E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -200,6 +270,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		797C879926C2A7D80088062F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C70FB0F625BEF61C00C9924E /* OpenMarket */;
+			targetProxy = 797C879826C2A7D80088062F /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C70FB10025BEF61C00C9924E /* Main.storyboard */ = {
@@ -221,6 +299,46 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		797C879A26C2A7D80088062F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = OpenMarketTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.wisdomH.OpenMarketTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OpenMarket.app/OpenMarket";
+			};
+			name = Debug;
+		};
+		797C879B26C2A7D80088062F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = OpenMarketTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.wisdomH.OpenMarketTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OpenMarket.app/OpenMarket";
+			};
+			name = Release;
+		};
 		C70FB10925BEF61D00C9924E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -378,6 +496,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		797C879C26C2A7D80088062F /* Build configuration list for PBXNativeTarget "OpenMarketTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				797C879A26C2A7D80088062F /* Debug */,
+				797C879B26C2A7D80088062F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C70FB0F225BEF61C00C9924E /* Build configuration list for PBXProject "OpenMarket" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
@@ -10,9 +10,9 @@ import Foundation
 class MockApiClient: Api, JSONDecodable {
     private static let delay = 1
     
-    func getMarketItems(for page: Int, completion: @escaping (MarketItems?) -> Void) {
+    func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void) {
         DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(MockApiClient.delay)) {
-            switch page {
+            switch pageNumber {
             case 1:
                 let fileName = "Items"
                 do {
@@ -26,6 +26,24 @@ class MockApiClient: Api, JSONDecodable {
                 completion(nil)
             }
             
+        }
+    }
+    
+    func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(MockApiClient.delay)) {
+            switch id {
+            case 1:
+                let fileName = "Item"
+                do {
+                    let jsonData = try self.readLocalFile(for: fileName)
+                    let item: MarketItem = try self.decodeJSON(from: jsonData)
+                    completion(item)
+                } catch {
+                    completion(nil)
+                }
+            default:
+                completion(nil)
+            }
         }
     }
 }

--- a/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
@@ -8,18 +8,24 @@
 import Foundation
 
 class MockApiClient: Api, JSONDecodable {
-    private static let delay = 5
+    private static let delay = 1
     
-    func fetchMarketItems(completion: @escaping (MarketItems?) -> Void) {
+    func getMarketItems(for page: Int, completion: @escaping (MarketItems?) -> Void) {
         DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(MockApiClient.delay)) {
-            let fileName = "Items"
-            do {
-                let jsonData = try self.readLocalFile(for: fileName)
-                let items: MarketItems = try self.decodeJSON(from: jsonData)
-                completion(items)
-            } catch {
+            switch page {
+            case 1:
+                let fileName = "Items"
+                do {
+                    let jsonData = try self.readLocalFile(for: fileName)
+                    let items: MarketItems = try self.decodeJSON(from: jsonData)
+                    completion(items)
+                } catch {
+                    completion(nil)
+                }
+            default:
                 completion(nil)
             }
+            
         }
     }
 }

--- a/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class MockApiClient: Api, JSONDecodable {
+class MockApiClient: MockApi, JSONDecodable {
     private static let delay = 1
     
     func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void) {
@@ -25,7 +25,6 @@ class MockApiClient: Api, JSONDecodable {
             default:
                 completion(nil)
             }
-            
         }
     }
     

--- a/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
@@ -1,0 +1,25 @@
+//
+//  MockApiClient.swift
+//  OpenMarket
+//
+//  Created by jost, 잼킹 on 2021/08/10.
+//
+
+import Foundation
+
+class MockApiClient: Api, JSONDecodable {
+    private static let delay = 5
+    
+    func fetchMarketItems(completion: @escaping (MarketItems?) -> Void) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(MockApiClient.delay)) {
+            let fileName = "Items"
+            do {
+                let jsonData = try self.readLocalFile(for: fileName)
+                let items: MarketItems = try self.decodeJSON(from: jsonData)
+                completion(items)
+            } catch {
+                completion(nil)
+            }
+        }
+    }
+}

--- a/OpenMarket/OpenMarket/Mocks/Item.json
+++ b/OpenMarket/OpenMarket/Mocks/Item.json
@@ -1,0 +1,17 @@
+{
+    "id": 1,
+    "title": "MacBook Pro",
+    "descriptions": "Apple M1 칩은 13형 MacBook Pro에 믿을 수 없을 만큼의 속도와 파워를 선사합니다.\n최대 2.8배 향상된 CPU 성능, 최대 5배 빨라진 그래픽 속도, 최대 11배 빨라진 머신 러닝 성능을 구현하는 최첨단 Apple 제작 Neural Engine, 여기에 무려 20시간 지속되는 Mac 사상 가장 오래가는 배터리까지.\n외장은 Apple의 가장 사랑받는 프로용 노트북 그대로, 하지만 그 능력은 한 차원 더 높아졌습니다.",
+    "price": 1690000,
+    "currency": "KRW",
+    "stock": 1000000000000,
+    "thumbnails": [
+        "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/1-1.png",
+        "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/1-2.png"
+    ],
+    "images": [
+        "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/images/1-1.png",
+        "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/images/1-2.png"
+    ],
+    "registration_date": 1611523563.719116
+}

--- a/OpenMarket/OpenMarket/Mocks/Items.json
+++ b/OpenMarket/OpenMarket/Mocks/Items.json
@@ -1,0 +1,251 @@
+{
+    "page": 1,
+    "items": [
+        {
+            "id": 1,
+            "title": "MacBook Pro",
+            "price": 1690,
+            "currency": "USD",
+            "stock": 0,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/1-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/1-2.png"
+            ],
+            "registration_date": 1611523563.7237701
+        },
+        {
+            "id": 2,
+            "title": "MacBook Air",
+            "price": 1290000,
+            "currency": "KRW",
+            "stock": 1000000000000,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/2-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/2-2.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/2-3.png"
+            ],
+            "registration_date": 1611523563.719116
+        },
+        {
+            "id": 3,
+            "title": "Mac mini",
+            "price": 890000,
+            "currency": "KRW",
+            "stock": 90,
+            "discounted_price": 89000,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/3-1.png"
+            ],
+            "registration_date": 1611523563.7245178
+        },
+        {
+            "id": 4,
+            "title": "iPad Pro",
+            "price": 999000,
+            "currency": "KRW",
+            "stock": 200000000,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/4-1.png"
+            ],
+            "registration_date": 1611523563.737014
+        },
+        {
+            "id": 5,
+            "title": "Apple Pencil",
+            "price": 165,
+            "currency": "USD",
+            "stock": 5000000,
+            "discounted_price": 160,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/5-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/5-2.png"
+            ],
+            "registration_date": 1611523563.725668
+        },
+        {
+            "id": 6,
+            "title": "iPhone 12 Pro",
+            "price": 1350,
+            "currency": "USD",
+            "stock": 0,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/6-1.png"
+            ],
+            "registration_date": 1611523563.72621
+        },
+        {
+            "id": 7,
+            "title": "iPhone 12 mini",
+            "price": 950000,
+            "currency": "KRW",
+            "stock": 500,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/7-1.png"
+            ],
+            "registration_date": 1611523563.726968
+        },
+        {
+            "id": 8,
+            "title": "AirPods Max",
+            "price": 719,
+            "currency": "USD",
+            "stock": 1000000000000,
+            "discounted_price": 500,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/8-1.png"
+            ],
+            "registration_date": 1611523563.727608
+        },
+        {
+            "id": 9,
+            "title": "Apple Watch Series 6",
+            "price": 539000,
+            "currency": "KRW",
+            "stock": 500,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/9-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/9-2.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/9-3.png"
+            ],
+            "registration_date": 1611523563.728167
+        },
+        {
+            "id": 10,
+            "title": "AirTag",
+            "price": 39,
+            "currency": "USD",
+            "stock": 90000,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/10-1.png"
+            ],
+            "registration_date": 1611523563.7287378
+        },
+        {
+            "id": 11,
+            "title": "MagSafe 충전기",
+            "price": 55000,
+            "currency": "KRW",
+            "stock": 1500000000,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/11-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/11-2.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/11-3.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/11-4.png"
+            ],
+            "registration_date": 1611523563.7292829
+        },
+        {
+            "id": 12,
+            "title": "Magic Trackpad 2",
+            "price": 179000,
+            "currency": "KRW",
+            "stock": 200,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/12-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/12-2.png"
+            ],
+            "registration_date": 1611523563.729826
+        },
+        {
+            "id": 13,
+            "title": "12.9형 iPad Pro(5세대)용 Magic Keyboard",
+            "price": 449000,
+            "currency": "KRW",
+            "stock": 9000000000,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/13-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/13-2.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/13-3.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/13-4.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/13-5.png"
+            ],
+            "registration_date": 1611523563.730362
+        },
+        {
+            "id": 14,
+            "title": "MagSafe형 iPhone 가죽 카드지갑",
+            "price": 75000,
+            "currency": "KRW",
+            "stock": 50000,
+            "discounted_price": 70000,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/14-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/14-2.png"
+            ],
+            "registration_date": 1611523563.7309098
+        },
+        {
+            "id": 15,
+            "title": "AirTag 루프",
+            "price": 39000,
+            "currency": "KRW",
+            "stock": 3000,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/15-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/15-2.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/15-3.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/15-4.png"
+            ],
+            "registration_date": 1611523563.7314491
+        },
+        {
+            "id": 16,
+            "title": "MagSafe형 iPhone 12 mini 실리콘 케이스",
+            "price": 59000,
+            "currency": "KRW",
+            "stock": 0,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/16-1.png"
+            ],
+            "registration_date": 1611523563.732012
+        },
+        {
+            "id": 17,
+            "title": "밀레니즈 루프",
+            "price": 125000,
+            "currency": "KRW",
+            "stock": 90000,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/17-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/17-2.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/17-3.png"
+            ],
+            "registration_date": 1611523563.732594
+        },
+        {
+            "id": 18,
+            "title": "Hermès 점핑 싱글 투어",
+            "price": 449,
+            "currency": "USD",
+            "stock": 0,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/18-1.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/18-2.png",
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/18-3.png"
+            ],
+            "registration_date": 1611523563.7334251
+        },
+        {
+            "id": 19,
+            "title": "Pro Display XDR",
+            "price": 6499,
+            "currency": "USD",
+            "stock": 99,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/19-1.png"
+            ],
+            "registration_date": 1611523563.734062
+        },
+        {
+            "id": 20,
+            "title": "Magic Keyboard with Numeric Keypad",
+            "price": 179,
+            "currency": "USD",
+            "stock": 0,
+            "thumbnails": [
+                "https://camp-open-market.s3.ap-northeast-2.amazonaws.com/thumbnails/20-1.png"
+            ],
+            "registration_date": 1611523563.7466989
+        }
+    ]
+}

--- a/OpenMarket/OpenMarket/Models/MarketItem.swift
+++ b/OpenMarket/OpenMarket/Models/MarketItem.swift
@@ -2,7 +2,7 @@
 //  MarketItem.swift
 //  OpenMarket
 //
-//  Created by 잼킹 on 2021/08/10.
+//  Created by Jost, 잼킹 on 2021/08/10.
 //
 
 import Foundation

--- a/OpenMarket/OpenMarket/Models/MarketItem.swift
+++ b/OpenMarket/OpenMarket/Models/MarketItem.swift
@@ -1,0 +1,24 @@
+//
+//  MarketItem.swift
+//  OpenMarket
+//
+//  Created by 잼킹 on 2021/08/10.
+//
+
+import Foundation
+
+struct MarketItem: Codable {
+    var id: Int
+    var title: String
+    var descriptions: String
+    var price: Int
+    var currency: String
+    var stock: Int
+    var thumbnails: [String]
+    var images: [String]
+    var registrationDate: Double
+    
+    enum CodinKeys: String, CodingKey {
+        case registrationDate = "registration_date"
+    }
+}

--- a/OpenMarket/OpenMarket/Models/MarketItem.swift
+++ b/OpenMarket/OpenMarket/Models/MarketItem.swift
@@ -10,15 +10,18 @@ import Foundation
 struct MarketItem: Codable {
     var id: Int
     var title: String
-    var descriptions: String
+    var descriptions: String?
     var price: Int
+    var discountedPrice: Int?
     var currency: String
     var stock: Int
     var thumbnails: [String]
-    var images: [String]
+    var images: [String]?
     var registrationDate: Double
     
-    enum CodinKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case registrationDate = "registration_date"
+        case discountedPrice = "discounted_price"
+        case id, title, descriptions, price, currency, stock, thumbnails, images
     }
 }

--- a/OpenMarket/OpenMarket/Models/MarketItem.swift
+++ b/OpenMarket/OpenMarket/Models/MarketItem.swift
@@ -2,24 +2,26 @@
 //  MarketItem.swift
 //  OpenMarket
 //
-//  Created by Jost, 잼킹 on 2021/08/10.
+//  Created by Jost, 잼킹 on 2021/08/11.
 //
 
 import Foundation
 
-struct MarketPageItem: Codable {
+struct MarketItem: Codable {
     var id: Int
     var title: String
+    var descriptions: String
     var price: Int
     var discountedPrice: Int?
     var currency: String
     var stock: Int
     var thumbnails: [String]
+    var images: [String]
     var registrationDate: Double
     
     enum CodingKeys: String, CodingKey {
         case registrationDate = "registration_date"
         case discountedPrice = "discounted_price"
-        case id, title, price, currency, stock, thumbnails
+        case id, title, descriptions, price, currency, stock, thumbnails, images
     }
 }

--- a/OpenMarket/OpenMarket/Models/MarketItems.swift
+++ b/OpenMarket/OpenMarket/Models/MarketItems.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct MarketItems: Codable {
     var page: Int
-    var items: [MarketItem]
+    var items: [MarketPageItem]
 }

--- a/OpenMarket/OpenMarket/Models/MarketItems.swift
+++ b/OpenMarket/OpenMarket/Models/MarketItems.swift
@@ -1,0 +1,13 @@
+//
+//  MarketItems.swift
+//  OpenMarket
+//
+//  Created by Jost, 잼킹 on 2021/08/10.
+//
+
+import Foundation
+
+struct MarketItems: Codable {
+    var page: Int
+    var items: [MarketItem]
+}

--- a/OpenMarket/OpenMarket/Models/MarketPageItem.swift
+++ b/OpenMarket/OpenMarket/Models/MarketPageItem.swift
@@ -7,16 +7,33 @@
 
 import Foundation
 
-struct MarketItem: Codable {
+struct MarketPageItem: Codable {
     var id: Int
     var title: String
-    var descriptions: String?
     var price: Int
     var discountedPrice: Int?
     var currency: String
     var stock: Int
     var thumbnails: [String]
-    var images: [String]?
+    var registrationDate: Double
+    
+    enum CodingKeys: String, CodingKey {
+        case registrationDate = "registration_date"
+        case discountedPrice = "discounted_price"
+        case id, title, price, currency, stock, thumbnails
+    }
+}
+
+struct MarketItem: Codable {
+    var id: Int
+    var title: String
+    var descriptions: String
+    var price: Int
+    var discountedPrice: Int?
+    var currency: String
+    var stock: Int
+    var thumbnails: [String]
+    var images: [String]
     var registrationDate: Double
     
     enum CodingKeys: String, CodingKey {

--- a/OpenMarket/OpenMarket/Models/RequestMarketItem.swift
+++ b/OpenMarket/OpenMarket/Models/RequestMarketItem.swift
@@ -1,0 +1,52 @@
+//
+//  PatchMarketItem.swift
+//  OpenMarket
+//
+//  Created by Jost, 잼킹 on 2021/08/11.
+//
+
+import Foundation
+
+struct RequestMarketItem: Codable {
+    var title: String?
+    var descriptions: String?
+    var price: Int?
+    var currency: String?
+    var stock: Int?
+    var discountedPrice: Int?
+    var images: [Data]?
+    var password: String
+    
+    init(postKey password: String, title: String, descriptions: String, price: Int, currency: String, stock: Int, discountedPrice: Int? = nil, images: [Data]) {
+        self.title = title
+        self.descriptions = descriptions
+        self.price = price
+        self.currency = currency
+        self.stock = stock
+        self.discountedPrice = discountedPrice
+        self.images = images
+        self.password = password
+    }
+    
+    init(patchKey password: String, title: String? = nil, descriptions: String? = nil, price: Int? = nil, currency: String? = nil, stock: Int? = nil, discountedPrice: Int? = nil, images: [Data]? = nil) {
+        self.title = title
+        self.descriptions = descriptions
+        self.price = price
+        self.currency = currency
+        self.stock = stock
+        self.discountedPrice = discountedPrice
+        self.images = images
+        self.password = password
+    }
+    
+    init(deleteKey password: String) {
+        self.init(patchKey: password)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case discountedPrice = "discounted_price"
+        case title, descriptions, price, currency, stock, images, password
+    }
+}
+
+

--- a/OpenMarket/OpenMarket/Protocols/Api.swift
+++ b/OpenMarket/OpenMarket/Protocols/Api.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol Api {
-    func fetchMarketItems(completion: @escaping (MarketItems?) -> Void)
+    func getMarketItems(for page: Int, completion: @escaping (MarketItems?) -> Void)
 }

--- a/OpenMarket/OpenMarket/Protocols/Api.swift
+++ b/OpenMarket/OpenMarket/Protocols/Api.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 protocol Api {
-    func getMarketItems(for page: Int, completion: @escaping (MarketItems?) -> Void)
+    func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void)
+    
+    func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void)
 }

--- a/OpenMarket/OpenMarket/Protocols/Api.swift
+++ b/OpenMarket/OpenMarket/Protocols/Api.swift
@@ -7,8 +7,15 @@
 
 import Foundation
 
-protocol Api {
+protocol Api {}
+
+protocol MockApi: Api {
     func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void)
-    
     func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void)
+}
+
+protocol ProdApi: MockApi {
+    func createMarketItem(for item: RequestMarketItem, completion: @escaping (MarketItem?) -> Void)
+    func updateMarketItem(for id: Int, with item: RequestMarketItem, completion: @escaping (MarketItem?) -> Void)
+    func deleteMarketItem(for id: Int, with password: String, completion: @escaping (MarketItem?) -> Void)
 }

--- a/OpenMarket/OpenMarket/Protocols/Api.swift
+++ b/OpenMarket/OpenMarket/Protocols/Api.swift
@@ -1,0 +1,12 @@
+//
+//  API.swift
+//  OpenMarket
+//
+//  Created by jost, 잼킹 on 2021/08/10.
+//
+
+import Foundation
+
+protocol Api {
+    func fetchMarketItems(completion: @escaping (MarketItems?) -> Void)
+}

--- a/OpenMarket/OpenMarket/Protocols/JSONDecodable.swift
+++ b/OpenMarket/OpenMarket/Protocols/JSONDecodable.swift
@@ -1,0 +1,33 @@
+//
+//  MockJSONParser.swift
+//  OpenMarket
+//
+//  Created by Jost, 잼킹 on 2021/08/10.
+//
+
+import Foundation
+
+enum ParsingError: Error {
+    case invalidFileName
+    case decodingError
+}
+
+protocol JSONDecodable {}
+
+extension JSONDecodable {
+    func readLocalFile(for name: String) throws -> Data {
+        guard let url = Bundle.main.url(forResource: name, withExtension: "json"),
+              let data = try? Data(contentsOf: url) else {
+            throw ParsingError.invalidFileName
+        }
+        return data
+    }
+    
+    func decodeJSON<T: Decodable>(from jsonData: Data) throws -> T {
+        let decoder = JSONDecoder()
+        guard let result = try? decoder.decode(T.self, from: jsonData) else {
+            throw ParsingError.decodingError
+        }
+        return result
+    }
+}

--- a/OpenMarket/OpenMarketTests/Info.plist
+++ b/OpenMarket/OpenMarketTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/OpenMarket/OpenMarketTests/OpenMarketTests.swift
+++ b/OpenMarket/OpenMarketTests/OpenMarketTests.swift
@@ -15,13 +15,13 @@ class OpenMarketTests: XCTestCase {
         sut = MockApiClient()
     }
     
-    func test_MockApiClient의_getMarketItem_메서드를_통해_page_에_1_전달시_MarketItems에_대한_데이터를_가져올_수_있다() {
+    func test_MockApiClient의_getMarketPageItems_메서드를_통해_page_에_1_전달시_MarketPageItems에_대한_데이터를_가져올_수_있다() {
         // given
         let page = 1
         let exp = XCTestExpectation(description: "getMarketItems()")
         
         // when
-        sut.getMarketItems(for: page) { marketItems in
+        sut.getMarketPageItems(for: page) { marketItems in
             guard let data = marketItems else {
                 XCTFail("Fail to getMarketItems()")
                 return
@@ -35,20 +35,60 @@ class OpenMarketTests: XCTestCase {
         wait(for: [exp], timeout: 5)
     }
     
-    func test_MockApiClient의_getMarketItem_메서드를_통해_page_에_2_전달시_MarketItems에_대한_데이터를_가져올_수_없다() {
+    func test_MockApiClient의_getMarketPageItems_메서드를_통해_page_에_2_전달시_MarketPageItems에_대한_데이터를_가져올_수_없다() {
         // given
         let page = 2
-        let exp = XCTestExpectation(description: "getMarketItems()")
+        let exp = XCTestExpectation(description: "getMarketPageItems()")
         
         // when
-        sut.getMarketItems(for: page) { marketItems in
+        sut.getMarketPageItems(for: page) { marketItems in
             guard let data = marketItems else {
-                XCTFail("Fail to getMarketItems()")
+                XCTFail("Fail to getMarketPageItems()")
                 exp.fulfill()
                 return
             }
             let expectedResult = false
             let result = data.items.isEmpty
+            // then
+            XCTAssertEqual(result, expectedResult)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+    }
+    
+    func test_MockApiClient의_getMarketItem_메서드를_통해_id_에_1_전달시_MarketItems에_대한_title_값은_MacBook_공백_Pro_이다() {
+        // given
+        let id = 1
+        let exp = XCTestExpectation(description: "getMarketItem()")
+        // when
+        sut.getMarketItem(for: id) { marketItem in
+            guard let item = marketItem else {
+                XCTFail("Fail to getMarketItem()")
+                exp.fulfill()
+                return
+            }
+            let expectedResult = "MacBook Pro"
+            let result = item.title
+            // then
+            XCTAssertEqual(result, expectedResult)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+    }
+    
+    func test_MockApiClient의_getMarketItem_메서드를_통해_id_에_2_전달시_MarketItems에_대한_값을_가져올수없다() {
+        // given
+        let id = 2
+        let exp = XCTestExpectation(description: "getMarketItem()")
+        // when
+        sut.getMarketItem(for: id) { marketItem in
+            guard let item = marketItem else {
+                XCTFail("Fail to getMarketItem()")
+                exp.fulfill()
+                return
+            }
+            let expectedResult = "MacBook Pro"
+            let result = item.title
             // then
             XCTAssertEqual(result, expectedResult)
             exp.fulfill()

--- a/OpenMarket/OpenMarketTests/OpenMarketTests.swift
+++ b/OpenMarket/OpenMarketTests/OpenMarketTests.swift
@@ -1,0 +1,58 @@
+//
+//  OpenMarketTests.swift
+//  OpenMarketTests
+//
+//  Created by YongHoon JJo on 2021/08/10.
+//
+
+import XCTest
+@testable import OpenMarket
+
+class OpenMarketTests: XCTestCase {
+    var sut: MockApiClient!
+    
+    override func setUp() {
+        sut = MockApiClient()
+    }
+    
+    func test_MockApiClient의_getMarketItem_메서드를_통해_page_에_1_전달시_MarketItems에_대한_데이터를_가져올_수_있다() {
+        // given
+        let page = 1
+        let exp = XCTestExpectation(description: "getMarketItems()")
+        
+        // when
+        sut.getMarketItems(for: page) { marketItems in
+            guard let data = marketItems else {
+                XCTFail("Fail to getMarketItems()")
+                return
+            }
+            let expectedResult = false
+            let result = data.items.isEmpty
+            // then
+            XCTAssertEqual(result, expectedResult)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+    }
+    
+    func test_MockApiClient의_getMarketItem_메서드를_통해_page_에_2_전달시_MarketItems에_대한_데이터를_가져올_수_없다() {
+        // given
+        let page = 2
+        let exp = XCTestExpectation(description: "getMarketItems()")
+        
+        // when
+        sut.getMarketItems(for: page) { marketItems in
+            guard let data = marketItems else {
+                XCTFail("Fail to getMarketItems()")
+                exp.fulfill()
+                return
+            }
+            let expectedResult = false
+            let result = data.items.isEmpty
+            // then
+            XCTAssertEqual(result, expectedResult)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+    }
+}


### PR DESCRIPTION
@SungPyo 
안녕하세요 날씨☀️!! Step1은 아니고 1-1로 첫 PR을 보내게 되었습니다 ㅎㅎ
중간 점검을 통해 조언을 받은 후 진행해보고자 조금은 이르지만 PR을 보내요!
잘 부탁드립니다 🙏

## 조언받고 싶은 부분.
### 1. 비동기 테스트 코드 관련

기존에 작성했던 테스트 코드는 동기적인 상황에서의 방법이었습니다. 지금 작성한 코드들은 비동기로 진행이 디는 코드들인데, 이런 비동기 코드들의 테스트 코드 작성을 이런식으로 하는것이 괜찮은지 궁금합니다.또한 실패 케이스에 대해서도 작성을 해봤는데요, 실패시 XCTFail() 을 활용하였는데, 이부분도 이런식으로 하는것이 괜찮은지 궁금합니다.

### 2. 두 메서드 비교

아래 두 코드가 같은 동작을 하지만 Bunle.main.path와 Bundle.main.url이 어떤 차이인지 궁금합니다..
공식문서에서는
- Bundle.main.url - 지정된 이름과 파일 확장자로 식별되는 리소스의 파일 URL을 반환
- Bunle.main.path - 지정된 이름과 파일 확장자로 식별되는 리소스의 전체 경로 이름을 반환
이렇게 설명이 끝이더라구요,,

```swift
func readLocalFile(for name: String) throws -> Data {
	  guard let bundlePath = Bundle.main.path(forResource: name, ofType: "json"),
	        let jsonData = try? String(contentsOfFile: bundlePath).data(using: .utf8) else {
	      throw ParsingError.invalidFileName
	  }
	  return jsonData
}

func readLocalFile3(for name: String) throws -> Data {
    guard let url = Bundle.main.url(forResource: name, withExtension: "json"),
          let data = try? Data(contentsOf: url) else {
        throw ParsingError.invalidFileName
    }
    return data
}
```

### 3. 모델 타입 나누기 관련
- 4가지 모든 케이스 활용
    - POST, GET, PATCH, DELETE 를 따로 타입을 구현할지에 대한 고민하였습니다.

        중복되지 않은 프로퍼티들도 있고, 옵셔널타입도 조금씩 달라서 따로따로 구현해야하나

        생각했었지만 중복되는 코드 부분을 해결하고 싶어 아래와 같이 구현하였습니다.

- 합치는 방법
    - 지금 구현된 RequestMarketItem 타입에 여러 개 init 메서드를을 통해

        POST,  PATCH, DELETE를 하나의 타입으로 구현하였습니다.

        타입을 따로 만드는 방법과 이렇게 하나의 타입에 init을 통한 구분 중 어떤 방법이

        더 괜찮은지 조언받고 싶습니다.

### 4. POST, PUT 등의 메서드 관련 데이터 전달시 어떤 방법이 더 괜찮은 방법인지 궁금합니다.

```swift
func createMarketItem(title: String,
                          descriptions: String,
                          price: Int,
                          currency: String,
                          stock: Int,
                          discountedPrice: Int?,
                          images: [Data],
                          password: String,
                          completion: @escaping (MarketItem?) -> Void)

func createMarketItem(for item: RequestMarketItem, completion: @escaping (MarketItem?) -> Void)
```

- 또한 API 문서에 File Array 타입이 있는데, 검색검색 해보니, `[Data]` 가 적합다하고 결론을 내렸는데요, 이부분에 대해 추천하시는 타입이 있다면 참고할만한 레퍼런스 부탁드리겠습니다.

### 5. API 프로토콜 분리 이유

```swift
protocol Api {}

protocol MockApi: Api {
    func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void)
    func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void)
}

protocol ProdApi: MockApi {
    func createMarketItem(for item: RequestMarketItem, completion: @escaping (MarketItem?) -> Void)
    func updateMarketItem(for id: Int, with item: RequestMarketItem, completion: @escaping (MarketItem?) -> Void)
    func deleteMarketItem(for id: Int, with password: String, completion: @escaping (MarketItem?) -> Void)
}

let api: Api = .dev ? MockApiClient() : ApiClient()
```

이런식으로 Mock 용과 일반용을 부품조립하는 모양을 생각하여 구현해봤습니다. 사실 프로토콜을 이렇게 구분할 이유는 없다고 생각합니다만, createMarketItem(), updateMarketItem(), deleteMarketItem() 에 대해 테스트 코드를 어떻게 구현해야할지 감이 안오기도 했고, 제공된 Mock 데이터를 활용하여 UnitTest 를 하란 내용이 있어 처음 의도와는 다르게 분리를 하게 되어습니다. (처음 의도했던 코드는 Api 프로토콜 내에 위의 5개의 메서드가 모두 포함된 구조였습니다.) POST, PATCH(or PUT), DELETE 에 대한 UnitTest 는 어떤식으로 진행하는지 궁금합니다.