### PR TITLE
오픈 마켓2 [STEP2] 허황, 애플사이다 

### DIFF
--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		08A5B0D8278589C2002E1ABE /* NetworkDataTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5B0D7278589C2002E1ABE /* NetworkDataTransfer.swift */; };
 		08A5B0DC27859A4A002E1ABE /* URLRequest+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5B0DB27859A4A002E1ABE /* URLRequest+Extension.swift */; };
 		08A5B0DE27859DBD002E1ABE /* OpenMarketURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5B0DD27859DBD002E1ABE /* OpenMarketURL.swift */; };
+		08AC5E3827A3D33E00214265 /* ProductDetailDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AC5E3727A3D33E00214265 /* ProductDetailDataSource.swift */; };
 		08AF0B59278D0ED8005FF21D /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF0B58278D0ED8005FF21D /* APIProtocol.swift */; };
 		08AF0B5B278D6227005FF21D /* LayoutKindSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF0B5A278D6227005FF21D /* LayoutKindSegmentedControl.swift */; };
 		08AF0B5D278EB4DC005FF21D /* ListProductCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF0B5C278EB4DC005FF21D /* ListProductCell.swift */; };
@@ -88,6 +89,7 @@
 		08A5B0D7278589C2002E1ABE /* NetworkDataTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDataTransfer.swift; sourceTree = "<group>"; };
 		08A5B0DB27859A4A002E1ABE /* URLRequest+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Extension.swift"; sourceTree = "<group>"; };
 		08A5B0DD27859DBD002E1ABE /* OpenMarketURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenMarketURL.swift; sourceTree = "<group>"; };
+		08AC5E3727A3D33E00214265 /* ProductDetailDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailDataSource.swift; sourceTree = "<group>"; };
 		08AF0B58278D0ED8005FF21D /* APIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
 		08AF0B5A278D6227005FF21D /* LayoutKindSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutKindSegmentedControl.swift; sourceTree = "<group>"; };
 		08AF0B5C278EB4DC005FF21D /* ListProductCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListProductCell.swift; sourceTree = "<group>"; };
@@ -321,6 +323,7 @@
 			isa = PBXGroup;
 			children = (
 				36D213F427A380D3003C6A77 /* ProductDetailViewController.swift */,
+				08AC5E3727A3D33E00214265 /* ProductDetailDataSource.swift */,
 			);
 			path = ProductDetailViewController;
 			sourceTree = "<group>";
@@ -577,6 +580,7 @@
 				082CD25D2799859B000AC366 /* MultipartFormData.swift in Sources */,
 				089C36BC27953F5A00EDE2B6 /* UILabel+Extension.swift in Sources */,
 				08AF0B5F278EFEF4005FF21D /* CALayer+Extension.swift in Sources */,
+				08AC5E3827A3D33E00214265 /* ProductDetailDataSource.swift in Sources */,
 				08BB9A8027917C2300D95A82 /* UIImageView+Extension.swift in Sources */,
 				08BCBD0D279FD42100FEF1B4 /* OpenMarketNavigationController.swift in Sources */,
 				3637AE25278EA8E7009003B7 /* Int+Extension.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		36D213A6279AB2DA003C6A77 /* UserInputChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213A5279AB2DA003C6A77 /* UserInputChecker.swift */; };
 		36D213EE27A11677003C6A77 /* AlertFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213ED27A11677003C6A77 /* AlertFactory.swift */; };
 		36D213F227A26821003C6A77 /* ProductListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213F127A26821003C6A77 /* ProductListLayout.swift */; };
+		36D213F527A380D3003C6A77 /* ProductDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213F427A380D3003C6A77 /* ProductDetailViewController.swift */; };
+		36D213F827A3B91A003C6A77 /* ProductDetailScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213F727A3B91A003C6A77 /* ProductDetailScrollView.swift */; };
 		36D617B72796C70000F7A9AB /* ProductManagementScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D617B62796C70000F7A9AB /* ProductManagementScrollView.swift */; };
 		36D617C02797E6BD00F7A9AB /* ProductPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D617BF2797E6BD00F7A9AB /* ProductPlaceholder.swift */; };
 		36D617C42798299700F7A9AB /* ProductRegisterImageFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D617C32798299700F7A9AB /* ProductRegisterImageFooterView.swift */; };
@@ -117,6 +119,8 @@
 		36D213A5279AB2DA003C6A77 /* UserInputChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInputChecker.swift; sourceTree = "<group>"; };
 		36D213ED27A11677003C6A77 /* AlertFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertFactory.swift; sourceTree = "<group>"; };
 		36D213F127A26821003C6A77 /* ProductListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListLayout.swift; sourceTree = "<group>"; };
+		36D213F427A380D3003C6A77 /* ProductDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailViewController.swift; sourceTree = "<group>"; };
+		36D213F727A3B91A003C6A77 /* ProductDetailScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailScrollView.swift; sourceTree = "<group>"; };
 		36D617B62796C70000F7A9AB /* ProductManagementScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductManagementScrollView.swift; sourceTree = "<group>"; };
 		36D617BF2797E6BD00F7A9AB /* ProductPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPlaceholder.swift; sourceTree = "<group>"; };
 		36D617C32798299700F7A9AB /* ProductRegisterImageFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRegisterImageFooterView.swift; sourceTree = "<group>"; };
@@ -275,6 +279,7 @@
 			children = (
 				08C21E93279BCE9700D704CF /* ProductListView */,
 				08C21E94279BCEC000D704CF /* ProductRegisterView */,
+				36D213F627A3B8C8003C6A77 /* ProductDetailView */,
 				C70FB10525BEF61D00C9924E /* LaunchScreen.storyboard */,
 			);
 			path = View;
@@ -286,6 +291,7 @@
 				08BCBD0C279FD42100FEF1B4 /* OpenMarketNavigationController.swift */,
 				08C21E95279BD03200D704CF /* ProductListViewController */,
 				08C21E96279BD03800D704CF /* ProductRegisterViewController */,
+				36D213F327A38062003C6A77 /* ProductDetailViewController */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -300,6 +306,22 @@
 				36D213ED27A11677003C6A77 /* AlertFactory.swift */,
 			);
 			path = Utility;
