### PR TITLE
오픈마켓 [Step1-2] Jost, Jamking

### DIFF
--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		273CFD0826C2C74400B338E0 /* Item.json in Resources */ = {isa = PBXBuildFile; fileRef = 273CFD0726C2C74400B338E0 /* Item.json */; };
 		7960DF0726C515C9005ACBE9 /* ApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7960DF0626C515C9005ACBE9 /* ApiClient.swift */; };
 		7960DF0A26C5291F005ACBE9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7960DF0926C5291F005ACBE9 /* Config.swift */; };
+		7960DF0C26C57AD4005ACBE9 /* ResponseErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7960DF0B26C57AD4005ACBE9 /* ResponseErrorMessage.swift */; };
 		797C878726C249700088062F /* MarketItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878626C249700088062F /* MarketItems.swift */; };
 		797C878926C258610088062F /* JSONDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878826C258610088062F /* JSONDecodable.swift */; };
 		797C879626C2A7D80088062F /* OpenMarketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C879526C2A7D80088062F /* OpenMarketTests.swift */; };
@@ -45,6 +46,7 @@
 		273CFD0726C2C74400B338E0 /* Item.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Item.json; sourceTree = "<group>"; };
 		7960DF0626C515C9005ACBE9 /* ApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiClient.swift; sourceTree = "<group>"; };
 		7960DF0926C5291F005ACBE9 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		7960DF0B26C57AD4005ACBE9 /* ResponseErrorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseErrorMessage.swift; sourceTree = "<group>"; };
 		797C878626C249700088062F /* MarketItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItems.swift; sourceTree = "<group>"; };
 		797C878826C258610088062F /* JSONDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodable.swift; sourceTree = "<group>"; };
 		797C879326C2A7D80088062F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -87,6 +89,7 @@
 				797C878626C249700088062F /* MarketItems.swift */,
 				797C879D26C2D2C30088062F /* MarketItem.swift */,
 				797C87A126C2D41A0088062F /* RequestMarketItem.swift */,
+				7960DF0B26C57AD4005ACBE9 /* ResponseErrorMessage.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
 				7960DF0A26C5291F005ACBE9 /* Config.swift in Sources */,
+				7960DF0C26C57AD4005ACBE9 /* ResponseErrorMessage.swift in Sources */,
 				797C879E26C2D2C30088062F /* MarketItem.swift in Sources */,
 				273CFCFC26C2440F00B338E0 /* MarketPageItem.swift in Sources */,
 				797C878726C249700088062F /* MarketItems.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		273CFD0326C29B2600B338E0 /* Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFD0226C29B2600B338E0 /* Api.swift */; };
 		273CFD0626C29D6800B338E0 /* MockApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273CFD0526C29D6800B338E0 /* MockApiClient.swift */; };
 		273CFD0826C2C74400B338E0 /* Item.json in Resources */ = {isa = PBXBuildFile; fileRef = 273CFD0726C2C74400B338E0 /* Item.json */; };
+		7960DF0726C515C9005ACBE9 /* ApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7960DF0626C515C9005ACBE9 /* ApiClient.swift */; };
+		7960DF0A26C5291F005ACBE9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7960DF0926C5291F005ACBE9 /* Config.swift */; };
 		797C878726C249700088062F /* MarketItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878626C249700088062F /* MarketItems.swift */; };
 		797C878926C258610088062F /* JSONDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C878826C258610088062F /* JSONDecodable.swift */; };
 		797C879626C2A7D80088062F /* OpenMarketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C879526C2A7D80088062F /* OpenMarketTests.swift */; };
