### PR TITLE
오픈마켓 2 [STEP 1] aCafela coffee, 호댕

### DIFF
--- a/OpenMarket/.swiftlint.yml
+++ b/OpenMarket/.swiftlint.yml
@@ -9,3 +9,5 @@ excluded:
 - OpenMarket/SceneDelegate.swift
 
 line_length: 99
+identifier_name:
+    max_length: 45

--- a/OpenMarket/.swiftlint.yml
+++ b/OpenMarket/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
 - trailing_whitespace
 - xctfail_message
+- type_body_length
 
 included:
 excluded:

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		C70FB10425BEF61D00C9924E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C70FB10325BEF61D00C9924E /* Assets.xcassets */; };
 		C70FB10725BEF61D00C9924E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C70FB10525BEF61D00C9924E /* LaunchScreen.storyboard */; };
 		DE00D5B72786EE0E0088795D /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = DE00D5B62786EE0E0088795D /* .swiftlint.yml */; };
+		DE29B51327A1398A00F85B2F /* Array+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE29B51227A1398A00F85B2F /* Array+extension.swift */; };
 		DE310512278E9D1300BF1EA5 /* UIViewController+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE310511278E9D1300BF1EA5 /* UIViewController+extension.swift */; };
 		DE4E23F32794039A005E6A40 /* ProductsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4E23F22794039A005E6A40 /* ProductsDataSource.swift */; };
 		DE62049F278D1D95009D5AE7 /* ProductsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE62049D278D1D95009D5AE7 /* ProductsTableViewCell.swift */; };
@@ -75,6 +76,7 @@
 		C70FB10825BEF61D00C9924E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DE00D5B62786EE0E0088795D /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		DE04FFBD27882BDD009156DA /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE29B51227A1398A00F85B2F /* Array+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+extension.swift"; sourceTree = "<group>"; };
 		DE310511278E9D1300BF1EA5 /* UIViewController+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+extension.swift"; sourceTree = "<group>"; };
 		DE4E23F22794039A005E6A40 /* ProductsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsDataSource.swift; sourceTree = "<group>"; };
 		DE62049D278D1D95009D5AE7 /* ProductsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTableViewCell.swift; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				3A4FCD3A2791B8DE00B95E40 /* UITableView+extension.swift */,
 				3A4FCD3C2791B90100B95E40 /* UICollectionView+extension.swift */,
 				3AEBE63C279A95110008808C /* UIImage+extension.swift */,
+				DE29B51227A1398A00F85B2F /* Array+extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -367,6 +370,7 @@
 				3A4FCD372791AB2B00B95E40 /* ProductCell.swift in Sources */,
 				3A7EA51D279695F700328CFA /* ProductRegistrationViewController.swift in Sources */,
 				DEAE69642785A61F00F21D21 /* NetworkError.swift in Sources */,
+				DE29B51327A1398A00F85B2F /* Array+extension.swift in Sources */,
 				DE639A0027994B7A00061734 /* ProductRegistrationError.swift in Sources */,
 				3AABC1D52782D701005DDCE8 /* ProductsList.swift in Sources */,
 			);

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		DE4E23F32794039A005E6A40 /* ProductsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4E23F22794039A005E6A40 /* ProductsDataSource.swift */; };
 		DE62049F278D1D95009D5AE7 /* ProductsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE62049D278D1D95009D5AE7 /* ProductsTableViewCell.swift */; };
 		DE6204A2278D574F009D5AE7 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6204A1278D574F009D5AE7 /* MainViewController.swift */; };
+		DE639A0027994B7A00061734 /* ProductRegistrationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6399FF27994B7A00061734 /* ProductRegistrationError.swift */; };
 		DE65CFF927840F5500E1B619 /* NetworkTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE65CFF827840F5500E1B619 /* NetworkTask.swift */; };
 		DE65CFFB27840F6F00E1B619 /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE65CFFA27840F6F00E1B619 /* JSONParser.swift */; };
 		DE6A81A627965BA000913772 /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6A81A527965BA000913772 /* ReusableView.swift */; };
@@ -76,6 +77,7 @@
 		DE4E23F22794039A005E6A40 /* ProductsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsDataSource.swift; sourceTree = "<group>"; };
 		DE62049D278D1D95009D5AE7 /* ProductsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTableViewCell.swift; sourceTree = "<group>"; };
 		DE6204A1278D574F009D5AE7 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		DE6399FF27994B7A00061734 /* ProductRegistrationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRegistrationError.swift; sourceTree = "<group>"; };
 		DE65CFF827840F5500E1B619 /* NetworkTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTask.swift; sourceTree = "<group>"; };
 		DE65CFFA27840F6F00E1B619 /* JSONParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
 		DE6A81A527965BA000913772 /* ReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableView.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				DEAE69632785A61F00F21D21 /* NetworkError.swift */,
+				DE6399FF27994B7A00061734 /* ProductRegistrationError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -360,6 +363,7 @@
 				3A4FCD372791AB2B00B95E40 /* ProductCell.swift in Sources */,
 				3A7EA51D279695F700328CFA /* ProductRegistrationViewController.swift in Sources */,
 				DEAE69642785A61F00F21D21 /* NetworkError.swift in Sources */,
+				DE639A0027994B7A00061734 /* ProductRegistrationError.swift in Sources */,
 				3AABC1D52782D701005DDCE8 /* ProductsList.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		3A4FCD392791B8AA00B95E40 /* ProductView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4FCD382791B8AA00B95E40 /* ProductView.swift */; };
 		3A4FCD3B2791B8DE00B95E40 /* UITableView+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4FCD3A2791B8DE00B95E40 /* UITableView+extension.swift */; };
 		3A4FCD3D2791B90100B95E40 /* UICollectionView+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4FCD3C2791B90100B95E40 /* UICollectionView+extension.swift */; };
+		3A7EA51B279695AF00328CFA /* ProductRegistration.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3A7EA51A279695AF00328CFA /* ProductRegistration.storyboard */; };
+		3A7EA51D279695F700328CFA /* ProductRegistrationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7EA51C279695F700328CFA /* ProductRegistrationViewController.swift */; };
 		3AA089892783E9CD002A0002 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA089882783E9CD002A0002 /* Image.swift */; };
 		3AA0898B2783EAB3002A0002 /* Vendor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA0898A2783EAB3002A0002 /* Vendor.swift */; };
 		3AAA1E2C2786C2320022D36D /* JSONParsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAA1E2B2786C2320022D36D /* JSONParsable.swift */; };
@@ -54,6 +56,8 @@
 		3A4FCD382791B8AA00B95E40 /* ProductView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductView.swift; sourceTree = "<group>"; };
 		3A4FCD3A2791B8DE00B95E40 /* UITableView+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+extension.swift"; sourceTree = "<group>"; };
 		3A4FCD3C2791B90100B95E40 /* UICollectionView+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+extension.swift"; sourceTree = "<group>"; };
+		3A7EA51A279695AF00328CFA /* ProductRegistration.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ProductRegistration.storyboard; sourceTree = "<group>"; };
+		3A7EA51C279695F700328CFA /* ProductRegistrationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRegistrationViewController.swift; sourceTree = "<group>"; };
 		3AA089882783E9CD002A0002 /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		3AA0898A2783EAB3002A0002 /* Vendor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vendor.swift; sourceTree = "<group>"; };
 		3AAA1E2B2786C2320022D36D /* JSONParsable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParsable.swift; sourceTree = "<group>"; };
@@ -115,6 +119,7 @@
 			children = (
 				DE6204A1278D574F009D5AE7 /* MainViewController.swift */,
 				DE4E23F22794039A005E6A40 /* ProductsDataSource.swift */,
+				3A7EA51C279695F700328CFA /* ProductRegistrationViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -128,6 +133,7 @@
 				C70FB10525BEF61D00C9924E /* LaunchScreen.storyboard */,
 				3A4FCD322791A7E000B95E40 /* ProductsCollectionViewCell.xib */,
 				3A4FCD342791A83B00B95E40 /* ProductsTableViewCell.xib */,
+				3A7EA51A279695AF00328CFA /* ProductRegistration.storyboard */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -289,6 +295,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A7EA51B279695AF00328CFA /* ProductRegistration.storyboard in Resources */,
 				DE00D5B72786EE0E0088795D /* .swiftlint.yml in Resources */,
 				C70FB10725BEF61D00C9924E /* LaunchScreen.storyboard in Resources */,
 				C70FB10425BEF61D00C9924E /* Assets.xcassets in Resources */,
@@ -351,6 +358,7 @@
 				DE310512278E9D1300BF1EA5 /* UIViewController+extension.swift in Sources */,
 				3A4FCD3D2791B90100B95E40 /* UICollectionView+extension.swift in Sources */,
 				3A4FCD372791AB2B00B95E40 /* ProductCell.swift in Sources */,
+				3A7EA51D279695F700328CFA /* ProductRegistrationViewController.swift in Sources */,
 				DEAE69642785A61F00F21D21 /* NetworkError.swift in Sources */,
 				3AABC1D52782D701005DDCE8 /* ProductsList.swift in Sources */,
 			);

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		3AAA1E2C2786C2320022D36D /* JSONParsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAA1E2B2786C2320022D36D /* JSONParsable.swift */; };
 		3AABC1D52782D701005DDCE8 /* ProductsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AABC1D42782D701005DDCE8 /* ProductsList.swift */; };
 		3AD394672788337C0080754F /* ProductsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD394662788337C0080754F /* ProductsCollectionViewCell.swift */; };
+		3AEBE63D279A95110008808C /* UIImage+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEBE63C279A95110008808C /* UIImage+extension.swift */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
 		C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */; };
 		C70FB10225BEF61C00C9924E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C70FB10025BEF61C00C9924E /* Main.storyboard */; };
@@ -65,6 +66,7 @@
 		3AABC1D42782D701005DDCE8 /* ProductsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsList.swift; sourceTree = "<group>"; };
 		3AD394662788337C0080754F /* ProductsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsCollectionViewCell.swift; sourceTree = "<group>"; };
 		3ADE3C6527882C15002980CA /* JSONParseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JSONParseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AEBE63C279A95110008808C /* UIImage+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+extension.swift"; sourceTree = "<group>"; };
 		C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		C70FB10125BEF61C00C9924E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				DE310511278E9D1300BF1EA5 /* UIViewController+extension.swift */,
 				3A4FCD3A2791B8DE00B95E40 /* UITableView+extension.swift */,
 				3A4FCD3C2791B90100B95E40 /* UICollectionView+extension.swift */,
+				3AEBE63C279A95110008808C /* UIImage+extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -345,6 +348,7 @@
 				3AD394672788337C0080754F /* ProductsCollectionViewCell.swift in Sources */,
 				3AA0898B2783EAB3002A0002 /* Vendor.swift in Sources */,
 				DE4E23F32794039A005E6A40 /* ProductsDataSource.swift in Sources */,
+				3AEBE63D279A95110008808C /* UIImage+extension.swift in Sources */,
 				3AA089892783E9CD002A0002 /* Image.swift in Sources */,
 				DE83171B2782D51A00FF2120 /* Currency.swift in Sources */,
 				3A4FCD392791B8AA00B95E40 /* ProductView.swift in Sources */,

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -112,6 +112,7 @@ class MainViewController: UIViewController {
         ) { coder in
             let productRegistrationViewController = ProductRegistrationViewController(
                 coder: coder,
+                isModifying: false,
                 networkTask: self.networkTask,
                 jsonParser: self.jsonParser
             ) {

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -103,8 +103,17 @@ class MainViewController: UIViewController {
     @IBAction func touchAddProductButton(_ sender: UIBarButtonItem) {
         let storyboard = UIStoryboard(name: productRegistrationStoryboardName, bundle: nil)
         let viewController = storyboard.instantiateViewController(
-            withIdentifier: productRegistrationViewControllerIdentifier
-        )
+            identifier: productRegistrationViewControllerIdentifier
+        ) { coder in
+            let productRegistrationViewController = ProductRegistrationViewController(
+                coder: coder,
+                networkTask: self.networkTask,
+                jsonParser: self.jsonParser
+            ) {
+                self.showAlert(title: "등록 성공", message: nil)
+            }
+            return productRegistrationViewController
+        }
         let navigationController = UINavigationController(rootViewController: viewController)
         navigationController.modalPresentationStyle = .fullScreen
         present(navigationController, animated: true, completion: nil)

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -47,8 +47,8 @@ class MainViewController: UIViewController {
                 }
             case .failure(let error):
                 self.showAlert(
-                    title: "Network error",
-                    message: "데이터를 불러오지 못했습니다.\n\(error.localizedDescription)"
+                    title: "데이터를 불러오지 못했습니다",
+                    message: "\(error.localizedDescription)"
                 )
                 self.loadingActivityIndicator.stopAnimating()
             }

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -3,6 +3,8 @@ import UIKit
 class MainViewController: UIViewController {
     private let tableViewCellNibName = "ProductsTableViewCell"
     private let collectionViewCellNibName = "ProductsCollectionViewCell"
+    private let productRegistrationStoryboardName = "ProductRegistration"
+    private let productRegistrationViewControllerIdentity = "ProductRegistrationViewController"
     private let loadingActivityIndicator = UIActivityIndicatorView()
     private var pageInformation: ProductsList?
     private let jsonParser: JSONParser = {
@@ -97,6 +99,14 @@ class MainViewController: UIViewController {
     @IBAction private func segmentedControlChanged(_ sender: UISegmentedControl) {
         changeSubview()
     }
+    
+    @IBAction func touchAddProductButton(_ sender: UIBarButtonItem) {
+        let storyboard = UIStoryboard(name: productRegistrationStoryboardName, bundle: nil)
+        let viewController = storyboard.instantiateViewController(
+            withIdentifier: productRegistrationViewControllerIdentity
+        )
+        present(viewController, animated: true, completion: nil)
+    }
 }
 
 extension MainViewController {
@@ -130,6 +140,7 @@ extension MainViewController {
                 nibName,
                 forCellWithReuseIdentifier: ProductsCollectionViewCell.reuseIdentifier
             )
+            collectionView.backgroundColor = .systemBackground
             return collectionView
         }
     }

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -101,6 +101,14 @@ class MainViewController: UIViewController {
         loadProductsList(pageNumber: 1)
     }
     
+    @objc private func handleRefrashControl() {
+        reloadData()
+        let scrollView = view as? UIScrollView
+        DispatchQueue.main.async {
+            scrollView?.refreshControl?.endRefreshing()
+        }
+    }
+    
     @IBAction private func segmentedControlChanged(_ sender: UISegmentedControl) {
         changeSubview()
     }
@@ -144,6 +152,12 @@ extension MainViewController {
                 nibName,
                 forCellReuseIdentifier: ProductsTableViewCell.reuseIdentifier
             )
+            tableView.refreshControl = UIRefreshControl()
+            tableView.refreshControl?.addTarget(
+                self,
+                action: #selector(handleRefrashControl),
+                for: .valueChanged
+            )
             return tableView
         case .grid:
             let nibName = UINib(nibName: collectionViewCellNibName, bundle: nil)
@@ -159,6 +173,12 @@ extension MainViewController {
                 forCellWithReuseIdentifier: ProductsCollectionViewCell.reuseIdentifier
             )
             collectionView.backgroundColor = .systemBackground
+            collectionView.refreshControl = UIRefreshControl()
+            collectionView.refreshControl?.addTarget(
+                self,
+                action: #selector(handleRefrashControl),
+                for: .valueChanged
+            )
             return collectionView
         }
     }

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -105,7 +105,9 @@ class MainViewController: UIViewController {
         let viewController = storyboard.instantiateViewController(
             withIdentifier: productRegistrationViewControllerIdentity
         )
-        present(viewController, animated: true, completion: nil)
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.modalPresentationStyle = .fullScreen
+        present(navigationController, animated: true, completion: nil)
     }
 }
 

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -96,6 +96,11 @@ class MainViewController: UIViewController {
         self.view = loadView(from: selectedSegment)
     }
     
+    private func reloadData() {
+        productsDataSource.removeAllProducts()
+        loadProductsList(pageNumber: 1)
+    }
+    
     @IBAction private func segmentedControlChanged(_ sender: UISegmentedControl) {
         changeSubview()
     }