+			sourceTree = "<group>";
+		};
+		36D213F327A38062003C6A77 /* ProductDetailViewController */ = {
+			isa = PBXGroup;
+			children = (
+				36D213F427A380D3003C6A77 /* ProductDetailViewController.swift */,
+			);
+			path = ProductDetailViewController;
+			sourceTree = "<group>";
+		};
+		36D213F627A3B8C8003C6A77 /* ProductDetailView */ = {
+			isa = PBXGroup;
+			children = (
+				36D213F727A3B91A003C6A77 /* ProductDetailScrollView.swift */,
+			);
+			path = ProductDetailView;
 			sourceTree = "<group>";
 		};
 		5833BDE63C0E1D92191D4EE2 /* Frameworks */ = {
@@ -541,6 +563,7 @@
 			files = (
 				C70FB0FF25BEF61C00C9924E /* ProductListViewController.swift in Sources */,
 				08A5B0DC27859A4A002E1ABE /* URLRequest+Extension.swift in Sources */,
+				36D213F527A380D3003C6A77 /* ProductDetailViewController.swift in Sources */,
 				08C21E98279BD07700D704CF /* ProductListDataSource.swift in Sources */,
 				082CD25D2799859B000AC366 /* MultipartFormData.swift in Sources */,
 				089C36BC27953F5A00EDE2B6 /* UILabel+Extension.swift in Sources */,
@@ -564,6 +587,7 @@
 				0893F0C42797EB7A00457C61 /* ProductImageCell.swift in Sources */,
 				08CA13EF279588E6005552A9 /* ProductsCollectionView.swift in Sources */,
 				3637AE1F278D8801009003B7 /* GridProductCell.swift in Sources */,
+				36D213F827A3B91A003C6A77 /* ProductDetailScrollView.swift in Sources */,
 				36D213F227A26821003C6A77 /* ProductListLayout.swift in Sources */,
 				36D617C82799B3DF00F7A9AB /* ProductDetailToRegister.swift in Sources */,
 				08BC398A2796E7AA002B5C7C /* RoundedRectTextField.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -51,6 +51,9 @@
 		36D213F227A26821003C6A77 /* ProductListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213F127A26821003C6A77 /* ProductListLayout.swift */; };
 		36D213F527A380D3003C6A77 /* ProductDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213F427A380D3003C6A77 /* ProductDetailViewController.swift */; };
 		36D213F827A3B91A003C6A77 /* ProductDetailScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213F727A3B91A003C6A77 /* ProductDetailScrollView.swift */; };
+		36D213FA27A3CE6F003C6A77 /* DetailViewProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213F927A3CE6F003C6A77 /* DetailViewProduct.swift */; };
+		36D213FC27A3CF3E003C6A77 /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213FB27A3CF3E003C6A77 /* ProductImage.swift */; };
+		36D213FE27A3CF6F003C6A77 /* Vendor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D213FD27A3CF6F003C6A77 /* Vendor.swift */; };
 		36D617B72796C70000F7A9AB /* ProductManagementScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D617B62796C70000F7A9AB /* ProductManagementScrollView.swift */; };
 		36D617C02797E6BD00F7A9AB /* ProductPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D617BF2797E6BD00F7A9AB /* ProductPlaceholder.swift */; };
 		36D617C42798299700F7A9AB /* ProductRegisterImageFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D617C32798299700F7A9AB /* ProductRegisterImageFooterView.swift */; };
@@ -121,6 +124,9 @@
 		36D213F127A26821003C6A77 /* ProductListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListLayout.swift; sourceTree = "<group>"; };
 		36D213F427A380D3003C6A77 /* ProductDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailViewController.swift; sourceTree = "<group>"; };
 		36D213F727A3B91A003C6A77 /* ProductDetailScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailScrollView.swift; sourceTree = "<group>"; };
+		36D213F927A3CE6F003C6A77 /* DetailViewProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewProduct.swift; sourceTree = "<group>"; };
+		36D213FB27A3CF3E003C6A77 /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
+		36D213FD27A3CF6F003C6A77 /* Vendor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vendor.swift; sourceTree = "<group>"; };
 		36D617B62796C70000F7A9AB /* ProductManagementScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductManagementScrollView.swift; sourceTree = "<group>"; };
 		36D617BF2797E6BD00F7A9AB /* ProductPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPlaceholder.swift; sourceTree = "<group>"; };
 		36D617C32798299700F7A9AB /* ProductRegisterImageFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRegisterImageFooterView.swift; sourceTree = "<group>"; };
@@ -270,6 +276,9 @@
 				36D617BF2797E6BD00F7A9AB /* ProductPlaceholder.swift */,
 				36D617C72799B3DF00F7A9AB /* ProductDetailToRegister.swift */,
 				36D213A5279AB2DA003C6A77 /* UserInputChecker.swift */,
+				36D213F927A3CE6F003C6A77 /* DetailViewProduct.swift */,
+				36D213FB27A3CF3E003C6A77 /* ProductImage.swift */,
+				36D213FD27A3CF6F003C6A77 /* Vendor.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -578,6 +587,7 @@
 				36D617C6279942E600F7A9AB /* ProductImageCollectionView.swift in Sources */,
 				3637AE292790287E009003B7 /* ProductRegisterViewController.swift in Sources */,
 				08A5B0D8278589C2002E1ABE /* NetworkDataTransfer.swift in Sources */,
+				36D213FC27A3CF3E003C6A77 /* ProductImage.swift in Sources */,
 				36D213A6279AB2DA003C6A77 /* UserInputChecker.swift in Sources */,
 				36D617C02797E6BD00F7A9AB /* ProductPlaceholder.swift in Sources */,
 				08B2CE8D2782E0D4009295F2 /* Currency.swift in Sources */,
@@ -596,9 +606,11 @@
 				3637AE27278F191A009003B7 /* ProductCellProtocol.swift in Sources */,
 				36D617B72796C70000F7A9AB /* ProductManagementScrollView.swift in Sources */,
 				08C21EA1279BE80500D704CF /* ProductRegisterResultAlert.swift in Sources */,
+				36D213FE27A3CF6F003C6A77 /* Vendor.swift in Sources */,
 				08AF854D278C003100392FC1 /* BaseURLProtocol.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
 				08AF0B59278D0ED8005FF21D /* APIProtocol.swift in Sources */,