@@ -41,6 +43,8 @@
 		273CFD0226C29B2600B338E0 /* Api.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Api.swift; sourceTree = "<group>"; };
 		273CFD0526C29D6800B338E0 /* MockApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApiClient.swift; sourceTree = "<group>"; };
 		273CFD0726C2C74400B338E0 /* Item.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Item.json; sourceTree = "<group>"; };
+		7960DF0626C515C9005ACBE9 /* ApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiClient.swift; sourceTree = "<group>"; };
+		7960DF0926C5291F005ACBE9 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		797C878626C249700088062F /* MarketItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketItems.swift; sourceTree = "<group>"; };
 		797C878826C258610088062F /* JSONDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodable.swift; sourceTree = "<group>"; };
 		797C879326C2A7D80088062F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -100,8 +104,17 @@
 			isa = PBXGroup;
 			children = (
 				273CFD0526C29D6800B338E0 /* MockApiClient.swift */,
+				7960DF0626C515C9005ACBE9 /* ApiClient.swift */,
 			);
 			path = ApiClients;
+			sourceTree = "<group>";
+		};
+		7960DF0826C5290B005ACBE9 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				7960DF0926C5291F005ACBE9 /* Config.swift */,
+			);
+			path = Config;
 			sourceTree = "<group>";
 		};
 		797C878A26C26BB20088062F /* Protocols */ = {
@@ -143,6 +156,7 @@
 		C70FB0F925BEF61C00C9924E /* OpenMarket */ = {
 			isa = PBXGroup;
 			children = (
+				7960DF0826C5290B005ACBE9 /* Config */,
 				273CFD0426C29B9E00B338E0 /* ApiClients */,
 				797C878A26C26BB20088062F /* Protocols */,
 				273CFCFD26C24BEE00B338E0 /* Mocks */,
@@ -268,10 +282,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7960DF0726C515C9005ACBE9 /* ApiClient.swift in Sources */,
 				797C878926C258610088062F /* JSONDecodable.swift in Sources */,
 				273CFD0626C29D6800B338E0 /* MockApiClient.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
+				7960DF0A26C5291F005ACBE9 /* Config.swift in Sources */,
 				797C879E26C2D2C30088062F /* MarketItem.swift in Sources */,
 				273CFCFC26C2440F00B338E0 /* MarketPageItem.swift in Sources */,
 				797C878726C249700088062F /* MarketItems.swift in Sources */,

--- a/OpenMarket/OpenMarket/ApiClients/ApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/ApiClient.swift
@@ -8,42 +8,63 @@
 import Foundation
 
 class ApiClient: Api, JSONDecodable {
-    func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void) {
+    func getMarketPageItems(for pageNumber: Int,
+                            completion: @escaping (Result<MarketItems, Error>) -> Void) {
         let url = "\(Config.baseUrl)/items/\(pageNumber)"
         self.callGetApi(MarketItems.self , url, completion)
     }
     
-    func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void) {
+    func getMarketItem(for id: Int, completion: @escaping (Result<MarketItem, Error>) -> Void) {
         let url = "\(Config.baseUrl)/item/\(id)"
         self.callGetApi(MarketItem.self, url, completion)
     }
 }
 
 extension ApiClient {
-    private func callGetApi<T>(_ type: T.Type, _ url: String, _ completion: @escaping (T?) -> Void) where T: Decodable {
+    private func callGetApi<T: Decodable>(_ type: T.Type,
+                               _ url: String,
+                               _ completion: @escaping (Result<T, Error>) -> Void) {
         let successRange = 200...299
         
         guard let url = URL(string: url) else {
+            completion(.failure(ApiError.invalidUrl))
             return
         }
         
         URLSession.shared.dataTask(with: url) { (data, response, error) in
-            guard error == nil,
-                  let statusCode = (response as? HTTPURLResponse)?.statusCode,
-                  successRange.contains(statusCode) else {
-                return
-            }
-            
-            guard let data = data else {
-                completion(nil)
-                return
-            }
-            
             do {
-                let item = try self.decodeJSON(T.self, from: data)
-                completion(item)
+                guard error == nil else {
+                    completion(.failure(ApiError.dataTask))
+                    return
+                }
+                
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    completion(.failure(ApiError.invalidResponse))
+                    return
+                }
+                
+                guard successRange.contains(httpResponse.statusCode) else {
+                    if let data = data {
+                        let parsedError = try self.decodeJSON(ResponseErrorMessage.self, from: data)
+                        completion(.failure(ApiError.serverMessage(message: parsedError.message)))
+                        return
+                    }
+                    
+                    completion(.failure(ApiError.outOfRange(statusCode: httpResponse.statusCode)))
+                    return
+                }
+                
+                guard let data = data else {
+                    completion(.failure(ApiError.invalideData))
+                    return
+                }
+                
+                let parsedData = try self.decodeJSON(T.self, from: data)
+                completion(.success(parsedData))
+            } catch let parsingError as ParsingError {
+                completion(.failure(parsingError))
             } catch {
-                completion(nil)
+                completion(.failure(ApiError.unknown))
             }
         }.resume()
     }

--- a/OpenMarket/OpenMarket/ApiClients/ApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/ApiClient.swift
@@ -10,35 +10,17 @@ import Foundation
 class ApiClient: Api, JSONDecodable {
     func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void) {
         let url = "\(Config.baseUrl)/items/\(pageNumber)"
-        let successRange = 200...299
-        
-        guard let url = URL(string: url) else {
-            return
-        }
-        
-        URLSession.shared.dataTask(with: url) { (data, response, error) in
-            guard error == nil,
-                  let statusCode = (response as? HTTPURLResponse)?.statusCode,
-                  successRange.contains(statusCode) else {
-                return
-            }
-            
-            guard let data = data else {
-                completion(nil)
-                return
-            }
-            
-            do {
-                let items: MarketItems = try self.decodeJSON(from: data)
-                completion(items)
-            } catch {
-                completion(nil)
-            }
-        }.resume()
+        self.callGetApi(MarketItems.self , url, completion)
     }
     
     func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void) {
         let url = "\(Config.baseUrl)/item/\(id)"
+        self.callGetApi(MarketItem.self, url, completion)
+    }
+}
+
+extension ApiClient {
+    private func callGetApi<T>(_ type: T.Type, _ url: String, _ completion: @escaping (T?) -> Void) where T: Decodable {
         let successRange = 200...299
         
         guard let url = URL(string: url) else {
@@ -58,7 +40,7 @@ class ApiClient: Api, JSONDecodable {
             }
             
             do {
-                let item: MarketItem = try self.decodeJSON(from: data)
+                let item = try self.decodeJSON(T.self, from: data)
                 completion(item)
             } catch {
                 completion(nil)

--- a/OpenMarket/OpenMarket/ApiClients/ApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/ApiClient.swift
@@ -1,0 +1,68 @@
+//
+//  ApiClient.swift
+//  OpenMarket
+//
+//  Created by Jost, 잼킹 on 2021/08/12.
+//
+
+import Foundation
+
+class ApiClient: Api, JSONDecodable {
+    func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void) {
+        let url = "\(Config.baseUrl)/items/\(pageNumber)"
+        let successRange = 200...299
+        
+        guard let url = URL(string: url) else {
+            return
+        }
+        
+        URLSession.shared.dataTask(with: url) { (data, response, error) in
+            guard error == nil,
+                  let statusCode = (response as? HTTPURLResponse)?.statusCode,
+                  successRange.contains(statusCode) else {
+                return
+            }
+            
+            guard let data = data else {
+                completion(nil)
+                return
+            }
+            
+            do {
+                let items: MarketItems = try self.decodeJSON(from: data)
+                completion(items)
+            } catch {
+                completion(nil)
+            }
+        }.resume()
+    }
+    
+    func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void) {
+        let url = "\(Config.baseUrl)/item/\(id)"
+        let successRange = 200...299
+        
+        guard let url = URL(string: url) else {
+            return
+        }
+        
+        URLSession.shared.dataTask(with: url) { (data, response, error) in
+            guard error == nil,
+                  let statusCode = (response as? HTTPURLResponse)?.statusCode,
+                  successRange.contains(statusCode) else {
+                return
+            }
+            
+            guard let data = data else {
+                completion(nil)
+                return
+            }
+            
+            do {
+                let item: MarketItem = try self.decodeJSON(from: data)
+                completion(item)
+            } catch {
+                completion(nil)
+            }
+        }.resume()
+    }
+}

--- a/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class MockApiClient: MockApi, JSONDecodable {
+class MockApiClient: Api, JSONDecodable {
     private static let delay = 1
     
     func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void) {

--- a/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
@@ -10,7 +10,7 @@ import Foundation
 class MockApiClient: Api, JSONDecodable {
     private static let delay = 1
     
-    func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void) {
+    func getMarketPageItems(for pageNumber: Int, completion: @escaping (Result<MarketItems, Error>) -> Void) {
         DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(MockApiClient.delay)) {
             switch pageNumber {
             case 1:
@@ -18,17 +18,19 @@ class MockApiClient: Api, JSONDecodable {
                 do {
                     let jsonData = try self.readLocalFile(for: fileName)
                     let items = try self.decodeJSON(MarketItems.self ,from: jsonData)
-                    completion(items)
+                    completion(.success(items))
+                } catch let parsingError as ParsingError {
+                    completion(.failure(parsingError))
                 } catch {
-                    completion(nil)
+                    completion(.failure(ParsingError.unknown))
                 }
             default:
-                completion(nil)
+                completion(.failure(ParsingError.unknown))
             }
         }
     }
     
-    func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void) {
+    func getMarketItem(for id: Int, completion: @escaping (Result<MarketItem, Error>) -> Void) {
         DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(MockApiClient.delay)) {
             switch id {
             case 1:
@@ -36,12 +38,14 @@ class MockApiClient: Api, JSONDecodable {
                 do {
                     let jsonData = try self.readLocalFile(for: fileName)
                     let item = try self.decodeJSON(MarketItem.self, from: jsonData)
-                    completion(item)
+                    completion(.success(item))
+                } catch let parsingError as ParsingError {
+                    completion(.failure(parsingError))
                 } catch {
-                    completion(nil)
+                    completion(.failure(ParsingError.unknown))
                 }
             default:
-                completion(nil)
+                completion(.failure(ParsingError.unknown))
             }
         }
     }

--- a/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
+++ b/OpenMarket/OpenMarket/ApiClients/MockApiClient.swift
@@ -17,7 +17,7 @@ class MockApiClient: Api, JSONDecodable {
                 let fileName = "Items"
                 do {
                     let jsonData = try self.readLocalFile(for: fileName)
-                    let items: MarketItems = try self.decodeJSON(from: jsonData)
+                    let items = try self.decodeJSON(MarketItems.self ,from: jsonData)
                     completion(items)
                 } catch {
                     completion(nil)
@@ -35,7 +35,7 @@ class MockApiClient: Api, JSONDecodable {
                 let fileName = "Item"
                 do {
                     let jsonData = try self.readLocalFile(for: fileName)
-                    let item: MarketItem = try self.decodeJSON(from: jsonData)
+                    let item = try self.decodeJSON(MarketItem.self, from: jsonData)
                     completion(item)
                 } catch {
                     completion(nil)

--- a/OpenMarket/OpenMarket/Config/Config.swift
+++ b/OpenMarket/OpenMarket/Config/Config.swift
@@ -1,0 +1,12 @@
+//
+//  Config.swift
+//  OpenMarket
+//
+//  Created by Jost, 잼킹 on 2021/08/12.
+//
+
+import Foundation
+
+enum Config {
+    static let baseUrl = "https://camp-open-market-2.herokuapp.com"
+}

--- a/OpenMarket/OpenMarket/Models/MarketItem.swift
+++ b/OpenMarket/OpenMarket/Models/MarketItem.swift
@@ -17,7 +17,7 @@ struct MarketItem: Codable {
     var stock: Int
     var thumbnails: [String]
     var images: [String]
-    var registrationDate: Double
+    var registrationDate: Date
     
     enum CodingKeys: String, CodingKey {
         case registrationDate = "registration_date"

--- a/OpenMarket/OpenMarket/Models/MarketPageItem.swift
+++ b/OpenMarket/OpenMarket/Models/MarketPageItem.swift
@@ -15,7 +15,7 @@ struct MarketPageItem: Codable {
     var currency: String
     var stock: Int
     var thumbnails: [String]
-    var registrationDate: Double
+    var registrationDate: Date
     
     enum CodingKeys: String, CodingKey {
         case registrationDate = "registration_date"

--- a/OpenMarket/OpenMarket/Models/ResponseErrorMessage.swift
+++ b/OpenMarket/OpenMarket/Models/ResponseErrorMessage.swift
@@ -1,0 +1,12 @@
+//
+//  ResponseErrorMessage.swift
+//  OpenMarket
+//
+//  Created by YongHoon JJo on 2021/08/13.
+//
+
+import Foundation
+
+struct ResponseErrorMessage: Codable {
+    let message: String
+}

--- a/OpenMarket/OpenMarket/Protocols/Api.swift
+++ b/OpenMarket/OpenMarket/Protocols/Api.swift
@@ -7,7 +7,36 @@
 
 import Foundation
 
+enum ApiError: LocalizedError {
+    case invalidUrl
+    case invalideData
+    case dataTask
+    case invalidResponse
+    case unknown
+    case outOfRange(statusCode: Int)
+    case serverMessage(message: String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidUrl:
+            return "Invalid URL"
+        case .invalideData:
+            return "Invalid Data"
+        case .dataTask:
+            return "DataTask Error"
+        case .invalidResponse:
+            return "Invalid Response"
+        case .unknown:
+            return "Api Unknown Error"
+        case .outOfRange(let statusCode):
+            return "status: \(statusCode)"
+        case .serverMessage(let message):
+            return message
+        }
+    }
+}
+
 protocol Api {
-    func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void)
-    func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void)
+    func getMarketPageItems(for pageNumber: Int, completion: @escaping (Result<MarketItems, Error>) -> Void)
+    func getMarketItem(for id: Int, completion: @escaping (Result<MarketItem, Error>) -> Void)
 }

--- a/OpenMarket/OpenMarket/Protocols/Api.swift
+++ b/OpenMarket/OpenMarket/Protocols/Api.swift
@@ -7,15 +7,7 @@
 
 import Foundation
 
-protocol Api {}
-
-protocol MockApi: Api {
+protocol Api {
     func getMarketPageItems(for pageNumber: Int, completion: @escaping (MarketItems?) -> Void)
     func getMarketItem(for id: Int, completion: @escaping (MarketItem?) -> Void)
-}
-
-protocol ProdApi: MockApi {
-    func createMarketItem(for item: RequestMarketItem, completion: @escaping (MarketItem?) -> Void)
-    func updateMarketItem(for id: Int, with item: RequestMarketItem, completion: @escaping (MarketItem?) -> Void)
-    func deleteMarketItem(for id: Int, with password: String, completion: @escaping (MarketItem?) -> Void)
 }

--- a/OpenMarket/OpenMarket/Protocols/JSONDecodable.swift
+++ b/OpenMarket/OpenMarket/Protocols/JSONDecodable.swift
@@ -7,9 +7,21 @@
 
 import Foundation
 
-enum ParsingError: Error {
+enum ParsingError: LocalizedError {
     case invalidFileName
     case decodingError
+    case unknown
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidFileName:
+            return "Invalide File Name"
+        case .decodingError:
+            return "Decoding Error"
+        case .unknown:
+            return "Parsing Unknown Error"
+        }
+    }
 }
 
 protocol JSONDecodable {}

--- a/OpenMarket/OpenMarket/Protocols/JSONDecodable.swift
+++ b/OpenMarket/OpenMarket/Protocols/JSONDecodable.swift
@@ -25,6 +25,7 @@ extension JSONDecodable {
     
     func decodeJSON<T: Decodable>(from jsonData: Data) throws -> T {
         let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
         guard let result = try? decoder.decode(T.self, from: jsonData) else {
             throw ParsingError.decodingError
         }

--- a/OpenMarket/OpenMarket/Protocols/JSONDecodable.swift
+++ b/OpenMarket/OpenMarket/Protocols/JSONDecodable.swift
@@ -23,7 +23,7 @@ extension JSONDecodable {
         return data
     }
     
-    func decodeJSON<T: Decodable>(from jsonData: Data) throws -> T {
+    func decodeJSON<T: Decodable>(_ type: T.Type, from jsonData: Data) throws -> T {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
         guard let result = try? decoder.decode(T.self, from: jsonData) else {

--- a/OpenMarket/OpenMarketTests/OpenMarketTests.swift
+++ b/OpenMarket/OpenMarketTests/OpenMarketTests.swift
@@ -21,15 +21,21 @@ class OpenMarketTests: XCTestCase {
         let exp = XCTestExpectation(description: "getMarketItems()")
         
         // when
-        sut.getMarketPageItems(for: page) { marketItems in
-            guard let data = marketItems else {
-                XCTFail("Fail to getMarketItems()")
-                return
+        sut.getMarketPageItems(for: page) { result in
+            switch result {
+            case .success(let marketdata):
+                let expectedResult = false
+                let result = marketdata.items.isEmpty
+                // then
+                XCTAssertEqual(result, expectedResult)
+            case .failure(let error):
+                if let apiError = error as? ApiError {
+                    XCTFail(apiError.localizedDescription)
+                }
+                if let parsingError = error as? ParsingError {
+                    XCTFail(parsingError.localizedDescription)
+                }
             }
-            let expectedResult = false
-            let result = data.items.isEmpty
-            // then
-            XCTAssertEqual(result, expectedResult)
             exp.fulfill()
         }
         wait(for: [exp], timeout: 5)
@@ -37,60 +43,75 @@ class OpenMarketTests: XCTestCase {
     
     func test_MockApiClient의_getMarketPageItems_메서드를_통해_page_에_2_전달시_MarketPageItems에_대한_데이터를_가져올_수_없다() {
         // given
-        let page = 2
+        let page = 1
         let exp = XCTestExpectation(description: "getMarketPageItems()")
-        
+
         // when
-        sut.getMarketPageItems(for: page) { marketItems in
-            guard let data = marketItems else {
-                XCTFail("Fail to getMarketPageItems()")
-                exp.fulfill()
-                return
+        sut.getMarketPageItems(for: page) { result in
+            switch result {
+            case .success(let marketdata):
+                let expectedResult = false
+                let result = marketdata.items.isEmpty
+                // then
+                XCTAssertEqual(result, expectedResult)
+            case .failure(let error):
+                if let apiError = error as? ApiError {
+                    XCTFail(apiError.localizedDescription)
+                }
+                if let parsingError = error as? ParsingError {
+                    XCTFail(parsingError.localizedDescription)
+                }
             }
-            let expectedResult = false
-            let result = data.items.isEmpty
-            // then
-            XCTAssertEqual(result, expectedResult)
             exp.fulfill()
         }
         wait(for: [exp], timeout: 5)
     }
-    
+
     func test_MockApiClient의_getMarketItem_메서드를_통해_id_에_1_전달시_MarketItems에_대한_title_값은_MacBook_공백_Pro_이다() {
         // given
         let id = 1
         let exp = XCTestExpectation(description: "getMarketItem()")
         // when
-        sut.getMarketItem(for: id) { marketItem in
-            guard let item = marketItem else {
-                XCTFail("Fail to getMarketItem()")
-                exp.fulfill()
-                return
+        sut.getMarketItem(for: id) { result in
+            switch result {
+            case .success(let marketdata):
+                let expectedResult = "MacBook Pro"
+                let result = marketdata.title
+                // then
+                XCTAssertEqual(result, expectedResult)
+            case .failure(let error):
+                if let apiError = error as? ApiError {
+                    XCTFail(apiError.localizedDescription)
+                }
+                if let parsingError = error as? ParsingError {
+                    XCTFail(parsingError.localizedDescription)
+                }
             }
-            let expectedResult = "MacBook Pro"
-            let result = item.title
-            // then
-            XCTAssertEqual(result, expectedResult)
             exp.fulfill()
         }
         wait(for: [exp], timeout: 5)
     }
-    
+
     func test_MockApiClient의_getMarketItem_메서드를_통해_id_에_2_전달시_MarketItems에_대한_값을_가져올수없다() {
         // given
         let id = 2
         let exp = XCTestExpectation(description: "getMarketItem()")
         // when
-        sut.getMarketItem(for: id) { marketItem in
-            guard let item = marketItem else {
-                XCTFail("Fail to getMarketItem()")
-                exp.fulfill()
-                return
+        sut.getMarketItem(for: id) { result in
+            switch result {
+            case .success(let marketdata):
+                let expectedResult = "MacBook Pro"
+                let result = marketdata.title
+                // then
+                XCTAssertEqual(result, expectedResult)
+            case .failure(let error):
+                if let apiError = error as? ApiError {
+                    XCTFail(apiError.localizedDescription)
+                }
+                if let parsingError = error as? ParsingError {
+                    XCTFail(parsingError.localizedDescription)
+                }
             }
-            let expectedResult = "MacBook Pro"
-            let result = item.title
-            // then
-            XCTAssertEqual(result, expectedResult)
             exp.fulfill()
         }
         wait(for: [exp], timeout: 5)


### PR DESCRIPTION
@SungPyo 
날씨 안녕하세요!! 1-1 리뷰 받은 후 열심히 달려서 Step1 전체코드 PR 보냅니다!! ㅎㅎ
이번 리뷰도 잘 부탁드립니다 🙏

## 고민한점 / 조언받고 싶은 부분

### 1. URLSession 형태 (shared vs default)

- As you're using them, they're functionally very similar. But using `sharedSession` doesn't give you the ability to customize the `NSURLSessionConfiguration` (e.g. tweak the cache, custom headers, etc.) nor use the delegate-based rendition of `NSURLSession`. But if you don't need those features, feel free to use `sharedSession` as it's easier.
- if you’re doing anything with caches, cookies, authentication, or custom networking protocols, you should probably be using a default session instead of the shared session.

일단 저희 프로젝트는 shared 형태로 구현되었는데 default 형태에 필요한 부분을 아직 느끼지 못해서

shared를 선택하게 되었습니다. 후에 프로젝트 요구사항에 커스텀이 필요하거나 백그라운드

데이터 전송 같은 구현부가 필요할 때 default 또는 다른 형태로 바꾸어도 될까요??

아니면 미리 파악해서 처음부터 형태를 정해놓고 시작하는 것이 좋을까요?

### 2. 저희의 프로젝트 진행 방향

저희는 스텝1 에서는 POST, PATCH, DELETE 메서드에 대한 네트워크 구현은

진행하지 않기로 하였습니다. 당장 스텝2에서 사용되지 않는점이 일단 가장 큰 이유였습니다.

그렇기 때문에, 스텝2에서 쓰이게 될 GET 메서드 두가지에 대해서만 구현을 하였고,

스텝2의 콜렉션 뷰에 집중하기로 하였습니다.

또한, 이후 스텝에서 등록, 수정, 삭제에 대한 요구사항이 있을 것으로 예상해보았는데

이때 해당 메서드에 대한 네트워크 구현에 필요한 내용을 공부하면서

해당 내용에 대해 구현을 진행할 예정입니다.

### 3. STEP1-1 에서 STEP1-2 를 진행하면서 변경된 사항

- Api 프로토콜에 정의되어 있는 메서드들의 Completion Handler 의 매개변수 타입을 Result<T, S> 타입으로 변경하였으며, 그로 인해 TDD 등의 로직이 변경되었습니다.

- 또한, 기존에 MockClient 를 위한 프로토콜을 분리했었는데, 이부분은 원래대로 돌려 Api 프로토콜로 ApiClient 타입과 MockApiClient 타입에 모두 대응될 수 있게 하였습니다.(스텝1-1 피드백 반영)