@@ -111,6 +116,7 @@ class MainViewController: UIViewController {
                 jsonParser: self.jsonParser
             ) {
                 self.showAlert(title: "등록 성공", message: nil)
+                self.reloadData()
             }
             return productRegistrationViewController
         }

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -4,7 +4,7 @@ class MainViewController: UIViewController {
     private let tableViewCellNibName = "ProductsTableViewCell"
     private let collectionViewCellNibName = "ProductsCollectionViewCell"
     private let productRegistrationStoryboardName = "ProductRegistration"
-    private let productRegistrationViewControllerIdentity = "ProductRegistrationViewController"
+    private let productRegistrationViewControllerIdentifier = "ProductRegistrationViewController"
     private let loadingActivityIndicator = UIActivityIndicatorView()
     private var pageInformation: ProductsList?
     private let jsonParser: JSONParser = {
@@ -103,7 +103,7 @@ class MainViewController: UIViewController {
     @IBAction func touchAddProductButton(_ sender: UIBarButtonItem) {
         let storyboard = UIStoryboard(name: productRegistrationStoryboardName, bundle: nil)
         let viewController = storyboard.instantiateViewController(
-            withIdentifier: productRegistrationViewControllerIdentity
+            withIdentifier: productRegistrationViewControllerIdentifier
         )
         let navigationController = UINavigationController(rootViewController: viewController)
         navigationController.modalPresentationStyle = .fullScreen

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -159,7 +159,7 @@ class MainViewController: UIViewController {
         changeSubview()
     }
     
-    @IBAction func touchAddProductButton(_ sender: UIBarButtonItem) {
+    @IBAction private func touchAddProductButton(_ sender: UIBarButtonItem) {
         let storyboard = UIStoryboard(
             name: ProductRegistrationViewController.storyboardName,
             bundle: nil

--- a/OpenMarket/OpenMarket/Controller/MainViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/MainViewController.swift
@@ -1,10 +1,6 @@
 import UIKit
 
 class MainViewController: UIViewController {
-    private let tableViewCellNibName = "ProductsTableViewCell"
-    private let collectionViewCellNibName = "ProductsCollectionViewCell"
-    private let productRegistrationStoryboardName = "ProductRegistration"
-    private let productRegistrationViewControllerIdentifier = "ProductRegistrationViewController"
     private let loadingActivityIndicator = UIActivityIndicatorView()
     private var pageInformation: ProductsList?
     private let jsonParser: JSONParser = {
@@ -114,9 +110,12 @@ class MainViewController: UIViewController {
     }
     
     @IBAction func touchAddProductButton(_ sender: UIBarButtonItem) {
-        let storyboard = UIStoryboard(name: productRegistrationStoryboardName, bundle: nil)
+        let storyboard = UIStoryboard(
+            name: ProductRegistrationViewController.storyboardName,
+            bundle: nil
+        )
         let viewController = storyboard.instantiateViewController(
-            identifier: productRegistrationViewControllerIdentifier
+            identifier: ProductRegistrationViewController.identifier
         ) { coder in
             let productRegistrationViewController = ProductRegistrationViewController(
                 coder: coder,
@@ -144,13 +143,13 @@ extension MainViewController {
     private func loadView(from segment: Segement) -> UIView {
         switch segment {
         case .list:
-            let nibName = UINib(nibName: tableViewCellNibName, bundle: nil)
+            let nibName = UINib(nibName: ProductsTableViewCell.identifier, bundle: nil)
             let tableView = UITableView()
             tableView.dataSource = productsDataSource
             tableView.delegate = self
             tableView.register(
                 nibName,
-                forCellReuseIdentifier: ProductsTableViewCell.reuseIdentifier
+                forCellReuseIdentifier: ProductsTableViewCell.identifier
             )
             tableView.refreshControl = UIRefreshControl()
             tableView.refreshControl?.addTarget(
@@ -160,7 +159,7 @@ extension MainViewController {
             )
             return tableView
         case .grid:
-            let nibName = UINib(nibName: collectionViewCellNibName, bundle: nil)
+            let nibName = UINib(nibName: ProductsCollectionViewCell.identifier, bundle: nil)
             let layout = UICollectionViewFlowLayout()
             layout.sectionInset = UIEdgeInsets(top: 0.0, left: 10.0, bottom: 0.0, right: 10.0)
             layout.sectionInsetReference = .fromSafeArea
@@ -170,7 +169,7 @@ extension MainViewController {
             collectionView.delegate = self
             collectionView.register(
                 nibName,
-                forCellWithReuseIdentifier: ProductsCollectionViewCell.reuseIdentifier
+                forCellWithReuseIdentifier: ProductsCollectionViewCell.identifier
             )
             collectionView.backgroundColor = .systemBackground
             collectionView.refreshControl = UIRefreshControl()
@@ -210,12 +209,12 @@ extension MainViewController: UITableViewDelegate {
                     return
                 }
                 let storyboard = UIStoryboard(
-                    name: self.productRegistrationStoryboardName,
+                    name: ProductRegistrationViewController.storyboardName,
                     bundle: nil
                 )
                 DispatchQueue.main.async {
                     let viewController = storyboard.instantiateViewController(
-                        identifier: self.productRegistrationViewControllerIdentifier
+                        identifier: ProductRegistrationViewController.identifier
                     ) { coder in
                         let productRegistrationViewController = ProductRegistrationViewController(
                             coder: coder,
@@ -263,12 +262,12 @@ extension MainViewController: UICollectionViewDelegate {
                     return
                 }
                 let storyboard = UIStoryboard(
-                    name: self.productRegistrationStoryboardName,
+                    name: ProductRegistrationViewController.storyboardName,
                     bundle: nil
                 )
                 DispatchQueue.main.async {
                     let viewController = storyboard.instantiateViewController(
-                        identifier: self.productRegistrationViewControllerIdentifier
+                        identifier: ProductRegistrationViewController.identifier
                     ) { coder in
                         let productRegistrationViewController = ProductRegistrationViewController(
                             coder: coder,

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -53,6 +53,9 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
             withReuseIdentifier: UICollectionViewCell.reuseIdentifier,
             for: indexPath
         )
+        cell.contentView.subviews.forEach { view in
+            view.removeFromSuperview()
+        }
         if indexPath.section == 0 {
             let image = images[indexPath.item]
             let imageView = UIImageView(frame: cell.contentView.frame)
@@ -75,6 +78,4 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         }
         return cell
     }
-    
-    
 }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -2,8 +2,6 @@ import UIKit
 
 class ProductRegistrationViewController: UIViewController, UINavigationControllerDelegate {
     static let storyboardName = "ProductRegistration"
-    private let identifier = "2836ea8c-7215-11ec-abfa-378889d9906f"
-    private let secret = "-3CSKv$cyHsK_@Wk"
     private let maximumDescriptionsLimit = 1000
     private let minimumDescriptionsLimit = 10
     private let maximumNameLimit = 100
@@ -77,7 +75,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         startActivityIndicator()
         DispatchQueue.global().async {
             let writtenSalesInformation = self.makeSalesInformation(
-                secret: self.secret,
+                secret: NetworkTask.secret,
                 maximumDescriptionsLimit: 1000,
                 minimumDescriptionsLimit: 10,
                 maximumNameLimit: 100,
@@ -106,7 +104,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             }
             
             self.networkTask?.requestProductRegistration(
-                identifier: self.identifier,
+                identifier: NetworkTask.identifier,
                 salesInformation: salesInformation,
                 images: imageDatas
             ) { result in
@@ -127,7 +125,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         startActivityIndicator()
         DispatchQueue.global().async {
             let writtenSalesInformation = self.modifiySalesInformation(
-                secret: self.secret,
+                secret: NetworkTask.secret,
                 maximumDescriptionsLimit: 1000,
                 minimumDescriptionsLimit: 10,
                 maximumNameLimit: 100,
@@ -144,7 +142,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             
             guard let productId = self.productInformation?.id else { return }
             self.networkTask?.requestProductModification(
-                identifier: self.identifier,
+                identifier: NetworkTask.identifier,
                 productId: productId,
                 information: modificationInformation
             ) { result in

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -71,6 +71,10 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         }
         return UIImage(cgImage: squareImage)
     }
+    
+    @IBAction func tapBackground(_ sender: UITapGestureRecognizer) {
+        view.endEditing(true)
+    }
 }
 
 extension ProductRegistrationViewController: UIImagePickerControllerDelegate {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -7,12 +7,15 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var verticalStackView: UIStackView!
     @IBOutlet weak var imagesCollectionView: UICollectionView!
+    @IBOutlet weak var productNameTextField: UITextField!
+    @IBOutlet weak var productPriceTextField: UITextField!
     @IBOutlet weak var descriptionTextView: UITextView!
     @IBOutlet weak var currencySegmentedControl: UISegmentedControl!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         imagesCollectionView.dataSource = self
+        productNameTextField.delegate = self
         setUpImagePicker()
         setupNavigationBar()
         setupTextView()
@@ -197,5 +200,14 @@ extension ProductRegistrationViewController: UITextViewDelegate {
             textView.text = "상품설명"
             textView.textColor = .placeholderText
         }
+    }
+}
+
+extension ProductRegistrationViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if textField == productNameTextField {
+            productPriceTextField.becomeFirstResponder()
+        }
+        return false
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -4,7 +4,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     private let imagePickerController = UIImagePickerController()
     private var images = [UIImage]()
     private var isModifying: Bool?
-    private var productId: Int?
+    private var productInformation: Product?
     private var networkTask: NetworkTask?
     private var jsonParser: JSONParser?
     private var completionHandler: (() -> Void)?
@@ -46,8 +46,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         self.networkTask = networkTask
         self.jsonParser = jsonParser
         self.completionHandler = completionHandler
-        self.productId = productInformation.id
-        loadProductInformation(from: productInformation)
+        self.productInformation = productInformation
     }
     
     override func viewDidLoad() {
@@ -57,6 +56,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         setUpImagePicker()
         setupNavigationBar()
         setupTextView()
+        loadProductInformation()
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillShow),
@@ -139,7 +139,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             return
         }
         
-        guard let productId = productId else { return }
+        guard let productId = productInformation?.id else { return }
         networkTask?.requestProductModification(
             identifier: identifier,
             productId: productId,
@@ -200,15 +200,17 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             )
             navigationItem.title = "상품등록"
         }
-        
     }
     
-    private func loadProductInformation(from productInformation: Product) {
+    private func loadProductInformation() {
+        guard let productInformation = productInformation else { return }
+        print(productInformation.id)
         productNameTextField.text = productInformation.name
         productPriceTextField.text = productInformation.price.description
         discountedPriceTextField.text = productInformation.discountedPrice.description
         stockTextField.text = productInformation.stock.description
         descriptionTextView.text = productInformation.description
+        descriptionTextView.textColor = .label
         if productInformation.currency == .krw {
             currencySegmentedControl.selectedSegmentIndex = 0
         } else if productInformation.currency == .usd {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -92,17 +92,14 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         var count = 0
         var imageDatas = [String: Data]()
         for image in images {
-            let compressionQuality: CGFloat = 0.8
             let fileName = "\(count).jpeg"
-            var originalImage = image
-            var imageData = originalImage.jpegData(compressionQuality: compressionQuality)
-            while let bytes = imageData?.count, bytes >= 300 * 1000 {
-                let multiplier: CGFloat = 0.8
-                originalImage = originalImage.resize(multiplier: multiplier)
-                imageData = originalImage.jpegData(compressionQuality: compressionQuality)
-            }
-            count += 1
+            let imageData = convertJPEG(
+                from: image,
+                finalByte: 300 * 1000,
+                compressionQuality: 0.8
+            )
             imageDatas[fileName] = imageData
+            count += 1
         }
         
         networkTask?.requestProductRegistration(
@@ -574,6 +571,21 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         button.addTarget(self, action: #selector(presentImagePicker), for: .touchUpInside)
         button.backgroundColor = .opaqueSeparator
         return button
+    }
+    
+    private func convertJPEG(
+        from image: UIImage,
+        finalByte: Int,
+        compressionQuality: CGFloat
+    ) -> Data? {
+        var originalImage = image
+        var imageData = image.jpegData(compressionQuality: compressionQuality)
+        while let bytes = imageData?.count, bytes > finalByte {
+            let multiplier: CGFloat = 0.8
+            originalImage = originalImage.resize(multiplier: multiplier)
+            imageData = originalImage.jpegData(compressionQuality: compressionQuality)
+        }
+        return imageData
     }
     
     @IBAction func tapBackground(_ sender: UITapGestureRecognizer) {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -110,14 +110,28 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
                 } else {
                     hideCaution(textField: textField, cautionLabel: productPriceCautionLabel)
                 }
-            }
-            if textField === discountedPriceTextField {
-                let discountedPrice = Decimal(string: textField.text ?? "")
-                guard let price = Decimal(string: productPriceTextField.text ?? "") else { return }
-                if let error = inspectMaximumDiscountedPrice(
+                if let price = Decimal(string: textField.text ?? ""),
+                   let discountedPrice = Decimal(string: discountedPriceTextField.text ?? ""),
+                   let error = inspectMaximumDiscountedPrice(
                     price: price,
                     discountedPrice: discountedPrice
-                ) {
+                   ) {
+                    showCaution(
+                        textField: discountedPriceTextField,
+                        cautionLabel: discountedPriceCautionLabel,
+                        message: error.errorDescription
+                    )
+                } else {
+                    hideCaution(textField: discountedPriceTextField, cautionLabel: discountedPriceCautionLabel)
+                }
+            }
+            if textField === discountedPriceTextField {
+                if let price = Decimal(string: productPriceTextField.text ?? ""),
+                   let discountedPrice = Decimal(string: textField.text ?? ""),
+                   let error = inspectMaximumDiscountedPrice(
+                    price: price,
+                    discountedPrice: discountedPrice
+                   ) {
                     showCaution(
                         textField: textField,
                         cautionLabel: discountedPriceCautionLabel,

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -4,11 +4,11 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     private let imagePickerController = UIImagePickerController()
     private var images = [UIImage]()
     
+    @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var verticalStackView: UIStackView!
     @IBOutlet weak var imagesCollectionView: UICollectionView!
     @IBOutlet weak var descriptionTextView: UITextView!
     @IBOutlet weak var currencySegmentedControl: UISegmentedControl!
-    @IBOutlet var textFields: [UITextField]!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -16,9 +16,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         setUpImagePicker()
         setupNavigationBar()
         setupTextView()
-        textFields.forEach { textField in
-            textField.delegate = self
-        }
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillShow),
@@ -46,12 +43,12 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             as? NSValue {
             let keyboardRectangle = keyboardFrame.cgRectValue
             let keyboardHeight = keyboardRectangle.height
-            view.frame.origin.y = -keyboardHeight
+            scrollView.contentInset.bottom = keyboardHeight
         }
     }
     
     @objc private func keyboardWillHide(_ sender: Notification) {
-        view.frame.origin.y = 0
+        scrollView.contentInset.bottom = 0
     }
     
     private func setupNavigationBar() {
@@ -202,5 +199,3 @@ extension ProductRegistrationViewController: UITextViewDelegate {
         }
     }
 }
-
-extension ProductRegistrationViewController: UITextFieldDelegate {}

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -204,7 +204,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     
     private func loadProductInformation() {
         guard let productInformation = productInformation else { return }
-        print(productInformation.id)
         productNameTextField.text = productInformation.name
         productPriceTextField.text = productInformation.price.description
         discountedPriceTextField.text = productInformation.discountedPrice.description
@@ -384,7 +383,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         return nil
     }
     
-    private func cropSquare(_ image: UIImage) -> UIImage? {
+    private func cropSquare(_ image: UIImage) -> UIImage? { // extension으로 옮기기
         let imageSize = image.size
         let shortLength = imageSize.width < imageSize.height ? imageSize.width : imageSize.height
         let origin = CGPoint(
@@ -396,7 +395,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         guard let squareImage = image.cgImage?.cropping(to: square) else {
             return nil
         }
-        return UIImage(cgImage: squareImage)
+        return UIImage(cgImage: squareImage, scale: 1.0, orientation: .up)
     }
     
     @IBAction func tapBackground(_ sender: UITapGestureRecognizer) {
@@ -413,14 +412,12 @@ extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
             picker.dismiss(animated: true, completion: nil)
             return
         }
-        print(newImage.size)
         let isSquare = newImage.size.width == newImage.size.height
         if isSquare == false {
             if let squareImage = cropSquare(newImage) {
                 newImage = squareImage
             }
         }
-        print(newImage.size)
         images.append(newImage)
         imagesCollectionView.reloadData()
         picker.dismiss(animated: true, completion: nil)

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -4,8 +4,11 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     private let imagePickerController = UIImagePickerController()
     private var images = [UIImage]()
     
+    @IBOutlet weak var verticalStackView: UIStackView!
     @IBOutlet weak var imagesCollectionView: UICollectionView!
     @IBOutlet weak var descriptionTextView: UITextView!
+    @IBOutlet weak var currencySegmentedControl: UISegmentedControl!
+    @IBOutlet var textFields: [UITextField]!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -13,6 +16,21 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         setUpImagePicker()
         setupNavigationBar()
         setupTextView()
+        textFields.forEach { textField in
+            textField.delegate = self
+        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
     }
     
     @objc private func dismissProductRegistration() {
@@ -21,6 +39,19 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     
     @objc private func presentImagePicker() {
         present(imagePickerController, animated: true, completion: nil)
+    }
+    
+    @objc private func keyboardWillShow(_ sender: Notification) {
+        if let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
+            as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            let keyboardHeight = keyboardRectangle.height
+            view.frame.origin.y = -keyboardHeight
+        }
+    }
+    
+    @objc private func keyboardWillHide(_ sender: Notification) {
+        view.frame.origin.y = 0
     }
     
     private func setupNavigationBar() {
@@ -171,3 +202,5 @@ extension ProductRegistrationViewController: UITextViewDelegate {
         }
     }
 }
+
+extension ProductRegistrationViewController: UITextFieldDelegate {}

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -151,6 +151,9 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             at: selectedSegmentIndex
         ) ?? ""
         
+        guard images.isEmpty == false else {
+            return .failure(.emptyImage)
+        }
         guard let name = productNameTextField.text, name.isEmpty == false else {
             return .failure(.emptyName)
         }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -62,10 +62,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     override func viewDidLoad() {
         super.viewDidLoad()
         imagesCollectionView.dataSource = self
-        productNameTextField.delegate = self
-        productPriceTextField.delegate = self
-        discountedPriceTextField.delegate = self
-        stockTextField.delegate = self
+        setupDelegate()
         setupImagePicker()
         setupNavigationBar()
         setupTextView()
@@ -286,6 +283,39 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         }
     }
     
+    private func setupDelegate() {
+        productNameTextField.delegate = self
+        productPriceTextField.delegate = self
+        discountedPriceTextField.delegate = self
+        stockTextField.delegate = self
+    }
+    
+    private func setupImagePicker() {
+        imagePickerController.sourceType = .photoLibrary
+        imagePickerController.delegate = self
+    }
+    
+    private func setupTextView() {
+        descriptionTextView.delegate = self
+        descriptionTextView.text = "상품설명"
+        descriptionTextView.textColor = .placeholderText
+        descriptionTextView.layer.borderWidth = 0.5
+        descriptionTextView.layer.cornerRadius = 5
+        descriptionTextView.layer.borderColor = CGColor(
+            srgbRed: 0.8,
+            green: 0.8,
+            blue: 0.8,
+            alpha: 1.0
+        )
+    }
+    
+    private func setupTextFieldTarget() {
+        productNameTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
+        productPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
+        discountedPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
+    }
+    
+    
     private func hideAllCautionLabel() {
         productNameCautionLabel.isHidden = true
         productPriceCautionLabel.isHidden = true
@@ -342,31 +372,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
                   let downloadedImage = UIImage(data: imageData) else { return }
             images.append(downloadedImage)
         }
-    }
-    
-    private func setupImagePicker() {
-        imagePickerController.sourceType = .photoLibrary
-        imagePickerController.delegate = self
-    }
-    
-    private func setupTextView() {
-        descriptionTextView.delegate = self
-        descriptionTextView.text = "상품설명"
-        descriptionTextView.textColor = .placeholderText
-        descriptionTextView.layer.borderWidth = 0.5
-        descriptionTextView.layer.cornerRadius = 5
-        descriptionTextView.layer.borderColor = CGColor(
-            srgbRed: 0.8,
-            green: 0.8,
-            blue: 0.8,
-            alpha: 1.0
-        )
-    }
-    
-    private func setupTextFieldTarget() {
-        productNameTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
-        productPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
-        discountedPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
     }
     
     private func makeSalesInformation(

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -536,21 +536,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         return nil
     }
     
-    private func cropSquare(_ image: UIImage) -> UIImage? { // extension으로 옮기기
-        let imageSize = image.size
-        let shortLength = imageSize.width < imageSize.height ? imageSize.width : imageSize.height
-        let origin = CGPoint(
-            x: imageSize.width / 2 - shortLength / 2,
-            y: imageSize.height / 2 - shortLength / 2
-        )
-        let size = CGSize(width: shortLength, height: shortLength)
-        let square = CGRect(origin: origin, size: size)
-        guard let squareImage = image.cgImage?.cropping(to: square) else {
-            return nil
-        }
-        return UIImage(cgImage: squareImage, scale: 1.0, orientation: .up)
-    }
-    
     @IBAction func tapBackground(_ sender: UITapGestureRecognizer) {
         view.endEditing(true)
     }
@@ -567,7 +552,7 @@ extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
         }
         let isSquare = newImage.size.width == newImage.size.height
         if isSquare == false {
-            if let squareImage = cropSquare(newImage) {
+            if let squareImage = newImage.cropSquare() {
                 newImage = squareImage
             }
         }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -138,7 +138,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     
     private func setUpImagePicker() {
         imagePickerController.sourceType = .photoLibrary
-//        imagePickerController.allowsEditing = true
         imagePickerController.delegate = self
     }
     

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -37,7 +37,23 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     
     private func setUpImagePicker() {
         imagePickerController.sourceType = .photoLibrary
+        imagePickerController.allowsEditing = true
         imagePickerController.delegate = self
+    }
+    
+    private func cropSquare(_ image: UIImage) -> UIImage? {
+        let imageSize = image.size
+        let shortLength = imageSize.width < imageSize.height ? imageSize.width : imageSize.height
+        let origin = CGPoint(
+            x: imageSize.width / 2 - shortLength / 2,
+            y: imageSize.height / 2 - shortLength / 2
+        )
+        let size = CGSize(width: shortLength, height: shortLength)
+        let square = CGRect(origin: origin, size: size)
+        guard let squareImage = image.cgImage?.cropping(to: square) else {
+            return nil
+        }
+        return UIImage(cgImage: squareImage)
     }
 }
 
@@ -46,10 +62,18 @@ extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
         _ picker: UIImagePickerController,
         didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
     ) {
-        if let newImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-            images.append(newImage)
-            imagesCollectionView.reloadData()
+        guard var newImage = info[.editedImage] as? UIImage else {
+            picker.dismiss(animated: true, completion: nil)
+            return
         }
+        let isSquare = newImage.size.width == newImage.size.height
+        if isSquare == false {
+            if let squareImage = cropSquare(newImage) {
+                newImage = squareImage
+            }
+        }
+        images.append(newImage)
+        imagesCollectionView.reloadData()
         picker.dismiss(animated: true, completion: nil)
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -66,10 +66,11 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         productPriceTextField.delegate = self
         discountedPriceTextField.delegate = self
         stockTextField.delegate = self
-        setUpImagePicker()
+        setupImagePicker()
         setupNavigationBar()
-        hideAllCautionLabel()
         setupTextView()
+        setupTextFieldTarget()
+        hideAllCautionLabel()
         loadProductInformation()
         NotificationCenter.default.addObserver(
             self,
@@ -83,9 +84,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             name: UIResponder.keyboardWillHideNotification,
             object: nil
         )
-        productNameTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
-        productPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
-        discountedPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
     }
     
     @objc private func textInputDidChange(_ sender: Any?) {
@@ -320,7 +318,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         }
     }
     
-    private func setUpImagePicker() {
+    private func setupImagePicker() {
         imagePickerController.sourceType = .photoLibrary
         imagePickerController.delegate = self
     }
@@ -337,6 +335,12 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             blue: 0.8,
             alpha: 1.0
         )
+    }
+    
+    private func setupTextFieldTarget() {
+        productNameTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
+        productPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
+        discountedPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
     }
     
     private func makeSalesInformation(

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -66,7 +66,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         setupImagePicker()
         setupNavigationBar()
         setupTextView()
-        setupTextFieldTarget()
         hideAllCautionLabel()
         loadProductInformation()
         NotificationCenter.default.addObserver(
@@ -81,80 +80,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             name: UIResponder.keyboardWillHideNotification,
             object: nil
         )
-    }
-    
-    @objc private func textInputDidChange(_ sender: Any?) {
-        if let textField = sender as? UITextField {
-            if textField === productNameTextField {
-                if let count = textField.text?.count,
-                   count < minimumNameLimit || count > maximumNameLimit {
-                    showCaution(
-                        textField: textField,
-                        cautionLabel: productNameCautionLabel,
-                        message: "글자를 \(minimumNameLimit)~\(maximumNameLimit)자로 입력해주세요"
-                    )
-                } else {
-                    hideCaution(textField: textField, cautionLabel: productNameCautionLabel)
-                }
-            }
-            if textField === productPriceTextField {
-                if let count = textField.text?.count, count == 0 {
-                    showCaution(
-                        textField: textField,
-                        cautionLabel: productPriceCautionLabel,
-                        message: "상품가격을 입력해주세요"
-                    )
-                } else {
-                    hideCaution(textField: textField, cautionLabel: productPriceCautionLabel)
-                }
-                if let price = Decimal(string: textField.text ?? ""),
-                   let discountedPrice = Decimal(string: discountedPriceTextField.text ?? ""),
-                   let error = inspectMaximumDiscountedPrice(
-                    price: price,
-                    discountedPrice: discountedPrice
-                   ) {
-                    showCaution(
-                        textField: discountedPriceTextField,
-                        cautionLabel: discountedPriceCautionLabel,
-                        message: error.errorDescription
-                    )
-                } else {
-                    hideCaution(
-                        textField: discountedPriceTextField,
-                        cautionLabel: discountedPriceCautionLabel
-                    )
-                }
-            }
-            if textField === discountedPriceTextField {
-                if let price = Decimal(string: productPriceTextField.text ?? ""),
-                   let discountedPrice = Decimal(string: textField.text ?? ""),
-                   let error = inspectMaximumDiscountedPrice(
-                    price: price,
-                    discountedPrice: discountedPrice
-                   ) {
-                    showCaution(
-                        textField: textField,
-                        cautionLabel: discountedPriceCautionLabel,
-                        message: error.errorDescription
-                    )
-                } else {
-                    hideCaution(textField: textField, cautionLabel: discountedPriceCautionLabel)
-                }
-            }
-        } else if let textView = sender as? UITextView {
-            if textView === descriptionTextView {
-                let count = textView.text.count
-                if count < minimumDescriptionsLimit || count > maximumDescriptionsLimit {
-                    showCaution(
-                        textView: textView,
-                        cautionLabel: descriptionCautionLabel,
-                        message: "글자를 \(minimumDescriptionsLimit)~\(maximumDescriptionsLimit)자로 입력해주세요"
-                    )
-                } else {
-                    hideCaution(textView: textView, cautionLabel: descriptionCautionLabel)
-                }
-            }
-        }
     }
     
     @objc private func registerProduct() {
@@ -304,30 +229,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         descriptionTextView.textColor = .placeholderText
         descriptionTextView.layer.borderWidth = 0.5
         descriptionTextView.layer.cornerRadius = 5
-        descriptionTextView.layer.borderColor = CGColor(
-            srgbRed: 0.8,
-            green: 0.8,
-            blue: 0.8,
-            alpha: 1.0
-        )
-    }
-    
-    private func setupTextFieldTarget() {
-        productNameTextField.addTarget(
-            self,
-            action: #selector(textInputDidChange(_:)),
-            for: .editingChanged
-        )
-        productPriceTextField.addTarget(
-            self,
-            action: #selector(textInputDidChange(_:)),
-            for: .editingChanged
-        )
-        discountedPriceTextField.addTarget(
-            self,
-            action: #selector(textInputDidChange(_:)),
-            for: .editingChanged
-        )
+        descriptionTextView.layer.borderColor = UIColor.separator.cgColor
     }
     
     private func hideAllCautionLabel() {
@@ -359,12 +261,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     
     private func hideCaution(textView: UITextView, cautionLabel: UILabel) {
         cautionLabel.isHidden = true
-        textView.layer.borderColor = CGColor(
-            srgbRed: 0.8,
-            green: 0.8,
-            blue: 0.8,
-            alpha: 1.0
-        )
+        textView.layer.borderColor = UIColor.separator.cgColor
     }
     
     private func loadProductInformation() {
@@ -492,6 +389,78 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             stock: stock,
             secret: secret)
         return .success(product)
+    }
+    
+    private func textInputDidChange(_ sender: Any, textLength: Int) {
+        if let textField = sender as? UITextField {
+            if productNameTextField.isFirstResponder {
+                if textLength < minimumNameLimit || textLength > maximumNameLimit {
+                    showCaution(
+                        textField: textField,
+                        cautionLabel: productNameCautionLabel,
+                        message: "글자를 \(minimumNameLimit)~\(maximumNameLimit)자로 입력해주세요"
+                    )
+                } else {
+                    hideCaution(textField: textField, cautionLabel: productNameCautionLabel)
+                }
+            }
+            if productPriceTextField.isFirstResponder {
+                if textLength == 0 {
+                    showCaution(
+                        textField: textField,
+                        cautionLabel: productPriceCautionLabel,
+                        message: "상품가격을 입력해주세요"
+                    )
+                } else {
+                    hideCaution(textField: textField, cautionLabel: productPriceCautionLabel)
+                }
+                if let price = Decimal(string: textField.text ?? ""),
+                   let discountedPrice = Decimal(string: discountedPriceTextField.text ?? ""),
+                   let error = inspectMaximumDiscountedPrice(
+                    price: price,
+                    discountedPrice: discountedPrice
+                   ) {
+                    showCaution(
+                        textField: discountedPriceTextField,
+                        cautionLabel: discountedPriceCautionLabel,
+                        message: error.errorDescription
+                    )
+                } else {
+                    hideCaution(
+                        textField: discountedPriceTextField,
+                        cautionLabel: discountedPriceCautionLabel
+                    )
+                }
+            }
+            if discountedPriceTextField.isFirstResponder {
+                if let price = Decimal(string: productPriceTextField.text ?? ""),
+                   let discountedPrice = Decimal(string: textField.text ?? ""),
+                   let error = inspectMaximumDiscountedPrice(
+                    price: price,
+                    discountedPrice: discountedPrice
+                   ) {
+                    showCaution(
+                        textField: textField,
+                        cautionLabel: discountedPriceCautionLabel,
+                        message: error.errorDescription
+                    )
+                } else {
+                    hideCaution(textField: textField, cautionLabel: discountedPriceCautionLabel)
+                }
+            }
+        } else if let textView = sender as? UITextView {
+            if descriptionTextView.isFirstResponder {
+                if textLength < minimumDescriptionsLimit || textLength > maximumDescriptionsLimit {
+                    showCaution(
+                        textView: textView,
+                        cautionLabel: descriptionCautionLabel,
+                        message: "글자를 \(minimumDescriptionsLimit)~\(maximumDescriptionsLimit)자로 입력해주세요"
+                    )
+                } else {
+                    hideCaution(textView: textView, cautionLabel: descriptionCautionLabel)
+                }
+            }
+        }
     }
     
     private func inspectInput(
@@ -678,8 +647,15 @@ extension ProductRegistrationViewController: UITextViewDelegate {
         }
     }
     
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if let count = textView.text?.count {
+            let textLength = count - range.length + text.count
+            textInputDidChange(textView, textLength: textLength)
+        }
+        return true
+    }
+    
     func textViewDidEndEditing(_ textView: UITextView) {
-        textInputDidChange(textView)
         if textView.text.isEmpty {
             textView.text = "상품설명"
             textView.textColor = .placeholderText
@@ -711,6 +687,15 @@ extension ProductRegistrationViewController: UITextFieldDelegate {
             let isValid = numberCharacterSet.isSuperset(of: inputCharacterSet)
             return isValid
         }
+        if let count = textField.text?.count {
+            let textLength = count - range.length + string.count
+            textInputDidChange(textField, textLength: textLength)
+        }
+        return true
+    }
+    
+    func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        textInputDidChange(textField, textLength: 0)
         return true
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -2,21 +2,23 @@ import UIKit
 
 class ProductRegistrationViewController: UIViewController, UINavigationControllerDelegate {
     private let imagePickerController = UIImagePickerController()
+    private var images = [UIImage]()
     
-    @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet weak var imagesCollectionView: UICollectionView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        imagesCollectionView.dataSource = self
         setUpImagePicker()
+    }
+    
+    @objc func presentImagePicker() {
+        present(imagePickerController, animated: true, completion: nil)
     }
     
     private func setUpImagePicker() {
         imagePickerController.sourceType = .photoLibrary
         imagePickerController.delegate = self
-    }
-    
-    @IBAction func touchUpInsideAddButton(_ sender: UIButton) {
-        present(imagePickerController, animated: true, completion: nil)
     }
 }
 
@@ -25,11 +27,54 @@ extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
         _ picker: UIImagePickerController,
         didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
     ) {
-        var image: UIImage? = nil
         if let newImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-            image = newImage
+            images.append(newImage)
+            imagesCollectionView.reloadData()
         }
-        imageView.image = image
         picker.dismiss(animated: true, completion: nil)
     }
+}
+
+extension ProductRegistrationViewController: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 2
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        if section == 0 {
+            return images.count
+        } else {
+            return 1
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: UICollectionViewCell.reuseIdentifier,
+            for: indexPath
+        )
+        if indexPath.section == 0 {
+            let image = images[indexPath.item]
+            let imageView = UIImageView(frame: cell.contentView.frame)
+            imageView.image = image
+            imageView.contentMode = .scaleAspectFit
+            cell.contentView.addSubview(imageView)
+        } else {
+            let button = UIButton(type: .system)
+            let image = UIImage(systemName: "plus")
+            button.setTitle(nil, for: .normal)
+            button.setImage(image, for: .normal)
+            button.addTarget(self, action: #selector(presentImagePicker), for: .touchUpInside)
+            button.backgroundColor = .opaqueSeparator
+            cell.contentView.addSubview(button)
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.topAnchor.constraint(equalTo: cell.contentView.topAnchor).isActive = true
+            button.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor).isActive = true
+            button.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor).isActive = true
+            button.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor).isActive = true
+        }
+        return cell
+    }
+    
+    
 }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -1,0 +1,35 @@
+import UIKit
+
+class ProductRegistrationViewController: UIViewController, UINavigationControllerDelegate {
+    private let imagePickerController = UIImagePickerController()
+    
+    @IBOutlet weak var imageView: UIImageView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpImagePicker()
+    }
+    
+    private func setUpImagePicker() {
+        imagePickerController.sourceType = .photoLibrary
+        imagePickerController.delegate = self
+    }
+    
+    @IBAction func touchUpInsideAddButton(_ sender: UIButton) {
+        present(imagePickerController, animated: true, completion: nil)
+    }
+}
+
+extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
+    func imagePickerController(
+        _ picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+    ) {
+        var image: UIImage? = nil
+        if let newImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+            image = newImage
+        }
+        imageView.image = image
+        picker.dismiss(animated: true, completion: nil)
+    }
+}

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -187,27 +187,17 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             return .failure(.emptyDiscription)
         }
         
-        if price.isSignMinus || discountedPrice?.isSignMinus == .some(true) {
-            return .failure(.negativePrice)
-        }
-        if let discountedPrice = discountedPrice, discountedPrice > price {
-            return .failure(.maximumDiscountedPrice(price))
-        }
-        if let maximumDescriptionsLimit = maximumDescriptionsLimit,
-           descriptions.count > maximumDescriptionsLimit {
-            return .failure(.maximumCharacterLimit(.description, maximumDescriptionsLimit))
-        }
-        if let minimumDescriptionsLimit = minimumDescriptionsLimit,
-           descriptions.count < minimumDescriptionsLimit {
-            return .failure(.minimumCharacterLimit(.description, minimumDescriptionsLimit))
-        }
-        if let maximumNameLimit = maximumNameLimit,
-           name.count > maximumNameLimit {
-            return .failure(.maximumCharacterLimit(.name, maximumNameLimit))
-        }
-        if let minimumNameLimit = minimumNameLimit,
-           name.count < minimumNameLimit {
-            return .failure(.minimumCharacterLimit(.name, minimumNameLimit))
+        if let error = inspectInput(
+            price: price,
+            discountedPrice: discountedPrice,
+            nameCount: name.count,
+            descriptionsCount: descriptions.count,
+            maximumDescriptionsLimit: maximumDescriptionsLimit,
+            minimumDescriptionsLimit: minimumDescriptionsLimit,
+            maximumNameLimit: maximumNameLimit,
+            minimumNameLimit: minimumNameLimit
+        ) {
+            return .failure(error)
         }
         
         let product = NetworkTask.SalesInformation(
@@ -219,6 +209,41 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             stock: stock,
             secret: secret)
         return .success(product)
+    }
+    
+    private func inspectInput(
+        price: Decimal,
+        discountedPrice: Decimal?,
+        nameCount: Int,
+        descriptionsCount: Int,
+        maximumDescriptionsLimit: Int?,
+        minimumDescriptionsLimit: Int?,
+        maximumNameLimit: Int?,
+        minimumNameLimit: Int?
+    ) -> ProductRegistrationError? {
+        if price.isSignMinus || discountedPrice?.isSignMinus == .some(true) {
+            return .negativePrice
+        }
+        if let discountedPrice = discountedPrice, discountedPrice > price {
+            return .maximumDiscountedPrice(price)
+        }
+        if let maximumDescriptionsLimit = maximumDescriptionsLimit,
+           descriptionsCount > maximumDescriptionsLimit {
+            return .maximumCharacterLimit(.description, maximumDescriptionsLimit)
+        }
+        if let minimumDescriptionsLimit = minimumDescriptionsLimit,
+           descriptionsCount < minimumDescriptionsLimit {
+            return .minimumCharacterLimit(.description, minimumDescriptionsLimit)
+        }
+        if let maximumNameLimit = maximumNameLimit,
+           nameCount > maximumNameLimit {
+            return .maximumCharacterLimit(.name, maximumNameLimit)
+        }
+        if let minimumNameLimit = minimumNameLimit,
+           nameCount < minimumNameLimit {
+            return .minimumCharacterLimit(.name, minimumNameLimit)
+        }
+        return nil
     }
     
     private func cropSquare(_ image: UIImage) -> UIImage? {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -10,10 +10,29 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         super.viewDidLoad()
         imagesCollectionView.dataSource = self
         setUpImagePicker()
+        setupNavigationBar()
+    }
+
+    @objc private func dismissProductRegistration() {
+        self.dismiss(animated: true, completion: nil)
     }
     
-    @objc func presentImagePicker() {
+    @objc private func presentImagePicker() {
         present(imagePickerController, animated: true, completion: nil)
+    }
+    
+    private func setupNavigationBar() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: self,
+            action: #selector(dismissProductRegistration)
+        )
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: nil
+        )
+        navigationItem.title = "상품등록"
     }
     
     private func setUpImagePicker() {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -69,18 +69,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         setupTextView()
         hideAllCautionLabel()
         loadProductInformation()
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(keyboardWillShow),
-            name: UIResponder.keyboardWillShowNotification,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(keyboardWillHide),
-            name: UIResponder.keyboardWillHideNotification,
-            object: nil
-        )
+        addKeyboardObserver()
     }
     
     @objc private func registerProduct() {
@@ -231,6 +220,21 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         descriptionTextView.layer.borderWidth = 0.5
         descriptionTextView.layer.cornerRadius = 5
         descriptionTextView.layer.borderColor = UIColor.separator.cgColor
+    }
+    
+    private func addKeyboardObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
     }
     
     private func hideAllCautionLabel() {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -595,11 +595,7 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int
     ) -> Int {
-        if section == 0 {
-            return images.count
-        } else {
-            return 1
-        }
+        return section == 0 ? images.count : 1
     }
     
     func collectionView(

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -16,19 +16,19 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     private var jsonParser: JSONParser?
     private var completionHandler: (() -> Void)?
     
-    @IBOutlet weak var scrollView: UIScrollView!
-    @IBOutlet weak var verticalStackView: UIStackView!
-    @IBOutlet weak var imagesCollectionView: UICollectionView!
-    @IBOutlet weak var productNameTextField: UITextField!
-    @IBOutlet weak var productPriceTextField: UITextField!
-    @IBOutlet weak var discountedPriceTextField: UITextField!
-    @IBOutlet weak var stockTextField: UITextField!
-    @IBOutlet weak var descriptionTextView: UITextView!
-    @IBOutlet weak var currencySegmentedControl: UISegmentedControl!
-    @IBOutlet weak var productNameCautionLabel: UILabel!
-    @IBOutlet weak var productPriceCautionLabel: UILabel!
-    @IBOutlet weak var discountedPriceCautionLabel: UILabel!
-    @IBOutlet weak var descriptionCautionLabel: UILabel!
+    @IBOutlet private weak var scrollView: UIScrollView!
+    @IBOutlet private weak var verticalStackView: UIStackView!
+    @IBOutlet private weak var imagesCollectionView: UICollectionView!
+    @IBOutlet private weak var productNameTextField: UITextField!
+    @IBOutlet private weak var productPriceTextField: UITextField!
+    @IBOutlet private weak var discountedPriceTextField: UITextField!
+    @IBOutlet private weak var stockTextField: UITextField!
+    @IBOutlet private weak var descriptionTextView: UITextView!
+    @IBOutlet private weak var currencySegmentedControl: UISegmentedControl!
+    @IBOutlet private weak var productNameCautionLabel: UILabel!
+    @IBOutlet private weak var productPriceCautionLabel: UILabel!
+    @IBOutlet private weak var discountedPriceCautionLabel: UILabel!
+    @IBOutlet private weak var descriptionCautionLabel: UILabel!
     
     convenience init?(
         coder: NSCoder,
@@ -588,7 +588,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         return imageData
     }
     
-    @IBAction func tapBackground(_ sender: UITapGestureRecognizer) {
+    @IBAction private func tapBackground(_ sender: UITapGestureRecognizer) {
         view.endEditing(true)
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -560,6 +560,13 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     }
 }
 
+extension ProductRegistrationViewController {
+    private enum Section: Int {
+        case imagesSection
+        case buttonSection
+    }
+}
+
 extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
     func imagePickerController(
         _ picker: UIImagePickerController,
@@ -594,7 +601,15 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int
     ) -> Int {
-        return section == 0 ? images.count : 1
+        guard let section = Section(rawValue: section) else {
+            return 0
+        }
+        switch section {
+        case .imagesSection:
+            return images.count
+        case .buttonSection:
+            return 1
+        }
     }
     
     func collectionView(
@@ -608,13 +623,17 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         cell.contentView.subviews.forEach { view in
             view.removeFromSuperview()
         }
-        if indexPath.section == 0 {
+        guard let section = Section(rawValue: indexPath.section) else {
+            return cell
+        }
+        switch section {
+        case .imagesSection:
             let image = images[indexPath.item]
             let imageView = UIImageView(frame: cell.contentView.frame)
             imageView.image = image
             imageView.contentMode = .scaleAspectFit
             cell.contentView.addSubview(imageView)
-        } else {
+        case .buttonSection:
             let button = UIButton(type: .system)
             let image = UIImage(systemName: "plus")
             button.setTitle(nil, for: .normal)

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -601,14 +601,14 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int
     ) -> Int {
-        guard let section = Section(rawValue: section) else {
-            return 0
-        }
+        let section = Section(rawValue: section)
         switch section {
         case .imagesSection:
             return images.count
         case .buttonSection:
             return 1
+        case .none:
+            return 0
         }
     }
     
@@ -623,9 +623,7 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         cell.contentView.subviews.forEach { view in
             view.removeFromSuperview()
         }
-        guard let section = Section(rawValue: indexPath.section) else {
-            return cell
-        }
+        let section = Section(rawValue: indexPath.section)
         switch section {
         case .imagesSection:
             let image = images[indexPath.item]
@@ -649,6 +647,7 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
                 button.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor)
             ]
             NSLayoutConstraint.activate(constraints)
+        case .none: break
         }
         return cell
     }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -76,12 +76,11 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             let fileName = "\(count).jpeg"
             var imageData = image.jpegData(compressionQuality: 0.8)
             while let bytes = imageData?.count, bytes >= 300 * 1000 {
-                imageData = resize(image, multiplier: multiplier)?.jpegData(compressionQuality: 0.8)
-                multiplier -= 0.01
+                imageData = image.resize(multiplier: multiplier).jpegData(compressionQuality: 0.8)
+                multiplier -= 0.05
             }