+				36D213FA27A3CE6F003C6A77 /* DetailViewProduct.swift in Sources */,
 				08AF0B5D278EB4DC005FF21D /* ListProductCell.swift in Sources */,
 				36D213EE27A11677003C6A77 /* AlertFactory.swift in Sources */,
 				08A4E45D2792B90D000C9AD9 /* Double+Extension.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		08A5B0DC27859A4A002E1ABE /* URLRequest+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5B0DB27859A4A002E1ABE /* URLRequest+Extension.swift */; };
 		08A5B0DE27859DBD002E1ABE /* OpenMarketURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5B0DD27859DBD002E1ABE /* OpenMarketURL.swift */; };
 		08AC5E3827A3D33E00214265 /* ProductDetailDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AC5E3727A3D33E00214265 /* ProductDetailDataSource.swift */; };
+		08AC5E3A27A3E3D700214265 /* ProductDetailImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AC5E3927A3E3D700214265 /* ProductDetailImageCell.swift */; };
 		08AF0B59278D0ED8005FF21D /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF0B58278D0ED8005FF21D /* APIProtocol.swift */; };
 		08AF0B5B278D6227005FF21D /* LayoutKindSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF0B5A278D6227005FF21D /* LayoutKindSegmentedControl.swift */; };
 		08AF0B5D278EB4DC005FF21D /* ListProductCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF0B5C278EB4DC005FF21D /* ListProductCell.swift */; };
@@ -90,6 +91,7 @@
 		08A5B0DB27859A4A002E1ABE /* URLRequest+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Extension.swift"; sourceTree = "<group>"; };
 		08A5B0DD27859DBD002E1ABE /* OpenMarketURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenMarketURL.swift; sourceTree = "<group>"; };
 		08AC5E3727A3D33E00214265 /* ProductDetailDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailDataSource.swift; sourceTree = "<group>"; };
+		08AC5E3927A3E3D700214265 /* ProductDetailImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailImageCell.swift; sourceTree = "<group>"; };
 		08AF0B58278D0ED8005FF21D /* APIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
 		08AF0B5A278D6227005FF21D /* LayoutKindSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutKindSegmentedControl.swift; sourceTree = "<group>"; };
 		08AF0B5C278EB4DC005FF21D /* ListProductCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListProductCell.swift; sourceTree = "<group>"; };
@@ -332,6 +334,7 @@
 			isa = PBXGroup;
 			children = (
 				36D213F727A3B91A003C6A77 /* ProductDetailScrollView.swift */,
+				08AC5E3927A3E3D700214265 /* ProductDetailImageCell.swift */,
 			);
 			path = ProductDetailView;
 			sourceTree = "<group>";