-            imageDatas[fileName] = imageData
-            print(imageData!.count / 1000)
             count += 1
+            imageDatas[fileName] = imageData
         }
         
         networkTask?.requestProductRegistration(
@@ -139,7 +138,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     
     private func setUpImagePicker() {
         imagePickerController.sourceType = .photoLibrary
-        imagePickerController.allowsEditing = true
+//        imagePickerController.allowsEditing = true
         imagePickerController.delegate = self
     }
     
@@ -261,19 +260,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         return UIImage(cgImage: squareImage)
     }
     
-    private func resize(_ image: UIImage, multiplier: CGFloat) -> UIImage? {
-        let origin = CGPoint(x: 0, y: 0)
-        let size = CGSize(
-            width: image.size.width * multiplier,
-            height: image.size.height * multiplier
-        )
-        let rectangle = CGRect(origin: origin, size: size)
-        guard let squareImage = image.cgImage?.cropping(to: rectangle) else {
-            return nil
-        }
-        return UIImage(cgImage: squareImage)
-    }
-    
     @IBAction func tapBackground(_ sender: UITapGestureRecognizer) {
         view.endEditing(true)
     }
@@ -284,16 +270,18 @@ extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
         _ picker: UIImagePickerController,
         didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
     ) {
-        guard var newImage = info[.editedImage] as? UIImage else {
+        guard var newImage = info[.originalImage] as? UIImage else {
             picker.dismiss(animated: true, completion: nil)
             return
         }
+        print(newImage.size)
         let isSquare = newImage.size.width == newImage.size.height
         if isSquare == false {
             if let squareImage = cropSquare(newImage) {
                 newImage = squareImage
             }
         }
+        print(newImage.size)
         images.append(newImage)
         imagesCollectionView.reloadData()
         picker.dismiss(animated: true, completion: nil)

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -91,14 +91,16 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         }
         
         var count = 0
-        var multiplier: CGFloat = 1.0
         var imageDatas = [String: Data]()
         for image in images {
+            let compressionQuality: CGFloat = 0.8
             let fileName = "\(count).jpeg"
-            var imageData = image.jpegData(compressionQuality: 0.8)
+            var originalImage = image
+            var imageData = originalImage.jpegData(compressionQuality: compressionQuality)
             while let bytes = imageData?.count, bytes >= 300 * 1000 {
-                imageData = image.resize(multiplier: multiplier).jpegData(compressionQuality: 0.8)
-                multiplier -= 0.05
+                let multiplier: CGFloat = 0.8
+                originalImage = originalImage.resize(multiplier: multiplier)
+                imageData = originalImage.jpegData(compressionQuality: compressionQuality)
             }
             count += 1
             imageDatas[fileName] = imageData

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -63,6 +63,9 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         super.viewDidLoad()
         imagesCollectionView.dataSource = self
         productNameTextField.delegate = self
+        productPriceTextField.delegate = self
+        discountedPriceTextField.delegate = self
+        stockTextField.delegate = self
         setUpImagePicker()
         setupNavigationBar()
         hideAllCautionLabel()
@@ -106,12 +109,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
                         cautionLabel: productPriceCautionLabel,
                         message: "상품가격을 입력해주세요"
                     )
-                } else if let price = Decimal(string: textField.text ?? ""),
-                    let error = inspectSign(price: price, discountedPrice: nil) {
-                    showCaution(
-                        textField: textField,
-                        cautionLabel: productPriceCautionLabel,
-                        message: error.errorDescription)
                 } else {
                     hideCaution(textField: textField, cautionLabel: productPriceCautionLabel)
                 }
@@ -123,12 +120,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
                     price: price,
                     discountedPrice: discountedPrice
                 ) {
-                    showCaution(
-                        textField: textField,
-                        cautionLabel: discountedPriceCautionLabel,
-                        message: error.errorDescription
-                    )
-                } else if let error = inspectSign(price: price, discountedPrice: discountedPrice) {
                     showCaution(
                         textField: textField,
                         cautionLabel: discountedPriceCautionLabel,
@@ -464,9 +455,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         maximumNameLimit: Int?,
         minimumNameLimit: Int?
     ) -> ProductRegistrationError? {
-        if let error = inspectSign(price: price, discountedPrice: discountedPrice) {
-            return error
-        }
         if let error = inspectMaximumDiscountedPrice(
             price: price,
             discountedPrice: discountedPrice
@@ -490,16 +478,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             limit: maximumDescriptionsLimit
         ) {
             return error
-        }
-        return nil
-    }
-    
-    private func inspectSign(
-        price: Decimal,
-        discountedPrice: Decimal?
-    ) -> ProductRegistrationError? {
-        if price.isSignMinus || discountedPrice?.isSignMinus == .some(true) {
-            return .negativePrice
         }
         return nil
     }
@@ -666,5 +644,24 @@ extension ProductRegistrationViewController: UITextFieldDelegate {
             productPriceTextField.becomeFirstResponder()
         }
         return false
+    }
+    
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        if textField === productPriceTextField ||
+            textField === discountedPriceTextField ||
+            textField === stockTextField {
+            if string.isEmpty {
+                return true
+            }
+            let numberCharacterSet = CharacterSet.decimalDigits
+            let inputCharacterSet = CharacterSet(charactersIn: string)
+            let isValid = numberCharacterSet.isSuperset(of: inputCharacterSet)
+            return isValid
+        }
+        return true
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 class ProductRegistrationViewController: UIViewController, UINavigationControllerDelegate {
+    private let identifier = "2836ea8c-7215-11ec-abfa-378889d9906f"
+    private let secret = "-3CSKv$cyHsK_@Wk"
     private let imagePickerController = UIImagePickerController()
     private var images = [UIImage]()
     private var isModifying: Bool?
@@ -72,8 +74,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     }
     
     @objc private func registerProduct() {
-        let identifier = "2836ea8c-7215-11ec-abfa-378889d9906f"
-        let secret = "-3CSKv$cyHsK_@Wk"
         let writtenSalesInformation = makeSalesInformation(
             secret: secret,
             maximumDescriptionsLimit: 1000,
@@ -123,8 +123,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     }
     
     @objc private func modifyProduct() {
-        let identifier = "2836ea8c-7215-11ec-abfa-378889d9906f"
-        let secret = "-3CSKv$cyHsK_@Wk"
         let writtenSalesInformation = modifiySalesInformation(
             secret: secret,
             maximumDescriptionsLimit: 1000,

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -145,18 +145,13 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             if textView === descriptionTextView {
                 let count = textView.text.count
                 if count < minimumDescriptionsLimit || count > maximumDescriptionsLimit {
-                    descriptionCautionLabel.text = "글자를 \(minimumDescriptionsLimit)~\(maximumDescriptionsLimit)자로 입력해주세요"
-                    descriptionCautionLabel.isHidden = false
-                    textView.layer.borderColor = UIColor.systemRed.cgColor
-                    textView.layer.borderWidth = 0.5
-                } else {
-                    descriptionCautionLabel.isHidden = true
-                    textView.layer.borderColor = CGColor(
-                        srgbRed: 0.8,
-                        green: 0.8,
-                        blue: 0.8,
-                        alpha: 1.0
+                    showCaution(
+                        textView: textView,
+                        cautionLabel: descriptionCautionLabel,
+                        message: "글자를 \(minimumDescriptionsLimit)~\(maximumDescriptionsLimit)자로 입력해주세요"
                     )
+                } else {
+                    hideCaution(textView: textView, cautionLabel: descriptionCautionLabel)
                 }
             }
         }
@@ -306,9 +301,26 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         textField.layer.borderWidth = 0.5
     }
     
+    private func showCaution(textView: UITextView, cautionLabel: UILabel, message: String?) {
+        cautionLabel.text = message
+        cautionLabel.isHidden = false
+        textView.layer.borderColor = UIColor.systemRed.cgColor
+        textView.layer.borderWidth = 0.5
+    }
+    
     private func hideCaution(textField: UITextField, cautionLabel: UILabel) {
         textField.layer.borderWidth = 0.0
         cautionLabel.isHidden = true
+    }
+    
+    private func hideCaution(textView: UITextView, cautionLabel: UILabel) {
+        cautionLabel.isHidden = true
+        textView.layer.borderColor = CGColor(
+            srgbRed: 0.8,
+            green: 0.8,
+            blue: 0.8,
+            alpha: 1.0
+        )
     }
     
     private func loadProductInformation() {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -80,7 +80,11 @@ extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
 
 extension ProductRegistrationViewController: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 2
+        if images.count < 5 {
+            return 2
+        } else {
+            return 1
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -586,9 +586,8 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         if images.count < 5, isModifying == false {
             return 2
-        } else {
-            return 1
         }
+        return 1
     }
     
     func collectionView(

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -5,12 +5,14 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     private var images = [UIImage]()
     
     @IBOutlet weak var imagesCollectionView: UICollectionView!
+    @IBOutlet weak var descriptionTextView: UITextView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         imagesCollectionView.dataSource = self
         setUpImagePicker()
         setupNavigationBar()
+        setupTextView()
     }
     
     @objc private func dismissProductRegistration() {
@@ -39,6 +41,20 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         imagePickerController.sourceType = .photoLibrary
         imagePickerController.allowsEditing = true
         imagePickerController.delegate = self
+    }
+    
+    private func setupTextView() {
+        descriptionTextView.delegate = self
+        descriptionTextView.text = "상품설명"
+        descriptionTextView.textColor = .placeholderText
+        descriptionTextView.layer.borderWidth = 0.5
+        descriptionTextView.layer.cornerRadius = 5
+        descriptionTextView.layer.borderColor = CGColor(
+            srgbRed: 0.8,
+            green: 0.8,
+            blue: 0.8,
+            alpha: 1.0
+        )
     }
     
     private func cropSquare(_ image: UIImage) -> UIImage? {
@@ -133,5 +149,21 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
             NSLayoutConstraint.activate(constraints)
         }
         return cell
+    }
+}
+
+extension ProductRegistrationViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .placeholderText {
+            textView.text = nil
+            textView.textColor = .label
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = "상품설명"
+            textView.textColor = .placeholderText
+        }
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 class ProductRegistrationViewController: UIViewController, UINavigationControllerDelegate {
+    static let storyboardName = "ProductRegistration"
     private let identifier = "2836ea8c-7215-11ec-abfa-378889d9906f"
     private let secret = "-3CSKv$cyHsK_@Wk"
     private let maximumDescriptionsLimit = 1000
@@ -606,7 +607,7 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         cellForItemAt indexPath: IndexPath
     ) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: UICollectionViewCell.reuseIdentifier,
+            withReuseIdentifier: UICollectionViewCell.identifier,
             for: indexPath
         )
         cell.contentView.subviews.forEach { view in

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -3,6 +3,8 @@ import UIKit
 class ProductRegistrationViewController: UIViewController, UINavigationControllerDelegate {
     private let imagePickerController = UIImagePickerController()
     private var images = [UIImage]()
+    private var isModifying: Bool?
+    private var productInformation: Product?
     private var networkTask: NetworkTask?
     private var jsonParser: JSONParser?
     private var completionHandler: (() -> Void)?
@@ -19,11 +21,29 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     
     convenience init?(
         coder: NSCoder,
+        isModifying: Bool,
         networkTask: NetworkTask,
         jsonParser: JSONParser,
         completionHandler: (() -> Void)?
     ) {
         self.init(coder: coder)
+        self.isModifying = isModifying
+        self.networkTask = networkTask
+        self.jsonParser = jsonParser
+        self.completionHandler = completionHandler
+    }
+    
+    convenience init?(
+        coder: NSCoder,
+        isModifying: Bool,
+        productInformation: Product,
+        networkTask: NetworkTask,
+        jsonParser: JSONParser,
+        completionHandler: (() -> Void)?
+    ) {
+        self.init(coder: coder)
+        self.isModifying = isModifying
+        self.productInformation = productInformation
         self.networkTask = networkTask
         self.jsonParser = jsonParser
         self.completionHandler = completionHandler
@@ -34,7 +54,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         imagesCollectionView.dataSource = self
         productNameTextField.delegate = self
         setUpImagePicker()
-        setupNavigationBar()
+        setupRegistrationNavigationBar()
         setupTextView()
         NotificationCenter.default.addObserver(
             self,
@@ -122,7 +142,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         scrollView.verticalScrollIndicatorInsets.bottom = 0
     }
     
-    private func setupNavigationBar() {
+    private func setupRegistrationNavigationBar() {
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .cancel,
             target: self,
@@ -134,6 +154,20 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             action: #selector(registerProduct)
         )
         navigationItem.title = "상품등록"
+    }
+    
+    private func setupModificationNavigationBar() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: self,
+            action: #selector(dismissProductRegistration)
+        )
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(modifyProduct)
+        )
+        navigationItem.title = "상품수정"
     }
     
     private func setUpImagePicker() {
@@ -289,7 +323,7 @@ extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
 
 extension ProductRegistrationViewController: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        if images.count < 5 {
+        if images.count < 5, isModifying == false {
             return 2
         } else {
             return 1

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -12,7 +12,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         setUpImagePicker()
         setupNavigationBar()
     }
-
+    
     @objc private func dismissProductRegistration() {
         self.dismiss(animated: true, completion: nil)
     }
@@ -87,7 +87,10 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         }
     }
     
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
         if section == 0 {
             return images.count
         } else {
@@ -95,7 +98,10 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         }
     }
     
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(
             withReuseIdentifier: UICollectionViewCell.reuseIdentifier,
             for: indexPath
@@ -118,10 +124,13 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
             button.backgroundColor = .opaqueSeparator
             cell.contentView.addSubview(button)
             button.translatesAutoresizingMaskIntoConstraints = false
-            button.topAnchor.constraint(equalTo: cell.contentView.topAnchor).isActive = true
-            button.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor).isActive = true
-            button.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor).isActive = true
-            button.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor).isActive = true
+            let constraints = [
+                button.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
+                button.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
+                button.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
+                button.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor)
+            ]
+            NSLayoutConstraint.activate(constraints)
         }
         return cell
     }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -108,11 +108,13 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             let keyboardRectangle = keyboardFrame.cgRectValue
             let keyboardHeight = keyboardRectangle.height
             scrollView.contentInset.bottom = keyboardHeight