@@ -613,6 +616,7 @@
 				36D213FE27A3CF6F003C6A77 /* Vendor.swift in Sources */,
 				08AF854D278C003100392FC1 /* BaseURLProtocol.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
+				08AC5E3A27A3E3D700214265 /* ProductDetailImageCell.swift in Sources */,
 				08AF0B59278D0ED8005FF21D /* APIProtocol.swift in Sources */,
 				36D213FA27A3CE6F003C6A77 /* DetailViewProduct.swift in Sources */,
 				08AF0B5D278EB4DC005FF21D /* ListProductCell.swift in Sources */,

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailDataSource.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailDataSource.swift
@@ -5,12 +5,15 @@ protocol ProductDetailDataSourceDelegate: AnyObject {
 }
 
 final class ProductDetailDataSource: NSObject {
-    
     // MARK: - Properties
     weak var delegate: ProductDetailDataSourceDelegate?
     var productDetail: DetailViewProduct?
     
-    func setupProducts(at productId: Int) {
+    func setupProducts(at productId: Int?) {
+        guard let productId = productId else {
+            return
+        }
+        
         NetworkDataTransfer().fetchData(api: ProductDetailAPI(id: productId),
                                         decodingType: DetailViewProduct.self) { [weak self] data in
             self?.productDetail = data

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailDataSource.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailDataSource.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+protocol ProductDetailDataSourceDelegate: AnyObject {
+    func productDetailDataSource(didFetchProduct product: DetailViewProduct?)
+}
+
+final class ProductDetailDataSource: NSObject {
+    
+    // MARK: - Properties
+    weak var delegate: ProductDetailDataSourceDelegate?
+    var productDetail: DetailViewProduct?
+    
+    func setupProducts(at productId: Int) {
+        NetworkDataTransfer().fetchData(api: ProductDetailAPI(id: productId),
+                                        decodingType: DetailViewProduct.self) { [weak self] data in
+            self?.productDetail = data
+            self?.delegate?.productDetailDataSource(didFetchProduct: self?.productDetail)
+        }
+    }
+}

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailDataSource.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailDataSource.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 protocol ProductDetailDataSourceDelegate: AnyObject {
     func productDetailDataSource(didFetchProduct product: DetailViewProduct?)
@@ -9,6 +10,7 @@ final class ProductDetailDataSource: NSObject {
     weak var delegate: ProductDetailDataSourceDelegate?
     var productDetail: DetailViewProduct?
     
+    // MARK: - Methods
     func setupProducts(at productId: Int?) {
         guard let productId = productId else {
             return
@@ -19,5 +21,29 @@ final class ProductDetailDataSource: NSObject {
             self?.productDetail = data
             self?.delegate?.productDetailDataSource(didFetchProduct: self?.productDetail)
         }
+    }
+}
+
+// MARK: - CollectionView DataSource
+extension ProductDetailDataSource: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return productDetail?.images.count ?? 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView,
+                        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProductDetailImageCell.identifier,
+                                                            for: indexPath) as? ProductDetailImageCell else {
+            return UICollectionViewCell()
+        }
+        
+        guard let productDetail = productDetail else {
+            return UICollectionViewCell()
+        }
+        
+        let imageURL = productDetail.images[indexPath.item].url
+        cell.setProductImage(url: imageURL)
+        
+        return cell
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
@@ -1,24 +1,29 @@
 import UIKit
 
 class ProductDetailViewController: UIViewController {
-    
     private let dataSource = ProductDetailDataSource()
     let productDetailScrollView = ProductDetailScrollView()
-
+    
+    private var productId: Int?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setup()
         setupNavigationBar()
         setupProductDetailScrollView()
         dataSource.delegate = self
-        dataSource.setupProducts(at: 1000)
+        dataSource.setupProducts(at: productId)
     }
     
-    func setup() {
+    func setProductId(_ productId: Int) {
+        self.productId = productId
+    }
+    
+    private func setup() {
         view.backgroundColor = .white
     }
     
-    func setupProductDetailScrollView() {
+    private func setupProductDetailScrollView() {
         view.addSubview(productDetailScrollView)
         productDetailScrollView.setupConstraints(with: view)
         productDetailScrollView.setupSubviews()
@@ -28,7 +33,7 @@ class ProductDetailViewController: UIViewController {
 // MARK: - NavigationBar
 extension ProductDetailViewController {
     private func setupNavigationBar() {
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", // 목록화면에서 navi로 이동하도록 연결
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "",
                                                            style: .plain,
                                                            target: nil,
                                                            action: nil)
@@ -55,6 +60,7 @@ extension ProductDetailViewController: ProductDetailDataSourceDelegate {
         if let product = product {
             DispatchQueue.main.async { [weak self] in
                 self?.productDetailScrollView.updateView(with: product)
+                self?.title = product.name  // Todo: 개선 필요
             }
         }
     }

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
@@ -73,6 +73,7 @@ extension ProductDetailViewController: ProductDetailDataSourceDelegate {
         if let product = product {
             DispatchQueue.main.async { [weak self] in
                 self?.productDetailScrollView.updateView(with: product)
+                self?.imageCollectionView.reloadData()
                 self?.title = product.name  // Todo: 개선 필요
             }
         }

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+class ProductDetailViewController: UIViewController {
+    let productDetailScrollView = ProductDetailScrollView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        setupNavigationBar()
+        setupProductDetailScrollView()
+    }
+    
+    func setup() {
+        view.backgroundColor = .white
+    }
+    
+    func setupProductDetailScrollView() {
+        view.addSubview(productDetailScrollView)
+        productDetailScrollView.setupConstraints(with: view)
+        productDetailScrollView.setupSubviews()
+    }
+}
+
+// MARK: - NavigationBar
+extension ProductDetailViewController {
+    private func setupNavigationBar() {
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", // 목록화면에서 navi로 이동하도록 연결
+                                                           style: .plain,
+                                                           target: nil,
+                                                           action: nil)
+        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action,
+                                                            target: self,
+                                                            action: #selector(touchUpActionButton))
+    }
+    
+    @objc private func touchUpActionButton() {
+        let editButton = UIAlertAction(title: "수정", style: .default, handler: nil) // 수정화면 연결
+        let deleteButton = UIAlertAction(title: "삭제", style: .destructive, handler: nil) // Alert의 TextField에 비밀번호 입력
+        let cancelButton = UIAlertAction(title: "취소", style: .cancel)
+        
+        let alert = AlertFactory().createAlert(style: .actionSheet, title: nil, message: nil, actions: editButton, deleteButton, cancelButton)
+        
+        present(alert, animated: true)
+    }
+}

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
@@ -1,16 +1,20 @@
 import UIKit
 
 class ProductDetailViewController: UIViewController {
+    // MARK: - Properties
     private let dataSource = ProductDetailDataSource()
     let productDetailScrollView = ProductDetailScrollView()
+    private(set) var imageCollectionView: UICollectionView!
     
     private var productId: Int?
     
+    // MARK: - Methods
     override func viewDidLoad() {
         super.viewDidLoad()
         setup()
         setupNavigationBar()
         setupProductDetailScrollView()
+        setupImageCollectionView()
         dataSource.delegate = self
         dataSource.setupProducts(at: productId)
     }
@@ -27,6 +31,14 @@ class ProductDetailViewController: UIViewController {
         view.addSubview(productDetailScrollView)
         productDetailScrollView.setupConstraints(with: view)
         productDetailScrollView.setupSubviews()
+    }
+    
+    private func setupImageCollectionView() {
+        imageCollectionView = productDetailScrollView.productDetailImageCollectionView
+        imageCollectionView.register(ProductDetailImageCell.self,
+                                     forCellWithReuseIdentifier: ProductDetailImageCell.identifier)
+        imageCollectionView.dataSource = dataSource
+        imageCollectionView.delegate = self
     }
 }
 
@@ -55,6 +67,7 @@ extension ProductDetailViewController {
     }
 }
 
+// MARK: - Product Detail DataSource Delegate
 extension ProductDetailViewController: ProductDetailDataSourceDelegate {
     func productDetailDataSource(didFetchProduct product: DetailViewProduct?) {
         if let product = product {
@@ -64,4 +77,15 @@ extension ProductDetailViewController: ProductDetailDataSourceDelegate {
             }
         }
     }
+}
+
+// MARK: - CollectionView Delegate
+extension ProductDetailViewController: UICollectionViewDelegate {
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView,
+                                   withVelocity velocity: CGPoint,
+                                   targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        let sideInset: CGFloat = 30
+        let page = Int(targetContentOffset.pointee.x / (view.frame.width - sideInset))
+        productDetailScrollView.imageNumberPageControl.currentPage = page
+      }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController/ProductDetailViewController.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 class ProductDetailViewController: UIViewController {
+    
+    private let dataSource = ProductDetailDataSource()
     let productDetailScrollView = ProductDetailScrollView()
 
     override func viewDidLoad() {
@@ -8,6 +10,8 @@ class ProductDetailViewController: UIViewController {
         setup()
         setupNavigationBar()
         setupProductDetailScrollView()
+        dataSource.delegate = self
+        dataSource.setupProducts(at: 1000)
     }
     
     func setup() {
@@ -39,8 +43,19 @@ extension ProductDetailViewController {
         let deleteButton = UIAlertAction(title: "삭제", style: .destructive, handler: nil) // Alert의 TextField에 비밀번호 입력
         let cancelButton = UIAlertAction(title: "취소", style: .cancel)
         
-        let alert = AlertFactory().createAlert(style: .actionSheet, title: nil, message: nil, actions: editButton, deleteButton, cancelButton)
+        let alert = AlertFactory().createAlert(style: .actionSheet,
+                                               actions: editButton, deleteButton, cancelButton)
         
         present(alert, animated: true)
+    }
+}
+
+extension ProductDetailViewController: ProductDetailDataSourceDelegate {
+    func productDetailDataSource(didFetchProduct product: DetailViewProduct?) {
+        if let product = product {
+            DispatchQueue.main.async { [weak self] in
+                self?.productDetailScrollView.updateView(with: product)
+            }
+        }
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController/ProductListDataSource.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController/ProductListDataSource.swift
@@ -101,8 +101,7 @@ extension ProductListDataSource: UICollectionViewDataSource {
         guard let product = products?[indexPath.item] else {
             return UICollectionViewCell()
         }
-        
-        cell.updateView(with: product)
+        cell.applyData(product)
         
         return cell
     }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController/ProductListLayout.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController/ProductListLayout.swift
@@ -1,7 +1,12 @@
 import UIKit
 
+protocol ProductListLayoutDelegate: AnyObject {
+    func productListLayout(didSelectCell productId: Int)
+}
+
 final class ProductListLayout: NSObject {
     private unowned var dataSource: ProductListDataSource
+    weak var delegate: ProductListLayoutDelegate?
     
     init(dataSource: ProductListDataSource) {
         self.dataSource = dataSource
@@ -73,5 +78,16 @@ extension ProductListLayout: UICollectionViewDelegateFlowLayout {
            refreshControl.isRefreshing {
             refreshControl.endRefreshing()
         }
+    }
+}
+
+// MARK: - CollectionView Delegate
+extension ProductListLayout: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? ProductCellProtocol else {
+            return
+        }
+        let productId = cell.productId
+        delegate?.productListLayout(didSelectCell: productId)
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController/ProductListViewController.swift
@@ -25,6 +25,7 @@ final class ProductListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupDataSource()
+        setupLayout()
         setupViewController()
         setupNavigationBar()
         setupProductListStackView()
@@ -72,6 +73,19 @@ extension ProductListViewController: ProductListDataSourceDelegate {
         DispatchQueue.main.async { [weak self] in
             self?.productListStackView.showRefreshButton()
         }
+    }
+}
+
+// MARK: - ProductListLayout Delegate
+extension ProductListViewController: ProductListLayoutDelegate {
+    private func setupLayout() {
+        layout.delegate = self
+    }
+    
+    func productListLayout(didSelectCell productId: Int) {
+        let productDetailViewController = ProductDetailViewController()
+        productDetailViewController.setProductId(productId)
+        navigationController?.pushViewController(productDetailViewController, animated: true)
     }
 }
 

--- a/OpenMarket/OpenMarket/Model/DetailViewProduct.swift
+++ b/OpenMarket/OpenMarket/Model/DetailViewProduct.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct DetailViewProduct: Codable {
+    let id: Int
+    let vendorId: Int
+    let name: String
+    let description: String
+    let thumbnail: String
+    let currency: Currency
+    let price: Double
+    let bargainPrice: Double
+    let discountedPrice: Double
+    let stock: Int
+    let images: [ProductImage]
+    let vendor: Vendor?
+    let createdAt: String
+    let issuedAt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id, vendorId, name, description, thumbnail, currency, price, bargainPrice,
+             discountedPrice, stock, images, createdAt, issuedAt
+        
+        case vendor = "vendors"
+    }
+}

--- a/OpenMarket/OpenMarket/Model/ProductImage.swift
+++ b/OpenMarket/OpenMarket/Model/ProductImage.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct ProductImage: Codable {
+    let id: Int
+    let url: String
+    let thumbnailUrl: String
+    let isUploadSucceed: Bool
+    let issuedAt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id, url, thumbnailUrl, issuedAt
+        
+        case isUploadSucceed = "succeed"
+    }
+}

--- a/OpenMarket/OpenMarket/Model/Vendor.swift
+++ b/OpenMarket/OpenMarket/Model/Vendor.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+struct Vendor: Codable {
+}

--- a/OpenMarket/OpenMarket/Protocol/ProductCellProtocol.swift
+++ b/OpenMarket/OpenMarket/Protocol/ProductCellProtocol.swift
@@ -1,5 +1,7 @@
 import UIKit
 
 protocol ProductCellProtocol: UICollectionViewCell {
-    func updateView(with data: Product)
+    var productId: Int { get }
+    
+    func applyData(_ data: Product)
 }

--- a/OpenMarket/OpenMarket/SceneDelegate.swift
+++ b/OpenMarket/OpenMarket/SceneDelegate.swift
@@ -16,7 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
         window = UIWindow(windowScene: windowScene)
-        let mainViewController = ProductListViewController()
+//        let mainViewController = ProductListViewController()
+        let mainViewController = ProductDetailViewController()
         let navigationController = OpenMarketNavigationController(rootViewController: mainViewController)
         
         window?.rootViewController = navigationController

--- a/OpenMarket/OpenMarket/SceneDelegate.swift
+++ b/OpenMarket/OpenMarket/SceneDelegate.swift
@@ -16,8 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
         window = UIWindow(windowScene: windowScene)
-//        let mainViewController = ProductListViewController()
-        let mainViewController = ProductDetailViewController()
+        let mainViewController = ProductListViewController()
+//        let mainViewController = ProductDetailViewController()
         let navigationController = OpenMarketNavigationController(rootViewController: mainViewController)
         
         window?.rootViewController = navigationController

--- a/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailImageCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailImageCell.swift
@@ -1,0 +1,35 @@
+import UIKit
+
+class ProductDetailImageCell: UICollectionViewCell {
+    static let identifier = "ProductDetailImageCell"
+    
+    let productImageView = UIImageView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupCell()
+        setupImageViwe()
+    }
+        
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupCell() {
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    private func setupImageViwe() {
+        addSubview(productImageView)
+        productImageView.translatesAutoresizingMaskIntoConstraints = false
+        productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor).isActive = true
+        productImageView.heightAnchor.constraint(equalTo: contentView.heightAnchor).isActive = true
+        productImageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
+        productImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
+    }
+    
+    func setProductImage(url: String) {
+        productImageView.contentMode = .scaleAspectFill
+        productImageView.loadImage(of: url)
+    }
+}

--- a/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
+++ b/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class ProductDetailScrollView: UIScrollView {
     private let verticalStackView = UIStackView()
-    private var productDetailImageCollectionView = UICollectionView(frame: CGRect.zero,
+    private(set) var productDetailImageCollectionView = UICollectionView(frame: CGRect.zero,
                                                                     collectionViewLayout: UICollectionViewFlowLayout())
     private(set) var imageNumberPageControl = UIPageControl()
     private let nameLabel = UILabel()
@@ -57,10 +57,10 @@ class ProductDetailScrollView: UIScrollView {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
         flowLayout.minimumLineSpacing = 0
-        flowLayout.itemSize = CGSize(width: UIScreen.main.bounds.width,
-                                     height: UIScreen.main.bounds.width)
+        flowLayout.itemSize = CGSize(width: UIScreen.main.bounds.width - 30,
+                                     height: UIScreen.main.bounds.width  - 30)
         productDetailImageCollectionView.collectionViewLayout = flowLayout
-
+        productDetailImageCollectionView.isPagingEnabled = true
         productDetailImageCollectionView.heightAnchor.constraint(equalTo: productDetailImageCollectionView.widthAnchor)
             .isActive = true
     }

--- a/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
+++ b/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
@@ -1,0 +1,71 @@
+import UIKit
+
+class ProductDetailScrollView: UIScrollView {
+    private let verticalStackView = UIStackView()
+    private var productDetailImageCollectionView = UICollectionView(frame: CGRect.zero,
+                                                                    collectionViewLayout: UICollectionViewFlowLayout())
+    private let imageNumberPageControl = UIPageControl()
+    private let nameLabel = UILabel()
+    private let stockLabel = UILabel()
+    private let bargainPriceLabel = UILabel()
+    private let priceLabel = UILabel()
+    private let descriptionTextView = UITextView()
+    
+    func setupConstraints(with superview: UIView) {
+        translatesAutoresizingMaskIntoConstraints = false
+        leadingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.leadingAnchor)
+            .isActive = true
+        trailingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.trailingAnchor)
+            .isActive = true
+        topAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.topAnchor)
+            .isActive = true
+        bottomAnchor.constraint(equalTo: superview.bottomAnchor)
+            .isActive = true
+        widthAnchor.constraint(equalToConstant: superview.frame.width).isActive = true
+    }
+    
+    func setupSubviews() {
+        setupVerticalStackView()
+        setupProductDetailImageCollectionView()
+        
+        setupSubviewsAutoresizingMask()
+    }
+    
+    func setupVerticalStackView() {
+        addSubview(verticalStackView)
+        verticalStackView.axis = .vertical
+        verticalStackView.alignment = .fill
+        verticalStackView.distribution = .fill
+        verticalStackView.spacing = 10
+        verticalStackView.backgroundColor = .systemBlue
+        let inset: CGFloat = 15
+        verticalStackView.layoutMargins = UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset)
+        verticalStackView.isLayoutMarginsRelativeArrangement = true
+        
+        verticalStackView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        verticalStackView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        verticalStackView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        verticalStackView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        verticalStackView.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
+    }
+    
+    func setupProductDetailImageCollectionView() {
+        verticalStackView.addArrangedSubview(productDetailImageCollectionView)
+        
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.scrollDirection = .horizontal
+        flowLayout.minimumLineSpacing = 0
+        flowLayout.itemSize = CGSize(width: UIScreen.main.bounds.width,
+                                     height: UIScreen.main.bounds.width)
+        productDetailImageCollectionView.collectionViewLayout = flowLayout
+
+        productDetailImageCollectionView.heightAnchor.constraint(equalTo: productDetailImageCollectionView.widthAnchor)
+            .isActive = true
+    }
+    
+    private func setupSubviewsAutoresizingMask() {
+        subviews.forEach { subview in
+            subview.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+}

--- a/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
+++ b/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
@@ -4,7 +4,7 @@ class ProductDetailScrollView: UIScrollView {
     private let verticalStackView = UIStackView()
     private var productDetailImageCollectionView = UICollectionView(frame: CGRect.zero,
                                                                     collectionViewLayout: UICollectionViewFlowLayout())
-    private let imageNumberPageControl = UIPageControl()
+    private(set) var imageNumberPageControl = UIPageControl()
     private let nameLabel = UILabel()
     private let stockLabel = UILabel()
     private let bargainPriceLabel = UILabel()
@@ -27,7 +27,10 @@ class ProductDetailScrollView: UIScrollView {
     func setupSubviews() {
         setupVerticalStackView()
         setupProductDetailImageCollectionView()
-        
+        setPageControl()
+        setLabelsStackView()
+        setLabels()
+        setupDescriptionTextView()
         setupSubviewsAutoresizingMask()
     }
     
@@ -37,7 +40,7 @@ class ProductDetailScrollView: UIScrollView {
         verticalStackView.alignment = .fill
         verticalStackView.distribution = .fill
         verticalStackView.spacing = 10
-        verticalStackView.backgroundColor = .systemBlue
+        verticalStackView.backgroundColor = .systemRed
         let inset: CGFloat = 15
         verticalStackView.layoutMargins = UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset)
         verticalStackView.isLayoutMarginsRelativeArrangement = true
@@ -61,6 +64,67 @@ class ProductDetailScrollView: UIScrollView {
 
         productDetailImageCollectionView.heightAnchor.constraint(equalTo: productDetailImageCollectionView.widthAnchor)
             .isActive = true
+    }
+    
+    func setPageControl() {
+        verticalStackView.addArrangedSubview(imageNumberPageControl)
+        imageNumberPageControl.numberOfPages = 5 // todo 밖에서 이미지 개수 설정
+        imageNumberPageControl.currentPage = 0
+        imageNumberPageControl.pageIndicatorTintColor = .lightGray
+        imageNumberPageControl.currentPageIndicatorTintColor = .systemBlue
+    }
+    
+    func setLabelsStackView() {
+        let horizontalStackView = UIStackView()
+        horizontalStackView.translatesAutoresizingMaskIntoConstraints = false
+        horizontalStackView.axis = .horizontal
+        horizontalStackView.distribution = .fill
+        verticalStackView.addArrangedSubview(horizontalStackView)
+        horizontalStackView.addArrangedSubview(nameLabel)
+        horizontalStackView.backgroundColor = .systemGray
+        
+        let stockAndPriceStackView = UIStackView()
+        stockAndPriceStackView.translatesAutoresizingMaskIntoConstraints = false
+        stockAndPriceStackView.axis = .vertical
+        stockAndPriceStackView.alignment = .trailing
+        stockAndPriceStackView.distribution = .fill
+       
+        horizontalStackView.addArrangedSubview(stockAndPriceStackView)
+        stockAndPriceStackView.addArrangedSubview(stockLabel)
+        stockAndPriceStackView.addArrangedSubview(priceLabel)
+        stockAndPriceStackView.addArrangedSubview(bargainPriceLabel)
+        stockAndPriceStackView.backgroundColor = .systemPink
+        stockAndPriceStackView.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+    
+    func setLabels() {
+        nameLabel.text = "제목제목제목제목제목제목제목제목제목제목제목"
+        nameLabel.font = .preferredFont(forTextStyle: .body)
+        nameLabel.textAlignment = .left
+        nameLabel.numberOfLines = 0
+          
+        stockLabel.text = "남은 수량 : 182"
+        stockLabel.font = .preferredFont(forTextStyle: .body)
+        stockLabel.textAlignment = .right
+        stockLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        
+        priceLabel.text = "KRW 20000"
+        priceLabel.font = .preferredFont(forTextStyle: .body)
+        priceLabel.textAlignment = .right
+        
+        bargainPriceLabel.text = "KRW 10000"
+        bargainPriceLabel.font = .preferredFont(forTextStyle: .body)
+        bargainPriceLabel.textAlignment = .right
+    }
+    
+    private func setupDescriptionTextView() {
+        verticalStackView.addArrangedSubview(descriptionTextView)
+        descriptionTextView.text = ProductPlaceholder.description.text
+        descriptionTextView.textColor = UIColor.lightGray
+        descriptionTextView.isEditable = false
+        descriptionTextView.isScrollEnabled = false
+        descriptionTextView.font = .preferredFont(forTextStyle: .body)
+        descriptionTextView.setContentHuggingPriority(.defaultLow, for: .vertical)
     }
     
     private func setupSubviewsAutoresizingMask() {

--- a/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
+++ b/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
@@ -68,7 +68,6 @@ class ProductDetailScrollView: UIScrollView {
     
     func setPageControl() {
         verticalStackView.addArrangedSubview(imageNumberPageControl)
-        imageNumberPageControl.numberOfPages = 5 // todo 밖에서 이미지 개수 설정
         imageNumberPageControl.currentPage = 0
         imageNumberPageControl.pageIndicatorTintColor = .lightGray
         imageNumberPageControl.currentPageIndicatorTintColor = .systemBlue
@@ -79,6 +78,8 @@ class ProductDetailScrollView: UIScrollView {
         horizontalStackView.translatesAutoresizingMaskIntoConstraints = false
         horizontalStackView.axis = .horizontal
         horizontalStackView.distribution = .fill
+        horizontalStackView.alignment = .top
+        horizontalStackView.spacing = 8
         verticalStackView.addArrangedSubview(horizontalStackView)
         horizontalStackView.addArrangedSubview(nameLabel)
         horizontalStackView.backgroundColor = .systemGray
@@ -99,7 +100,7 @@ class ProductDetailScrollView: UIScrollView {
     
     func setLabels() {
         nameLabel.text = "제목제목제목제목제목제목제목제목제목제목제목"
-        nameLabel.font = .preferredFont(forTextStyle: .body)
+        nameLabel.font = .preferredFont(forTextStyle: .headline)
         nameLabel.textAlignment = .left
         nameLabel.numberOfLines = 0
           
@@ -120,7 +121,7 @@ class ProductDetailScrollView: UIScrollView {
     private func setupDescriptionTextView() {
         verticalStackView.addArrangedSubview(descriptionTextView)
         descriptionTextView.text = ProductPlaceholder.description.text
-        descriptionTextView.textColor = UIColor.lightGray
+        descriptionTextView.textColor = .black
         descriptionTextView.isEditable = false
         descriptionTextView.isScrollEnabled = false
         descriptionTextView.font = .preferredFont(forTextStyle: .body)
@@ -131,5 +132,53 @@ class ProductDetailScrollView: UIScrollView {
         subviews.forEach { subview in
             subview.translatesAutoresizingMaskIntoConstraints = false
         }
+    }
+    
+    func updateView(with data: DetailViewProduct) {
+        imageNumberPageControl.numberOfPages = data.images.count
+        
+        nameLabel.text = data.name
+        changePriceAndDiscountedPriceLabel(price: data.price,
+                                           discountedPrice: data.discountedPrice,
+                                           bargainPrice: data.bargainPrice,
+                                           currency: data.currency)
+        changeStockLabel(by: data.stock)
+        changeDescriptionTextView(with: data.description)
+    }
+    
+    private func changePriceAndDiscountedPriceLabel(price: Double,
+                                                    discountedPrice: Double,
+                                                    bargainPrice: Double,
+                                                    currency: Currency) {
+        if discountedPrice == 0 {
+            priceLabel.attributedText = nil
+            priceLabel.textColor = .systemGray
+            priceLabel.text = "\(currency.rawValue) \(price.formattedWithComma())"
+            
+            bargainPriceLabel.isHidden = true
+        } else {
+            let priceText = "\(currency.rawValue) \(price.formattedWithComma())"
+            priceLabel.strikeThrough(text: priceText)
+            priceLabel.textColor = .systemRed
+            
+            bargainPriceLabel.isHidden = false
+            bargainPriceLabel.text = "\(currency.rawValue) \(bargainPrice.formattedWithComma())"
+        }
+    }
+    
+    private func changeStockLabel(by stock: Int) {
+        if stock == 0 {
+            stockLabel.text = "품절"
+            stockLabel.textColor = .systemYellow
+            stockLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        } else {
+            stockLabel.text = "잔여수량 : \(stock.formattedWithComma())"
+            stockLabel.textColor = .systemGray
+            stockLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        }
+    }
+    
+    private func changeDescriptionTextView(with text: String) {
+        descriptionTextView.text = text
     }
 }

--- a/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
+++ b/OpenMarket/OpenMarket/View/ProductDetailView/ProductDetailScrollView.swift
@@ -40,7 +40,6 @@ class ProductDetailScrollView: UIScrollView {
         verticalStackView.alignment = .fill
         verticalStackView.distribution = .fill
         verticalStackView.spacing = 10
-        verticalStackView.backgroundColor = .systemRed
         let inset: CGFloat = 15
         verticalStackView.layoutMargins = UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset)
         verticalStackView.isLayoutMarginsRelativeArrangement = true
@@ -82,7 +81,6 @@ class ProductDetailScrollView: UIScrollView {
         horizontalStackView.spacing = 8
         verticalStackView.addArrangedSubview(horizontalStackView)
         horizontalStackView.addArrangedSubview(nameLabel)
-        horizontalStackView.backgroundColor = .systemGray
         
         let stockAndPriceStackView = UIStackView()
         stockAndPriceStackView.translatesAutoresizingMaskIntoConstraints = false
@@ -94,26 +92,21 @@ class ProductDetailScrollView: UIScrollView {
         stockAndPriceStackView.addArrangedSubview(stockLabel)
         stockAndPriceStackView.addArrangedSubview(priceLabel)
         stockAndPriceStackView.addArrangedSubview(bargainPriceLabel)
-        stockAndPriceStackView.backgroundColor = .systemPink
         stockAndPriceStackView.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
     
     func setLabels() {
-        nameLabel.text = "제목제목제목제목제목제목제목제목제목제목제목"
         nameLabel.font = .preferredFont(forTextStyle: .headline)
         nameLabel.textAlignment = .left
         nameLabel.numberOfLines = 0
           
-        stockLabel.text = "남은 수량 : 182"
         stockLabel.font = .preferredFont(forTextStyle: .body)
         stockLabel.textAlignment = .right
         stockLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         
-        priceLabel.text = "KRW 20000"
         priceLabel.font = .preferredFont(forTextStyle: .body)
         priceLabel.textAlignment = .right
         
-        bargainPriceLabel.text = "KRW 10000"
         bargainPriceLabel.font = .preferredFont(forTextStyle: .body)
         bargainPriceLabel.textAlignment = .right
     }

--- a/OpenMarket/OpenMarket/View/ProductListView/GridProductCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListView/GridProductCell.swift
@@ -10,6 +10,8 @@ final class GridProductCell: UICollectionViewCell, ProductCellProtocol {
     private let bargainPriceLabel = UILabel()
     private let stockLabel = UILabel()
     
+    private(set) var productId: Int = 0
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupBorderLine()
@@ -92,7 +94,16 @@ final class GridProductCell: UICollectionViewCell, ProductCellProtocol {
         stockLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
     }
     
-    func updateView(with data: Product) {
+    func applyData(_ data: Product) {
+        setProductId(with: data)
+        updateView(with: data)
+    }
+    
+    private func setProductId(with data: Product) {
+        productId = data.id
+    }
+    
+    private func updateView(with data: Product) {
         productThumbnailView.loadImage(of: data.thumbnail)
         nameLabel.text = data.name
         changePriceAndDiscountedPriceLabel(price: data.price,

--- a/OpenMarket/OpenMarket/View/ProductListView/ListProductCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListView/ListProductCell.swift
@@ -11,6 +11,8 @@ final class ListProductCell: UICollectionViewCell, ProductCellProtocol {
     private let stockLabel = UILabel()
     private let accessoryImageView = UIImageView()
     
+    private(set) var productId: Int = 0
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUnderLine()
@@ -137,7 +139,16 @@ final class ListProductCell: UICollectionViewCell, ProductCellProtocol {
         stockLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
     
-    func updateView(with data: Product) {
+    func applyData(_ data: Product) {
+        setProductId(with: data)
+        updateView(with: data)
+    }
+    
+    private func setProductId(with data: Product) {
+        productId = data.id
+    }
+    
+    private func updateView(with data: Product) {
         productThumbnailView.loadImage(of: data.thumbnail)
         nameLabel.text = data.name
         changePriceAndDiscountedPriceLabel(price: data.price,

--- a/OpenMarket/OpenMarket/View/ProductRegisterView/ProductImageCollectionView.swift
+++ b/OpenMarket/OpenMarket/View/ProductRegisterView/ProductImageCollectionView.swift
@@ -3,7 +3,7 @@ import UIKit
 class ProductImageCollectionView: UICollectionView {
     var reloadDataCompletionHandler: (() -> Void)?
     
-    func setupConstraints(with superview: UIView) {
+    func setupConstraints(with superview: UIView) { // ToDo: 호출하도록 수정
         translatesAutoresizingMaskIntoConstraints = false
         leadingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.leadingAnchor)
             .isActive = true


### PR DESCRIPTION
메이슨 안녕하세요. @myssun0325
애플사이다 @just1103, 허황 @hwangjeha 입니다.
STEP2 완료하진 못했지만 진행한 부분까지 피드백 받을 수 있을까 하고 PR 드립니다.(쭈굴)🙈
STEP4 브랜치를 깜빡해서 STEP3으로 올리겠습니다😭

## STEP2 구현내용
### 구현 화면 
![상품 상세 화면](https://user-images.githubusercontent.com/70856586/151527449-1c7f5f01-389a-428b-942b-b1b50b585cc5.gif)

### 1. 상품 상세 조회 Model 타입 구현
상품의 상세 정보를 받기 위해 모델 타입을 구현했습니다.
Vendor 타입은 서버에서 Responce로 응답을 보내주긴 하지만 현재 프로젝트에선 사용하고 있지 않아 타입만 만들어줬습니다.
### 2. 화면 이동 (상품 목록 화면 -> 상품 상세 화면)
상품 목록화면에서 Cell을 탭하면, 해당 제품의 상세화면으로 이동합니다. Cell의 productId 프로퍼티를 추가하여 해당 Cell의 정보를 받아오도록 구현했습니다.

### 3. 상품 상세 화면 구현
상품 상세 화면은 스크롤 뷰로 구현했습니다. 내부에 컬렉션 뷰, 스택 뷰를 활용하여 레이아웃을 잡았습니다.
또 상품 상세 화면의 데이터 소스 역할을 하는 ProductDetailDataSource 타입을 델리게이트 패턴을 적용하여 뷰컨트롤러 델리게이트로 사용하도록 했습니다.

### 아직 구현하지 못한 부분
- Action Sheet의 형태만 구현했고, 수정 또는 삭제 Action 버튼을 탭했을 때 제품 수정화면을 연결하거나, 사용자에게 비밀번호를 입력받는 기능은 아직 구현하지 못했습니다. 
- 추후에 상품 수정화면은 상품 등록화면과 유사한 기능이 많으므로 동일한 부모 클래스를 공유하는 ViewController을 추가할 예정입니다. (처음에는 상품 등록/수정 화면이 동일한 ViewController를 사용하도록 할 계획이었지만, 이미지 CollectionView와 관련된 기능이 예상외로 차이점이 많아서 별도의 ViewController를 추가하는 게 적절하다고 판단했습니다.)

## 고민한 점 및 궁금한 점

### 1. 화면 전환 시 데이터 전달 방법
상품 리스트 화면에서 상품 상세 화면으로 전환될 때 선택된 상품의 id를 넘겨줘야하는데 효율적인 전달 방법을 구현하지 못했습니다. 화면 전환시 상품 상세 화면 뷰컨의 productId 를 변경하는 메서드를 호출하고 productId를 변경하는 방식으로 구현했습니다.
추후, 델리게이트 패턴이나 프로토콜을 활용해 productId를 넘겨주는 방식으로 개선하겠습니다.


STEP 2를 전부 구현하지 못해서 고민한 점이나 궁금한 점이 많이 없네요😭
4주동안 리뷰해주시느라 정말 고생 많으셨습니다.
추상화부터 ViewController 분리까지 어려운 내용이 많았는데 정말 많은 도움이 됐습니다. 감사합니다🤩🤩🤩