+            scrollView.verticalScrollIndicatorInsets.bottom = keyboardHeight
         }
     }
     
     @objc private func keyboardWillHide(_ sender: Notification) {
         scrollView.contentInset.bottom = 0
+        scrollView.verticalScrollIndicatorInsets.bottom = 0
     }
     
     private func setupNavigationBar() {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -4,7 +4,6 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     private let imagePickerController = UIImagePickerController()
     private var images = [UIImage]()
     private var isModifying: Bool?
-    private var productInformation: Product?
     private var networkTask: NetworkTask?
     private var jsonParser: JSONParser?
     private var completionHandler: (() -> Void)?
@@ -43,10 +42,10 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     ) {
         self.init(coder: coder)
         self.isModifying = isModifying
-        self.productInformation = productInformation
         self.networkTask = networkTask
         self.jsonParser = jsonParser
         self.completionHandler = completionHandler
+        loadProductInformation(from: productInformation)
     }
     
     override func viewDidLoad() {
@@ -168,6 +167,25 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             action: #selector(modifyProduct)
         )
         navigationItem.title = "상품수정"
+    }
+    
+    private func loadProductInformation(from productInformation: Product) {
+        productNameTextField.text = productInformation.name
+        productPriceTextField.text = productInformation.price.description
+        discountedPriceTextField.text = productInformation.discountedPrice.description
+        stockTextField.text = productInformation.stock.description
+        descriptionTextView.text = productInformation.description
+        if productInformation.currency == .krw {
+            currencySegmentedControl.selectedSegmentIndex = 0
+        } else if productInformation.currency == .usd {
+            currencySegmentedControl.selectedSegmentIndex = 1
+        }
+        productInformation.images?.forEach { image in
+            guard let url = URL(string: image.url),
+                  let imageData = try? Data(contentsOf: url),
+                  let downloadedImage = UIImage(data: imageData) else { return }
+            images.append(downloadedImage)
+        }
     }
     
     private func setUpImagePicker() {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -564,10 +564,11 @@ extension ProductRegistrationViewController: UIImagePickerControllerDelegate {
         _ picker: UIImagePickerController,
         didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
     ) {
-        guard var newImage = info[.originalImage] as? UIImage else {
-            picker.dismiss(animated: true, completion: nil)
-            return
-        }
+        guard picker.isBeingDismissed == false,
+              var newImage = info[.originalImage] as? UIImage else {
+                  picker.dismiss(animated: true, completion: nil)
+                  return
+              }
         let isSquare = newImage.size.width == newImage.size.height
         if isSquare == false {
             if let squareImage = newImage.cropSquare() {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -632,7 +632,8 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
 
 extension ProductRegistrationViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.textColor == .placeholderText {
+        let textViewIsEmpty = textView.textColor == .placeholderText
+        if textViewIsEmpty {
             textView.text = nil
             textView.textColor = .label
         }

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -65,7 +65,7 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         productNameTextField.delegate = self
         setUpImagePicker()
         setupNavigationBar()
-        hideCautionLabel()
+        hideAllCautionLabel()
         setupTextView()
         loadProductInformation()
         NotificationCenter.default.addObserver(
@@ -90,26 +90,24 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
             if textField === productNameTextField {
                 if let count = textField.text?.count,
                    count < minimumNameLimit || count > maximumNameLimit {
-                    productNameCautionLabel.text = "글자를 \(minimumNameLimit)~\(maximumNameLimit)자로 입력해주세요"
-                    productNameCautionLabel.isHidden = false
-                    textField.layer.borderColor = UIColor.systemRed.cgColor
-                    textField.layer.cornerRadius = 5
-                    textField.layer.borderWidth = 0.5
+                    showCaution(
+                        textField: textField,
+                        cautionLabel: productNameCautionLabel,
+                        message: "글자를 \(minimumNameLimit)~\(maximumNameLimit)자로 입력해주세요"
+                    )
                 } else {
-                    productNameCautionLabel.isHidden = true
-                    textField.layer.borderWidth = 0.0
+                    hideCaution(textField: textField, cautionLabel: productNameCautionLabel)
                 }
             }
             if textField === productPriceTextField {
                 if let count = textField.text?.count, count == 0 {
-                    productPriceCautionLabel.text = "상품가격을 입력해주세요"
-                    productPriceCautionLabel.isHidden = false
-                    textField.layer.borderColor = UIColor.systemRed.cgColor
-                    textField.layer.cornerRadius = 5
-                    textField.layer.borderWidth = 0.5
+                    showCaution(
+                        textField: textField,
+                        cautionLabel: productPriceCautionLabel,
+                        message: "상품가격을 입력해주세요"
+                    )
                 } else {
-                    productPriceCautionLabel.isHidden = true
-                    textField.layer.borderWidth = 0.0
+                    hideCaution(textField: textField, cautionLabel: productPriceCautionLabel)
                 }
             }
             if textField === discountedPriceTextField {
@@ -119,14 +117,13 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
                     price: price,
                     discountedPrice: discountedPrice
                 ) {
-                    discountedPriceCautionLabel.text = error.errorDescription
-                    discountedPriceCautionLabel.isHidden = false
-                    textField.layer.borderColor = UIColor.systemRed.cgColor
-                    textField.layer.cornerRadius = 5
-                    textField.layer.borderWidth = 0.5
+                    showCaution(
+                        textField: textField,
+                        cautionLabel: discountedPriceCautionLabel,
+                        message: error.errorDescription
+                    )
                 } else {
-                    discountedPriceCautionLabel.isHidden = true
-                    textField.layer.borderWidth = 0.0
+                    hideCaution(textField: textField, cautionLabel: discountedPriceCautionLabel)
                 }
             }
         } else if let textView = sender as? UITextView {
@@ -279,11 +276,24 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         }
     }
     
-    private func hideCautionLabel() {
+    private func hideAllCautionLabel() {
         productNameCautionLabel.isHidden = true
         productPriceCautionLabel.isHidden = true
         discountedPriceCautionLabel.isHidden = true
         descriptionCautionLabel.isHidden = true
+    }
+    
+    private func showCaution(textField: UITextField, cautionLabel: UILabel, message: String?) {
+        cautionLabel.text = message
+        cautionLabel.isHidden = false
+        textField.layer.borderColor = UIColor.systemRed.cgColor
+        textField.layer.cornerRadius = 5
+        textField.layer.borderWidth = 0.5
+    }
+    
+    private func hideCaution(textField: UITextField, cautionLabel: UILabel) {
+        textField.layer.borderWidth = 0.0
+        cautionLabel.isHidden = true
     }
     
     private func loadProductInformation() {

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -119,7 +119,10 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
                         message: error.errorDescription
                     )
                 } else {
-                    hideCaution(textField: discountedPriceTextField, cautionLabel: discountedPriceCautionLabel)
+                    hideCaution(
+                        textField: discountedPriceTextField,
+                        cautionLabel: discountedPriceCautionLabel
+                    )
                 }
             }
             if textField === discountedPriceTextField {
@@ -310,11 +313,22 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
     }
     
     private func setupTextFieldTarget() {
-        productNameTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
-        productPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
-        discountedPriceTextField.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
+        productNameTextField.addTarget(
+            self,
+            action: #selector(textInputDidChange(_:)),
+            for: .editingChanged
+        )
+        productPriceTextField.addTarget(
+            self,
+            action: #selector(textInputDidChange(_:)),
+            for: .editingChanged
+        )
+        discountedPriceTextField.addTarget(
+            self,
+            action: #selector(textInputDidChange(_:)),
+            for: .editingChanged
+        )
     }
-    
     
     private func hideAllCautionLabel() {
         productNameCautionLabel.isHidden = true

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -64,11 +64,17 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         }
         
         var count = 0
+        var multiplier: CGFloat = 1.0
         var imageDatas = [String: Data]()
         for image in images {
             let fileName = "\(count).jpeg"
-            let imageData = image.jpegData(compressionQuality: 0.8)
+            var imageData = image.jpegData(compressionQuality: 0.8)
+            while let bytes = imageData?.count, bytes >= 300 * 1000 {
+                imageData = resize(image, multiplier: multiplier)?.jpegData(compressionQuality: 0.8)
+                multiplier -= 0.01
+            }
             imageDatas[fileName] = imageData
+            print(imageData!.count / 1000)
             count += 1
         }
         
@@ -189,6 +195,19 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         let size = CGSize(width: shortLength, height: shortLength)
         let square = CGRect(origin: origin, size: size)
         guard let squareImage = image.cgImage?.cropping(to: square) else {
+            return nil
+        }
+        return UIImage(cgImage: squareImage)
+    }
+    
+    private func resize(_ image: UIImage, multiplier: CGFloat) -> UIImage? {
+        let origin = CGPoint(x: 0, y: 0)
+        let size = CGSize(
+            width: image.size.width * multiplier,
+            height: image.size.height * multiplier
+        )
+        let rectangle = CGRect(origin: origin, size: size)
+        guard let squareImage = image.cgImage?.cropping(to: rectangle) else {
             return nil
         }
         return UIImage(cgImage: squareImage)

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -555,6 +555,23 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
         return nil
     }
     
+    private func makeImageView(with image: UIImage, frame: CGRect) -> UIImageView {
+        let imageView = UIImageView(frame: frame)
+        imageView.image = image
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }
+    
+    private func makeButton(systemName: String) -> UIButton {
+        let button = UIButton(type: .system)
+        let image = UIImage(systemName: systemName)
+        button.setTitle(nil, for: .normal)
+        button.setImage(image, for: .normal)
+        button.addTarget(self, action: #selector(presentImagePicker), for: .touchUpInside)
+        button.backgroundColor = .opaqueSeparator
+        return button
+    }
+    
     @IBAction func tapBackground(_ sender: UITapGestureRecognizer) {
         view.endEditing(true)
     }
@@ -627,17 +644,10 @@ extension ProductRegistrationViewController: UICollectionViewDataSource {
         switch section {
         case .imagesSection:
             let image = images[indexPath.item]
-            let imageView = UIImageView(frame: cell.contentView.frame)
-            imageView.image = image
-            imageView.contentMode = .scaleAspectFit
+            let imageView = makeImageView(with: image, frame: cell.contentView.frame)
             cell.contentView.addSubview(imageView)
         case .buttonSection:
-            let button = UIButton(type: .system)
-            let image = UIImage(systemName: "plus")
-            button.setTitle(nil, for: .normal)
-            button.setImage(image, for: .normal)
-            button.addTarget(self, action: #selector(presentImagePicker), for: .touchUpInside)
-            button.backgroundColor = .opaqueSeparator
+            let button = makeButton(systemName: "plus")
             cell.contentView.addSubview(button)
             button.translatesAutoresizingMaskIntoConstraints = false
             let constraints = [

--- a/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductRegistrationViewController.swift
@@ -106,6 +106,12 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
                         cautionLabel: productPriceCautionLabel,
                         message: "상품가격을 입력해주세요"
                     )
+                } else if let price = Decimal(string: textField.text ?? ""),
+                    let error = inspectSign(price: price, discountedPrice: nil) {
+                    showCaution(
+                        textField: textField,
+                        cautionLabel: productPriceCautionLabel,
+                        message: error.errorDescription)
                 } else {
                     hideCaution(textField: textField, cautionLabel: productPriceCautionLabel)
                 }
@@ -117,6 +123,12 @@ class ProductRegistrationViewController: UIViewController, UINavigationControlle
                     price: price,
                     discountedPrice: discountedPrice
                 ) {
+                    showCaution(
+                        textField: textField,
+                        cautionLabel: discountedPriceCautionLabel,
+                        message: error.errorDescription
+                    )
+                } else if let error = inspectSign(price: price, discountedPrice: discountedPrice) {
                     showCaution(
                         textField: textField,
                         cautionLabel: discountedPriceCautionLabel,

--- a/OpenMarket/OpenMarket/Controller/ProductsDataSource.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductsDataSource.swift
@@ -21,6 +21,20 @@ class ProductsDataSource: NSObject {
         products = [Product]()
     }
     
+    func productId(at index: Int) -> Int? {
+        guard products.count > index else {
+            return nil
+        }
+        return products[index].id
+    }
+    
+    func vendorId(at index: Int) -> Int? {
+        guard products.count > index else {
+            return nil
+        }
+        return products[index].vendorId
+    }
+    
     private func setupCellImage(
         for cell: ProductCell,
         from url: URL,

--- a/OpenMarket/OpenMarket/Controller/ProductsDataSource.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductsDataSource.swift
@@ -22,17 +22,11 @@ class ProductsDataSource: NSObject {
     }
     
     func productId(at index: Int) -> Int? {
-        guard products.count > index else {
-            return nil
-        }
-        return products[index].id
+        return products[safe: index]?.id
     }
     
     func vendorId(at index: Int) -> Int? {
-        guard products.count > index else {
-            return nil
-        }
-        return products[index].vendorId
+        return products[safe: index]?.vendorId
     }
     
     private func setupCellImage(

--- a/OpenMarket/OpenMarket/Controller/ProductsDataSource.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductsDataSource.swift
@@ -17,6 +17,10 @@ class ProductsDataSource: NSObject {
         return index == products.count - 1
     }
     
+    func removeAllProducts() {
+        products = [Product]()
+    }
+    
     private func setupCellImage(
         for cell: ProductCell,
         from url: URL,

--- a/OpenMarket/OpenMarket/Controller/ProductsDataSource.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductsDataSource.swift
@@ -75,7 +75,7 @@ extension ProductsDataSource: UITableViewDataSource {
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
         let product = products[indexPath.row]
-        let reuseIdentifier = ProductsTableViewCell.reuseIdentifier
+        let reuseIdentifier = ProductsTableViewCell.identifier
         let cell = tableView.dequeueReusableCell(
             withIdentifier: reuseIdentifier,
             for: indexPath
@@ -111,7 +111,7 @@ extension ProductsDataSource: UICollectionViewDataSource {
         cellForItemAt indexPath: IndexPath
     ) -> UICollectionViewCell {
         let product = products[indexPath.item]
-        let reuseIdentifier = ProductsCollectionViewCell.reuseIdentifier
+        let reuseIdentifier = ProductsCollectionViewCell.identifier
         let cell = collectionView.dequeueReusableCell(
             withReuseIdentifier: reuseIdentifier,
             for: indexPath

--- a/OpenMarket/OpenMarket/Error/ProductRegistrationError.swift
+++ b/OpenMarket/OpenMarket/Error/ProductRegistrationError.swift
@@ -8,7 +8,6 @@ enum ProductRegistrationError: Error {
     case emptyImage
     case maximumCharacterLimit(TextCategory, Int)
     case minimumCharacterLimit(TextCategory, Int)
-    case negativePrice
     case maximumDiscountedPrice(Decimal)
 }
 
@@ -29,8 +28,6 @@ extension ProductRegistrationError: LocalizedError {
             return "\(category)을 \(count)글자 이하로 입력해주세요"
         case .minimumCharacterLimit(let category, let count):
             return "\(category)을 \(count)글자 이상 입력해주세요"
-        case .negativePrice:
-            return "금액을 양수로 입력해주세요"
         case .maximumDiscountedPrice(let price):
             return "할인금액을 \(price) 이하로 입력해주세요"
         }

--- a/OpenMarket/OpenMarket/Error/ProductRegistrationError.swift
+++ b/OpenMarket/OpenMarket/Error/ProductRegistrationError.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum ProductRegistrationError: Error {
+    case emptyName
+    case emptyDiscription
+    case emptyPrice
+    case emptyCurrency
+}
+
+extension ProductRegistrationError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            return "상품명을 입력해주세요"
+        case .emptyDiscription:
+            return "상품설명을 입력해주세요"
+        case .emptyPrice:
+            return "상품가격을 입력해주세요"
+        case .emptyCurrency:
+            return "통화가 선택되지 않았습니다"
+        }
+    }
+}

--- a/OpenMarket/OpenMarket/Error/ProductRegistrationError.swift
+++ b/OpenMarket/OpenMarket/Error/ProductRegistrationError.swift
@@ -5,6 +5,7 @@ enum ProductRegistrationError: Error {
     case emptyDiscription
     case emptyPrice
     case emptyCurrency
+    case emptyImage
 }
 
 extension ProductRegistrationError: LocalizedError {
@@ -18,6 +19,8 @@ extension ProductRegistrationError: LocalizedError {
             return "상품가격을 입력해주세요"
         case .emptyCurrency:
             return "통화가 선택되지 않았습니다"
+        case .emptyImage:
+            return "이미지를 추가해주세요"
         }
     }
 }

--- a/OpenMarket/OpenMarket/Error/ProductRegistrationError.swift
+++ b/OpenMarket/OpenMarket/Error/ProductRegistrationError.swift
@@ -6,6 +6,10 @@ enum ProductRegistrationError: Error {
     case emptyPrice
     case emptyCurrency
     case emptyImage
+    case maximumCharacterLimit(TextCategory, Int)
+    case minimumCharacterLimit(TextCategory, Int)
+    case negativePrice
+    case maximumDiscountedPrice(Decimal)
 }
 
 extension ProductRegistrationError: LocalizedError {
@@ -21,6 +25,30 @@ extension ProductRegistrationError: LocalizedError {
             return "통화가 선택되지 않았습니다"
         case .emptyImage:
             return "이미지를 추가해주세요"
+        case .maximumCharacterLimit(let category, let count):
+            return "\(category)을 \(count)글자 이하로 입력해주세요"
+        case .minimumCharacterLimit(let category, let count):
+            return "\(category)을 \(count)글자 이상 입력해주세요"
+        case .negativePrice:
+            return "금액을 양수로 입력해주세요"
+        case .maximumDiscountedPrice(let price):
+            return "할인금액을 \(price) 이하로 입력해주세요"
+        }
+    }
+}
+
+extension ProductRegistrationError {
+    enum TextCategory: CustomStringConvertible {
+        case name
+        case description
+        
+        var description: String {
+            switch self {
+            case .name:
+                return "상품명"
+            case .description:
+                return "상품설명"
+            }
         }
     }
 }

--- a/OpenMarket/OpenMarket/Extension/Array+extension.swift
+++ b/OpenMarket/OpenMarket/Extension/Array+extension.swift
@@ -1,0 +1,8 @@
+extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard self.count > index else {
+            return nil
+        }
+        return self[index]
+    }
+}

--- a/OpenMarket/OpenMarket/Extension/UIImage+extension.swift
+++ b/OpenMarket/OpenMarket/Extension/UIImage+extension.swift
@@ -11,4 +11,19 @@ extension UIImage {
         }
         return renderImage
     }
+    
+    func cropSquare() -> UIImage? {
+        let imageSize = self.size
+        let shortLength = imageSize.width < imageSize.height ? imageSize.width : imageSize.height
+        let origin = CGPoint(
+            x: imageSize.width / 2 - shortLength / 2,
+            y: imageSize.height / 2 - shortLength / 2
+        )
+        let size = CGSize(width: shortLength, height: shortLength)
+        let square = CGRect(origin: origin, size: size)
+        guard let squareImage = self.cgImage?.cropping(to: square) else {
+            return nil
+        }
+        return UIImage(cgImage: squareImage)
+    }
 }

--- a/OpenMarket/OpenMarket/Extension/UIImage+extension.swift
+++ b/OpenMarket/OpenMarket/Extension/UIImage+extension.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+extension UIImage {
+    func resize(multiplier: CGFloat) -> UIImage {
+        let newWidth = self.size.width * multiplier
+        let newheight = self.size.height * multiplier
+        let size = CGSize(width: newWidth, height: newheight)
+        let render = UIGraphicsImageRenderer(size: size)
+        let renderImage = render.image { _ in
+            draw(in: CGRect(origin: .zero, size: size))
+        }
+        return renderImage
+    }
+}

--- a/OpenMarket/OpenMarket/Extension/UIImage+extension.swift
+++ b/OpenMarket/OpenMarket/Extension/UIImage+extension.swift
@@ -24,6 +24,6 @@ extension UIImage {
         guard let squareImage = self.cgImage?.cropping(to: square) else {
             return nil
         }
-        return UIImage(cgImage: squareImage)
+        return UIImage(cgImage: squareImage, scale: 1.0, orientation: self.imageOrientation)
     }
 }

--- a/OpenMarket/OpenMarket/Model/Product.swift
+++ b/OpenMarket/OpenMarket/Model/Product.swift
@@ -6,9 +6,9 @@ struct Product: Decodable {
     let name: String
     let thumbnail: String
     let currency: Currency
-    let price: Double
-    let bargainPrice: Double
-    let discountedPrice: Double
+    let price: Decimal
+    let bargainPrice: Decimal
+    let discountedPrice: Decimal
     let stock: Int
     let images: [Image]?
     let vendor: Vendor?
@@ -104,7 +104,7 @@ extension Product {
     }
 }
 
-private extension Double {
+private extension Decimal {
     var formatted: String? {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal

--- a/OpenMarket/OpenMarket/Model/Product.swift
+++ b/OpenMarket/OpenMarket/Model/Product.swift
@@ -4,6 +4,7 @@ struct Product: Decodable {
     let id: Int
     let vendorId: Int
     let name: String
+    let description: String?
     let thumbnail: String
     let currency: Currency
     let price: Decimal
@@ -17,7 +18,7 @@ struct Product: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case vendor = "vendors"
-        case id, vendorId, name, thumbnail, currency, price, bargainPrice, discountedPrice, stock,
+        case id, vendorId, name, description, thumbnail, currency, price, bargainPrice, discountedPrice, stock,
              images, createdAt, issuedAt
     }
 }

--- a/OpenMarket/OpenMarket/Model/Product.swift
+++ b/OpenMarket/OpenMarket/Model/Product.swift
@@ -86,7 +86,7 @@ extension Product {
         )
     }
     var attributedPrice: NSAttributedString {
-        if self.bargainPrice == 0.0 {
+        if self.discountedPrice == 0.0 {
             return formattedOriginalPrice
         }
 

--- a/OpenMarket/OpenMarket/Model/Product.swift
+++ b/OpenMarket/OpenMarket/Model/Product.swift
@@ -18,8 +18,8 @@ struct Product: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case vendor = "vendors"
-        case id, vendorId, name, description, thumbnail, currency, price, bargainPrice, discountedPrice, stock,
-             images, createdAt, issuedAt
+        case id, vendorId, name, description, thumbnail, currency, price, bargainPrice,
+             discountedPrice, stock, images, createdAt, issuedAt
     }
 }
 
@@ -90,7 +90,7 @@ extension Product {
         if self.discountedPrice == 0.0 {
             return formattedOriginalPrice
         }
-
+        
         let priceWithBargainPrice = NSMutableAttributedString()
         let blank = NSAttributedString(string: " ")
         

--- a/OpenMarket/OpenMarket/Protocol/ReusableView.swift
+++ b/OpenMarket/OpenMarket/Protocol/ReusableView.swift
@@ -1,20 +1,27 @@
 import UIKit
 
 protocol ReusableView: NSObject {
-    static var reuseIdentifier: String { get }
+    static var identifier: String { get }
 }
 
 extension ReusableView where Self: UITableViewCell {
-    static var reuseIdentifier: String {
+    static var identifier: String {
         return String(describing: self)
     }
 }
 
 extension ReusableView where Self: UICollectionViewCell {
-    static var reuseIdentifier: String {
+    static var identifier: String {
+        return String(describing: self)
+    }
+}
+
+extension ReusableView where Self: UIViewController {
+    static var identifier: String {
         return String(describing: self)
     }
 }
 
 extension UITableViewCell: ReusableView {}
 extension UICollectionViewCell: ReusableView {}
+extension UIViewController: ReusableView {}

--- a/OpenMarket/OpenMarket/Util/NetworkTask.swift
+++ b/OpenMarket/OpenMarket/Util/NetworkTask.swift
@@ -240,7 +240,7 @@ extension NetworkTask {
         let price: Decimal
         let currency: Currency
         let discountedPrice: Decimal?
-        let stock: Int?
+        let stock: UInt?
         let secret: String
     }
     
@@ -251,7 +251,7 @@ extension NetworkTask {
         let price: Decimal?
         let currency: Currency?
         let discountedPrice: Decimal?
-        let stock: Int?
+        let stock: UInt?
         let secret: String
     }
 }

--- a/OpenMarket/OpenMarket/Util/NetworkTask.swift
+++ b/OpenMarket/OpenMarket/Util/NetworkTask.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 struct NetworkTask {
-    private let boundary = UUID().uuidString
+    static let identifier = "2836ea8c-7215-11ec-abfa-378889d9906f"
+    static let secret = "-3CSKv$cyHsK_@Wk"
     let jsonParser: JSONParsable
+    private let boundary = UUID().uuidString
     
     func requestHealthChekcer(completionHandler: @escaping (Result<Data, Error>) -> Void) {
         guard let url = NetworkAddress.healthChecker.url else { return }

--- a/OpenMarket/OpenMarket/Util/NetworkTask.swift
+++ b/OpenMarket/OpenMarket/Util/NetworkTask.swift
@@ -237,9 +237,9 @@ extension NetworkTask {
     struct SalesInformation: Encodable {
         let name: String
         let descriptions: String
-        let price: Double
+        let price: Decimal
         let currency: Currency
-        let discountedPrice: Double?
+        let discountedPrice: Decimal?
         let stock: Int?
         let secret: String
     }
@@ -248,9 +248,9 @@ extension NetworkTask {
         let name: String?
         let descriptions: String?
         let thumbnailId: Int?
-        let price: Int?
+        let price: Decimal?
         let currency: Currency?
-        let discountedPrice: Double?
+        let discountedPrice: Decimal?
         let stock: Int?
         let secret: String
     }

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -32,7 +32,11 @@
                                 <action selector="segmentedControlChanged:" destination="UkZ-gV-asY" eventType="valueChanged" id="AZE-NV-rKM"/>
                             </connections>
                         </segmentedControl>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="0iu-rd-SuS"/>
+                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="0iu-rd-SuS">
+                            <connections>
+                                <action selector="touchAddProductButton:" destination="UkZ-gV-asY" id="LzG-5S-Qvn"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="viewSegmentedControl" destination="lWY-7m-R2h" id="msJ-9f-wl6"/>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -18,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="sUH-76-23j">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="interactive" translatesAutoresizingMaskIntoConstraints="NO" id="sUH-76-23j">
                                 <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="feO-Qm-QpU">

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -122,11 +122,8 @@
                         <outlet property="currencySegmentedControl" destination="qKi-jQ-m6O" id="o3K-7O-NJR"/>
                         <outlet property="descriptionTextView" destination="o62-V6-w3f" id="SNQ-fv-n7N"/>
                         <outlet property="imagesCollectionView" destination="ZrB-Kj-swc" id="CCw-Gl-27a"/>
+                        <outlet property="scrollView" destination="sUH-76-23j" id="9Qg-CF-vmt"/>
                         <outlet property="verticalStackView" destination="feO-Qm-QpU" id="PnV-FH-K0I"/>
-                        <outletCollection property="textFields" destination="H9c-Oa-Jxk" collectionClass="NSMutableArray" id="7Zy-uw-0So"/>
-                        <outletCollection property="textFields" destination="k8m-gd-TMC" collectionClass="NSMutableArray" id="asU-zc-vDV"/>
-                        <outletCollection property="textFields" destination="olJ-Ls-k1P" collectionClass="NSMutableArray" id="M5S-Ab-mwN"/>
-                        <outletCollection property="textFields" destination="GxI-aR-xfs" collectionClass="NSMutableArray" id="gCF-Xx-hHZ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -121,10 +121,12 @@
                     <connections>
                         <outlet property="currencySegmentedControl" destination="qKi-jQ-m6O" id="o3K-7O-NJR"/>
                         <outlet property="descriptionTextView" destination="o62-V6-w3f" id="SNQ-fv-n7N"/>
+                        <outlet property="discountedPriceTextField" destination="olJ-Ls-k1P" id="zDO-cH-h7a"/>
                         <outlet property="imagesCollectionView" destination="ZrB-Kj-swc" id="CCw-Gl-27a"/>
                         <outlet property="productNameTextField" destination="H9c-Oa-Jxk" id="LEk-9o-4yZ"/>
                         <outlet property="productPriceTextField" destination="k8m-gd-TMC" id="t0w-rR-nDk"/>
                         <outlet property="scrollView" destination="sUH-76-23j" id="9Qg-CF-vmt"/>
+                        <outlet property="stockTextField" destination="GxI-aR-xfs" id="umt-fn-edq"/>
                         <outlet property="verticalStackView" destination="feO-Qm-QpU" id="PnV-FH-K0I"/>
                     </connections>
                 </viewController>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -22,10 +22,10 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="feO-Qm-QpU">
-                                        <rect key="frame" x="20" y="20" width="374" height="973.5"/>
+                                        <rect key="frame" x="10" y="10" width="394" height="923.5"/>
                                         <subviews>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ZrB-Kj-swc">
-                                                <rect key="frame" x="0.0" y="0.0" width="374" height="128"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="394" height="128"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="128" id="N8C-Wd-Jhs"/>
@@ -48,20 +48,20 @@
                                                 </cells>
                                             </collectionView>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="H9c-Oa-Jxk">
-                                                <rect key="frame" x="0.0" y="133" width="374" height="34"/>
+                                                <rect key="frame" x="0.0" y="133" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="bjx-VE-tHp">
-                                                <rect key="frame" x="0.0" y="172" width="374" height="34"/>
+                                                <rect key="frame" x="0.0" y="172" width="394" height="34"/>
                                                 <subviews>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품가격" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="k8m-gd-TMC">
-                                                        <rect key="frame" x="0.0" y="0.0" width="272" height="34"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="292" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                                     </textField>
                                                     <segmentedControl opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="qKi-jQ-m6O">
-                                                        <rect key="frame" x="277" y="0.0" width="97" height="35"/>
+                                                        <rect key="frame" x="297" y="0.0" width="97" height="35"/>
                                                         <segments>
                                                             <segment title="KRW"/>
                                                             <segment title="USD"/>
@@ -70,17 +70,17 @@
                                                 </subviews>
                                             </stackView>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="할인금액" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="olJ-Ls-k1P">
-                                                <rect key="frame" x="0.0" y="211" width="374" height="34"/>
+                                                <rect key="frame" x="0.0" y="211" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="재고수량" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="GxI-aR-xfs">
-                                                <rect key="frame" x="0.0" y="250" width="374" height="34"/>
+                                                <rect key="frame" x="0.0" y="250" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                             </textField>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="o62-V6-w3f">
-                                                <rect key="frame" x="0.0" y="289" width="374" height="684.5"/>
+                                                <rect key="frame" x="0.0" y="289" width="394" height="634.5"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -91,11 +91,10 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="bottom" secondItem="Ag6-RC-dGh" secondAttribute="bottom" constant="-20" id="0J8-JB-wXt"/>
-                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="width" secondItem="Ohl-L2-TY6" secondAttribute="width" constant="-40" id="Hz4-Rr-tas"/>
-                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="top" secondItem="Ag6-RC-dGh" secondAttribute="top" constant="20" id="QbB-zg-iMs"/>
-                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="trailing" secondItem="Ag6-RC-dGh" secondAttribute="trailing" constant="-20" id="kxS-Vk-mCw"/>
-                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="leading" secondItem="Ag6-RC-dGh" secondAttribute="leading" constant="20" id="pvd-t3-dKs"/>
+                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="bottom" secondItem="Ag6-RC-dGh" secondAttribute="bottom" constant="-10" id="0J8-JB-wXt"/>
+                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="width" secondItem="Ohl-L2-TY6" secondAttribute="width" constant="-20" id="Hz4-Rr-tas"/>
+                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="top" secondItem="Ag6-RC-dGh" secondAttribute="top" constant="10" id="QbB-zg-iMs"/>
+                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="width" secondItem="Ag6-RC-dGh" secondAttribute="width" id="ffM-Nz-j8h"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="Ag6-RC-dGh"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="Ohl-L2-TY6"/>
@@ -104,10 +103,12 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="sUH-76-23j" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="9cl-9K-aI0"/>
+                            <constraint firstItem="feO-Qm-QpU" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="10" id="3Ec-vE-PvU"/>
+                            <constraint firstItem="sUH-76-23j" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="9cl-9K-aI0"/>
                             <constraint firstItem="sUH-76-23j" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="Puw-ry-IlG"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="feO-Qm-QpU" secondAttribute="trailing" constant="10" id="Ucw-XP-FBW"/>
                             <constraint firstItem="sUH-76-23j" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Vzh-Bb-JQe"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="sUH-76-23j" secondAttribute="trailing" id="m1K-6w-5Kn"/>
+                            <constraint firstAttribute="trailing" secondItem="sUH-76-23j" secondAttribute="trailing" id="m1K-6w-5Kn"/>
                         </constraints>
                     </view>
                     <connections>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -22,7 +22,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="feO-Qm-QpU">
-                                        <rect key="frame" x="10" y="10" width="394" height="923.5"/>
+                                        <rect key="frame" x="10" y="10" width="394" height="469"/>
                                         <subviews>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ZrB-Kj-swc">
                                                 <rect key="frame" x="0.0" y="0.0" width="394" height="128"/>
@@ -80,9 +80,12 @@
                                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                             </textField>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="o62-V6-w3f">
-                                                <rect key="frame" x="0.0" y="289" width="394" height="634.5"/>
+                                                <rect key="frame" x="0.0" y="289" width="394" height="180"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="180" id="ZcZ-v9-p3p"/>
+                                                </constraints>
+                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -112,6 +115,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="descriptionTextView" destination="o62-V6-w3f" id="SNQ-fv-n7N"/>
                         <outlet property="imagesCollectionView" destination="ZrB-Kj-swc" id="CCw-Gl-27a"/>
                     </connections>
                 </viewController>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -119,8 +119,14 @@
                         </connections>
                     </view>
                     <connections>
+                        <outlet property="currencySegmentedControl" destination="qKi-jQ-m6O" id="o3K-7O-NJR"/>
                         <outlet property="descriptionTextView" destination="o62-V6-w3f" id="SNQ-fv-n7N"/>
                         <outlet property="imagesCollectionView" destination="ZrB-Kj-swc" id="CCw-Gl-27a"/>
+                        <outlet property="verticalStackView" destination="feO-Qm-QpU" id="PnV-FH-K0I"/>
+                        <outletCollection property="textFields" destination="H9c-Oa-Jxk" collectionClass="NSMutableArray" id="7Zy-uw-0So"/>
+                        <outletCollection property="textFields" destination="k8m-gd-TMC" collectionClass="NSMutableArray" id="asU-zc-vDV"/>
+                        <outletCollection property="textFields" destination="olJ-Ls-k1P" collectionClass="NSMutableArray" id="M5S-Ab-mwN"/>
+                        <outletCollection property="textFields" destination="GxI-aR-xfs" collectionClass="NSMutableArray" id="gCF-Xx-hHZ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sUH-76-23j">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="feO-Qm-QpU">
                                         <rect key="frame" x="10" y="10" width="394" height="923.5"/>
@@ -105,7 +105,7 @@
                         <constraints>
                             <constraint firstItem="feO-Qm-QpU" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="10" id="3Ec-vE-PvU"/>
                             <constraint firstItem="sUH-76-23j" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="9cl-9K-aI0"/>
-                            <constraint firstItem="sUH-76-23j" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="Puw-ry-IlG"/>
+                            <constraint firstItem="sUH-76-23j" firstAttribute="bottom" secondItem="5EZ-qb-Rvc" secondAttribute="bottom" id="Puw-ry-IlG"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="feO-Qm-QpU" secondAttribute="trailing" constant="10" id="Ucw-XP-FBW"/>
                             <constraint firstItem="sUH-76-23j" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Vzh-Bb-JQe"/>
                             <constraint firstAttribute="trailing" secondItem="sUH-76-23j" secondAttribute="trailing" id="m1K-6w-5Kn"/>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -18,36 +18,64 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ZrB-Kj-swc">
-                                <rect key="frame" x="20" y="64" width="374" height="128"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sUH-76-23j">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="feO-Qm-QpU">
+                                        <rect key="frame" x="20" y="20" width="374" height="812.5"/>
+                                        <subviews>
+                                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ZrB-Kj-swc">
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="128"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="128" id="N8C-Wd-Jhs"/>
+                                                </constraints>
+                                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" sectionInsetReference="safeArea" id="6cb-Ju-gtu">
+                                                    <size key="itemSize" width="128" height="128"/>
+                                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
+                                                </collectionViewFlowLayout>
+                                                <cells>
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="UICollectionViewCell" id="T4E-Bv-YzE">
+                                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="8fN-AW-6aa">
+                                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </collectionViewCellContentView>
+                                                    </collectionViewCell>
+                                                </cells>
+                                            </collectionView>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="o62-V6-w3f">
+                                                <rect key="frame" x="0.0" y="128" width="374" height="684.5"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <mutableString key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</mutableString>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="128" id="N8C-Wd-Jhs"/>
+                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="bottom" secondItem="Ag6-RC-dGh" secondAttribute="bottom" constant="-20" id="0J8-JB-wXt"/>
+                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="width" secondItem="Ohl-L2-TY6" secondAttribute="width" constant="-40" id="Hz4-Rr-tas"/>
+                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="top" secondItem="Ag6-RC-dGh" secondAttribute="top" constant="20" id="QbB-zg-iMs"/>
+                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="trailing" secondItem="Ag6-RC-dGh" secondAttribute="trailing" constant="-20" id="kxS-Vk-mCw"/>
+                                    <constraint firstItem="feO-Qm-QpU" firstAttribute="leading" secondItem="Ag6-RC-dGh" secondAttribute="leading" constant="20" id="pvd-t3-dKs"/>
                                 </constraints>
-                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" sectionInsetReference="safeArea" id="6cb-Ju-gtu">
-                                    <size key="itemSize" width="128" height="128"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="UICollectionViewCell" id="T4E-Bv-YzE">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="8fN-AW-6aa">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                    </collectionViewCell>
-                                </cells>
-                            </collectionView>
+                                <viewLayoutGuide key="contentLayoutGuide" id="Ag6-RC-dGh"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="Ohl-L2-TY6"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="ZrB-Kj-swc" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="20" id="AS9-ez-hVg"/>
-                            <constraint firstItem="ZrB-Kj-swc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="Ltw-uM-zhE"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="ZrB-Kj-swc" secondAttribute="trailing" constant="20" id="OxT-vI-CVU"/>
+                            <constraint firstItem="sUH-76-23j" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="9cl-9K-aI0"/>
+                            <constraint firstItem="sUH-76-23j" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="Puw-ry-IlG"/>
+                            <constraint firstItem="sUH-76-23j" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Vzh-Bb-JQe"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="sUH-76-23j" secondAttribute="trailing" id="m1K-6w-5Kn"/>
                         </constraints>
                     </view>
                     <connections>
@@ -60,6 +88,9 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -18,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sUH-76-23j">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="sUH-76-23j">
                                 <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="feO-Qm-QpU">

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -19,10 +19,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ZrB-Kj-swc">
-                                <rect key="frame" x="0.0" y="64" width="414" height="130"/>
+                                <rect key="frame" x="20" y="64" width="374" height="128"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="130" id="N8C-Wd-Jhs"/>
+                                    <constraint firstAttribute="height" constant="128" id="N8C-Wd-Jhs"/>
                                 </constraints>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" sectionInsetReference="safeArea" id="6cb-Ju-gtu">
                                     <size key="itemSize" width="128" height="128"/>
@@ -32,7 +32,7 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="UICollectionViewCell" id="T4E-Bv-YzE">
-                                        <rect key="frame" x="0.0" y="1" width="128" height="128"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="8fN-AW-6aa">
                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
@@ -46,8 +46,8 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="ZrB-Kj-swc" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="20" id="AS9-ez-hVg"/>
-                            <constraint firstItem="ZrB-Kj-swc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="Ltw-uM-zhE"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="ZrB-Kj-swc" secondAttribute="trailing" id="OxT-vI-CVU"/>
+                            <constraint firstItem="ZrB-Kj-swc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="Ltw-uM-zhE"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="ZrB-Kj-swc" secondAttribute="trailing" constant="20" id="OxT-vI-CVU"/>
                         </constraints>
                     </view>
                     <connections>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -47,7 +47,7 @@
                                                     </collectionViewCell>
                                                 </cells>
                                             </collectionView>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="H9c-Oa-Jxk">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="H9c-Oa-Jxk">
                                                 <rect key="frame" x="0.0" y="133" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -55,7 +55,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="bjx-VE-tHp">
                                                 <rect key="frame" x="0.0" y="172" width="394" height="34"/>
                                                 <subviews>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품가격" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="k8m-gd-TMC">
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품가격" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="k8m-gd-TMC">
                                                         <rect key="frame" x="0.0" y="0.0" width="292" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
@@ -69,12 +69,12 @@
                                                     </segmentedControl>
                                                 </subviews>
                                             </stackView>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="할인금액" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="olJ-Ls-k1P">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="할인금액" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="olJ-Ls-k1P">
                                                 <rect key="frame" x="0.0" y="211" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                             </textField>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="재고수량" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="GxI-aR-xfs">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="재고수량" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="GxI-aR-xfs">
                                                 <rect key="frame" x="0.0" y="250" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
@@ -105,6 +105,7 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="feO-Qm-QpU" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="10" id="3Ec-vE-PvU"/>
                             <constraint firstItem="sUH-76-23j" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="9cl-9K-aI0"/>
@@ -113,6 +114,9 @@
                             <constraint firstItem="sUH-76-23j" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Vzh-Bb-JQe"/>
                             <constraint firstAttribute="trailing" secondItem="sUH-76-23j" secondAttribute="trailing" id="m1K-6w-5Kn"/>
                         </constraints>
+                        <connections>
+                            <outletCollection property="gestureRecognizers" destination="6vC-5U-Tp1" appends="YES" id="6Iv-iO-nlH"/>
+                        </connections>
                     </view>
                     <connections>
                         <outlet property="descriptionTextView" destination="o62-V6-w3f" id="SNQ-fv-n7N"/>
@@ -120,6 +124,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="6vC-5U-Tp1">
+                    <connections>
+                        <action selector="tapBackground:" destination="Y6W-OH-hqX" id="PCz-WZ-XhI"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="118.84057971014494" y="95.758928571428569"/>
         </scene>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,26 +18,40 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ktx-6c-s0O">
-                                <rect key="frame" x="20" y="85" width="170" height="193"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tOu-h3-1hR">
-                                <rect key="frame" x="198" y="85" width="170" height="172"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
-                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" image="plus" catalog="system"/>
-                                <connections>
-                                    <action selector="touchUpInsideAddButton:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="I9i-4W-8Go"/>
-                                </connections>
-                            </button>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ZrB-Kj-swc">
+                                <rect key="frame" x="0.0" y="64" width="414" height="130"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="130" id="N8C-Wd-Jhs"/>
+                                </constraints>
+                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" sectionInsetReference="safeArea" id="6cb-Ju-gtu">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="UICollectionViewCell" id="T4E-Bv-YzE">
+                                        <rect key="frame" x="0.0" y="1" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="8fN-AW-6aa">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ZrB-Kj-swc" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="20" id="AS9-ez-hVg"/>
+                            <constraint firstItem="ZrB-Kj-swc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="Ltw-uM-zhE"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="ZrB-Kj-swc" secondAttribute="trailing" id="OxT-vI-CVU"/>
+                        </constraints>
                     </view>
                     <connections>
-                        <outlet property="imageView" destination="ktx-6c-s0O" id="3ym-Mg-8Ox"/>
+                        <outlet property="imagesCollectionView" destination="ZrB-Kj-swc" id="CCw-Gl-27a"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -45,10 +60,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="plus" catalog="system" width="128" height="113"/>
-        <systemColor name="opaqueSeparatorColor">
-            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -50,7 +50,7 @@
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="H9c-Oa-Jxk">
                                                 <rect key="frame" x="0.0" y="133" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
+                                                <textInputTraits key="textInputTraits" returnKeyType="next"/>
                                             </textField>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="bjx-VE-tHp">
                                                 <rect key="frame" x="0.0" y="172" width="394" height="34"/>
@@ -122,6 +122,8 @@
                         <outlet property="currencySegmentedControl" destination="qKi-jQ-m6O" id="o3K-7O-NJR"/>
                         <outlet property="descriptionTextView" destination="o62-V6-w3f" id="SNQ-fv-n7N"/>
                         <outlet property="imagesCollectionView" destination="ZrB-Kj-swc" id="CCw-Gl-27a"/>
+                        <outlet property="productNameTextField" destination="H9c-Oa-Jxk" id="LEk-9o-4yZ"/>
+                        <outlet property="productPriceTextField" destination="k8m-gd-TMC" id="t0w-rR-nDk"/>
                         <outlet property="scrollView" destination="sUH-76-23j" id="9Qg-CF-vmt"/>
                         <outlet property="verticalStackView" destination="feO-Qm-QpU" id="PnV-FH-K0I"/>
                     </connections>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -22,7 +22,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="feO-Qm-QpU">
-                                        <rect key="frame" x="10" y="10" width="394" height="469"/>
+                                        <rect key="frame" x="10" y="10" width="394" height="543"/>
                                         <subviews>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ZrB-Kj-swc">
                                                 <rect key="frame" x="0.0" y="0.0" width="394" height="128"/>
@@ -47,13 +47,25 @@
                                                     </collectionViewCell>
                                                 </cells>
                                             </collectionView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="글자를 3~100자로 입력해주세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sdQ-Ds-Rol">
+                                                <rect key="frame" x="0.0" y="133" width="394" height="13.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                <color key="textColor" systemColor="systemRedColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="H9c-Oa-Jxk">
-                                                <rect key="frame" x="0.0" y="133" width="394" height="34"/>
+                                                <rect key="frame" x="0.0" y="151.5" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" returnKeyType="next"/>
                                             </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bgB-GQ-lxB">
+                                                <rect key="frame" x="0.0" y="190.5" width="394" height="13.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                <color key="textColor" systemColor="systemRedColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="bjx-VE-tHp">
-                                                <rect key="frame" x="0.0" y="172" width="394" height="34"/>
+                                                <rect key="frame" x="0.0" y="209" width="394" height="34"/>
                                                 <subviews>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품가격" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="k8m-gd-TMC">
                                                         <rect key="frame" x="0.0" y="0.0" width="292" height="34"/>
@@ -69,18 +81,30 @@
                                                     </segmentedControl>
                                                 </subviews>
                                             </stackView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0v-Wm-7ga">
+                                                <rect key="frame" x="0.0" y="248" width="394" height="13.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                <color key="textColor" systemColor="systemRedColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="할인금액" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="olJ-Ls-k1P">
-                                                <rect key="frame" x="0.0" y="211" width="394" height="34"/>
+                                                <rect key="frame" x="0.0" y="266.5" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="재고수량" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="GxI-aR-xfs">
-                                                <rect key="frame" x="0.0" y="250" width="394" height="34"/>
+                                                <rect key="frame" x="0.0" y="305.5" width="394" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                             </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbK-vX-vHC">
+                                                <rect key="frame" x="0.0" y="344.5" width="394" height="13.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                <color key="textColor" systemColor="systemRedColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="o62-V6-w3f">
-                                                <rect key="frame" x="0.0" y="289" width="394" height="180"/>
+                                                <rect key="frame" x="0.0" y="363" width="394" height="180"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="180" id="ZcZ-v9-p3p"/>
@@ -120,10 +144,14 @@
                     </view>
                     <connections>
                         <outlet property="currencySegmentedControl" destination="qKi-jQ-m6O" id="o3K-7O-NJR"/>
+                        <outlet property="descriptionCautionLabel" destination="lbK-vX-vHC" id="unA-c6-teI"/>
                         <outlet property="descriptionTextView" destination="o62-V6-w3f" id="SNQ-fv-n7N"/>
+                        <outlet property="discountedPriceCautionLabel" destination="Q0v-Wm-7ga" id="CAF-Sw-Qfz"/>
                         <outlet property="discountedPriceTextField" destination="olJ-Ls-k1P" id="zDO-cH-h7a"/>
                         <outlet property="imagesCollectionView" destination="ZrB-Kj-swc" id="CCw-Gl-27a"/>
+                        <outlet property="productNameCautionLabel" destination="sdQ-Ds-Rol" id="HK4-lO-3pc"/>
                         <outlet property="productNameTextField" destination="H9c-Oa-Jxk" id="LEk-9o-4yZ"/>
+                        <outlet property="productPriceCautionLabel" destination="bgB-GQ-lxB" id="9cc-kd-Qfj"/>
                         <outlet property="productPriceTextField" destination="k8m-gd-TMC" id="t0w-rR-nDk"/>
                         <outlet property="scrollView" destination="sUH-76-23j" id="9Qg-CF-vmt"/>
                         <outlet property="stockTextField" destination="GxI-aR-xfs" id="umt-fn-edq"/>
@@ -146,6 +174,9 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -21,8 +21,8 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sUH-76-23j">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="feO-Qm-QpU">
-                                        <rect key="frame" x="20" y="20" width="374" height="812.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="feO-Qm-QpU">
+                                        <rect key="frame" x="20" y="20" width="374" height="973.5"/>
                                         <subviews>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ZrB-Kj-swc">
                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="128"/>
@@ -47,10 +47,42 @@
                                                     </collectionViewCell>
                                                 </cells>
                                             </collectionView>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="H9c-Oa-Jxk">
+                                                <rect key="frame" x="0.0" y="133" width="374" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="bjx-VE-tHp">
+                                                <rect key="frame" x="0.0" y="172" width="374" height="34"/>
+                                                <subviews>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품가격" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="k8m-gd-TMC">
+                                                        <rect key="frame" x="0.0" y="0.0" width="272" height="34"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
+                                                    </textField>
+                                                    <segmentedControl opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="qKi-jQ-m6O">
+                                                        <rect key="frame" x="277" y="0.0" width="97" height="35"/>
+                                                        <segments>
+                                                            <segment title="KRW"/>
+                                                            <segment title="USD"/>
+                                                        </segments>
+                                                    </segmentedControl>
+                                                </subviews>
+                                            </stackView>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="할인금액" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="olJ-Ls-k1P">
+                                                <rect key="frame" x="0.0" y="211" width="374" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="재고수량" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="GxI-aR-xfs">
+                                                <rect key="frame" x="0.0" y="250" width="374" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                            </textField>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="o62-V6-w3f">
-                                                <rect key="frame" x="0.0" y="128" width="374" height="684.5"/>
+                                                <rect key="frame" x="0.0" y="289" width="374" height="684.5"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <mutableString key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</mutableString>
+                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>

--- a/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
+++ b/OpenMarket/OpenMarket/View/ProductRegistration.storyboard
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Product Registration View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="ProductRegistrationViewController" id="Y6W-OH-hqX" customClass="ProductRegistrationViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ktx-6c-s0O">
+                                <rect key="frame" x="20" y="85" width="170" height="193"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tOu-h3-1hR">
+                                <rect key="frame" x="198" y="85" width="170" height="172"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" image="plus" catalog="system"/>
+                                <connections>
+                                    <action selector="touchUpInsideAddButton:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="I9i-4W-8Go"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <connections>
+                        <outlet property="imageView" destination="ktx-6c-s0O" id="3ym-Mg-8Ox"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="118.84057971014494" y="95.758928571428569"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="plus" catalog="system" width="128" height="113"/>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
안녕하세요, @protocorn93 
오픈마켓 2 Step 1 마무리되서 PR 보내드립니다! 
생각보다 고려할 내용이 많아 늦어졌네요... 😅

이번 프로젝트도 잘 부탁드립니다 🙏

## 🤔 고민한 점

### 1️⃣ Dismiss interactively를 사용

기존에는 스토리보드의 attribute Inspector에서 keyboard 설정을 `Dismiss on drag`로 했습니다. 하지만 드래그를 할 때마다 키보드를 닫을 필요는 없다고 판단했고 키보드를 닫을 수 있는 액션은 필요하다고 판단하여 `Dismiss interactively`를 사용했습니다. 

키보드를 닫을 수 있는 액션에 `TextView`나 `TextField`가 아닌 다른 곳을 터치하면 `Tap gesture recognizer`를 통해 키보드를 닫을 수 있도록 구현은 해놓았으나 이는 사용자가 알 수 없을 수도 있겠다고 판단하여 `Dismiss interactively`를 사용하는 것이 적합하다고 판단했습니다. 

### 2️⃣ 키보드가 컨텐츠를 가리지 않을 것

키보드가 컨텐츠를 가리지 않도록 하는 방법에 대해 고민했습니다. 
처음에는 아래처럼 view.frame의 origin을 직접 변경하는 방식을 선택했습니다. 

```swift
@objc private func keyboardWillShow(_ sender: Notification) {
    if let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
        let keyboardRectangle = keyboardFrame.cgRectValue
        let keyboardHeight = keyboardRectangle.height
        view.frame.origin.y = -keyboardHeight
    }
}

@objc private func keyboardWillHide(_ sender: Notification) {
    view.frame.origin.y = 0
}
```

하지만 이렇게 했을 때 화면 자체가 올라가면서 위에 있는 내용을 볼 수 없는 문제가 발생했습니다. 
따라서 화면 자체를 위로 올리는 것이 아닌 스크롤 뷰의 contentInset을 키보드의 높이만큼 늘리는 방법을 선택했습니다. 

```swift
scrollView.contentInset.bottom = keyboardHeight
```

이런 식으로 scrollView의 하단 contentInset을 키보드만큼 주어 위에 있는 내용도 확인할 수 있으면서 컨텐츠도 가리지 않도록 구현했습니다. 

### 3️⃣ 실시간 입력값 유효성 검증

> **Dynamically validate field values.**
It’s frustrating when you have to go back and correct mistakes after filling out a lengthy form. Whenever possible, check field values immediately after entry so users can correct them right away.
> 

> 사용자가 입력한 정보를 잘못 입력했을 때 텍스트 필드에 인라인으로 오류 메시지를 나타낸다. 이때 오류 메시지는 레이블과 구분되는 디자인을 권장한다.
[https://brunch.co.kr/@chulhochoiucj0/20](https://brunch.co.kr/@chulhochoiucj0/20)
> 

![t1 daumcdn net](https://user-images.githubusercontent.com/90880660/150791333-e7a7cdf7-3c88-422c-954f-8f24590b675b.png)

https://user-images.githubusercontent.com/90880660/150813149-8d6a019f-9a2c-4f01-a6b1-0483e29767a3.mp4



HIG 문서에서 TextField를 통해 받은 데이터의 유효성을 실시간으로 검증하라는 내용이 있었습니다. 따라서 기존에는 Done 버튼을 누를 때만 상품 등록 내용이 적합하게 작성되었는지 검증했지만, textField의 내용을 수정할 때마다 유효성을 검증해야겠다고 판단했습니다. 

디자인의 경우 레이블의 경우 이미 PlaceHolder를 통해 보여주고 있었기 때문에 오류 메세지는 TextField의 상단에 표시되도록 구현했습니다. 

```swift
.addTarget(self, action: #selector(textInputDidChange(_:)), for: .editingChanged)
```

실시간으로 값을 점검하기 위해 위 코드를 사용하여 수정될 때마다 `textInputDidChange(_:)` 메서드가 호출될 수 있도록 했습니다. 

다만 TextView의 경우 addTarget 메서드가 존재하지 않아 TextView만 `UITextViewDelegate`의 메서드인 `textViewDidEndEditing` 를 호출해 사용했습니다. 해당 메서드의 경우 실시간이 아닌 TextView의 수정이 끝났을 때만 호출되는 문제가 있었는데 이는 아직 해결하지 못했습니다. 

### 4️⃣ 이미지를 크롭 및 리사이즈

명세에서 이미지가 정사각형으로 크롭이 되어 들어가있었고, 이미지의 용량도 300KB 미만으로 넣어야 했기 때문에 이미지를 크롭하고 리사이즈하는 방법에 대해 고민했습니다. 

이미지 크롭의 경우 가로 세로 길이를 비교하여 짧은 쪽을 기준으로 크롭을 하는 방식을 선택했습니다. 

```swift
func cropSquare() -> UIImage? {
    let imageSize = self.size
    let shortLength = imageSize.width < imageSize.height ? imageSize.width : imageSize.height
    let origin = CGPoint(
        x: imageSize.width / 2 - shortLength / 2,
        y: imageSize.height / 2 - shortLength / 2
    )
    let size = CGSize(width: shortLength, height: shortLength)
    let square = CGRect(origin: origin, size: size)
    guard let squareImage = self.cgImage?.cropping(to: square) else {
        return nil
    }
    return UIImage(cgImage: squareImage)
}
```

또한 이 조건의 경우 이미지 선택이 완료되었을 때 이뤄져야 하기 때문에 **imagePickerController(_:didFinishPickingMediaWithInfo:)** 메서드에서 조건을 추가해줬습니다. 

<img width="785" alt="스크린샷 2022-01-24 오후 10 13 46" src="https://user-images.githubusercontent.com/90880660/150791141-b002649c-c0ee-4abb-9478-c74357913df9.png">

origin의 경우 가운데로 크롭이 될 수 있도록 그림처럼 origin을 이동시켜줬습니다. 

## ❓ 질문

### 1️⃣ 뷰컨 분리 실패

주로 `ProductRegistrationViewController.swift` 파일이 문제입니다.
프로퍼티도 많고, 중복되는 코드도 제법 있습니다. 복잡하기도 합니다.

line 86 `textInputDidChange(_ sender: Any?)` , line 497 `inspectInput()` 이 두 함수는 `if` 가 많습니다. `else if` 를 써야하거나 언래핑된 결과값이 필요해서 `if` 를 썼기에 분리하지 못했습니다.
line 160 `registerProduct()`, line 209 `modifyProduct()` 는 리턴 타입과 `productId` 프로퍼티가 다릅니다.
line 534 `inspectMaximumDiscountedPrice` 부터 line 577 `inspectMinimumName` 의 함수는 line 86 `textInputDidChange(_)` 에서 사용하려고 분리했습니다. 그런데 오히려 더 복잡해 보일지 걱정됩니다.

데이터 소스는 아래 코드의 `presentImagePicker()` 때문에 분리하지 못했습니다.

```swift
// ProductRegistrationViewController.swift
// line 656
button.addTarget(self, action: #selector(presentImagePicker), for: .touchUpInside)
```

### 2️⃣ iOS 14.0에서 자동으로 컬렉션뷰에 배경색이 설정되는 문제

iOS 15.0에서는 문제가 없었지만 iOS 14.0에선 segmented Controll을 통해 컬렉션뷰로 이동할 때 검은 색으로 배경이 바뀌는 문제가 있었습니다. 물론 아래 코드를 추가하여 문제를 해결하긴 했습니다. 

```swift
collectionView.backgroundColor = .systemBackground
```

다만 아직 왜 이런 현상이 일어나는지는 찾지 못했습니다...🥲 
혹시 콘은 왜 이런 현상이 발생하는지 알고 계실까요?

### 3️⃣ 꽃 사진만 자동으로 180도 회전이 되는 문제

UIImage 크롭 후에 생기는 문제입니다.
시뮬레이터에 미리 준비된 사진 중에서 꽃 사진이 뒤집혀서 나옵니다. 다른 사진은 문제가 없습니다.

<img width="506" alt="스크린샷 2022-01-24 오후 10 06 18" src="https://user-images.githubusercontent.com/90880660/150791645-840059cc-67ea-44ed-a885-622c82f31c93.png">

### 4️⃣ 이미지 피커에서 더블 클릭을 하는 경우 이미지가 2개 올라가는 문제

이미지 피커가 닫히지 전에 두번 누르면, 2개 올라갑니다. 이를 막을 방법이 있을까요?

### 5️⃣ TextView의 수정을 실시간으로 알 수 있는 방법

저희 코드에서 TextView는 입력이 끝나야 유효성을 검증합니다.
유저가 위의 텍스트 필드부터 입력했다면, 상품설명을 쓰던 유저가 텍스트 필드처럼 입력중에 검증될 것이라 예상할 것입니다. 그래서 지금 상황은 혼란스러울 듯 합니다. 좋은 방법이 있나요?

### 6️⃣ 이미지 리사이즈에 메모리가 많이 필요한 문제

아래는 기본 꽃 사진을 5장 업로드할 때입니다. 메모리가 엄청나게 많이 듭니다. 리사이즈 횟수가 더 많은 코드에서는 7GB를 쓸 때도 있었습니다.
swift는 ARC를 사용하므로 가비지 컬렉터와 달리 필요없는 인스턴스가 즉시 해제될 것인데, 어디서 메모리를 이렇게 쓰는 걸까요?

<img width="1522" alt="스크린샷 2022-01-24 오후 10 42 54" src="https://user-images.githubusercontent.com/90880660/150794938-96079c87-ef87-45a3-8a19-a9be01e3a729.png">

