### PR TITLE
오픈 마켓 II [STEP2] 아샌, 제인

### DIFF
--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		473CF1372783E07700B8DA1F /* OpenMarketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473CF1362783E07700B8DA1F /* OpenMarketTests.swift */; };
 		473CF13D2783E08B00B8DA1F /* ProductList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470F81732782E8AC006B4734 /* ProductList.swift */; };
 		473CF13E2783E08D00B8DA1F /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470F81752782F51A006B4734 /* JSONParser.swift */; };
+		47F2A2CB27A13E800079DC9A /* ProductDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F2A2CA27A13E800079DC9A /* ProductDetailViewController.swift */; };
 		47FF35712789CAB80098FB0C /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FF35702789CAB80098FB0C /* URLSessionProtocol.swift */; };
 		47FF35722789CABC0098FB0C /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FF35702789CAB80098FB0C /* URLSessionProtocol.swift */; };
 		47FF35732789CF8D0098FB0C /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB8FBD12783E4780036A4E3 /* APIManager.swift */; };
@@ -83,6 +84,7 @@
 		47321089279068340052EEB1 /* Int+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+extension.swift"; sourceTree = "<group>"; };
 		473CF1342783E07700B8DA1F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		473CF1362783E07700B8DA1F /* OpenMarketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenMarketTests.swift; sourceTree = "<group>"; };
+		47F2A2CA27A13E800079DC9A /* ProductDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailViewController.swift; sourceTree = "<group>"; };
 		47FF35702789CAB80098FB0C /* URLSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionProtocol.swift; sourceTree = "<group>"; };
 		47FF35762789CFC30098FB0C /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		47FF35782789CFD50098FB0C /* MockURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSessionDataTask.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				C70FB0FE25BEF61C00C9924E /* OpenMarketViewController.swift */,
 				EAC5F3BB278EBE9800AD2DA5 /* OpenMarketViewLayout.swift */,
 				4708E50A2797E21D002BBCED /* AddProductViewController.swift */,
+				47F2A2CA27A13E800079DC9A /* ProductDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -459,6 +462,7 @@
 				4713AACC27857F4700396E26 /* URLManager.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* OpenMarketViewController.swift in Sources */,
 				4708E5092797CE05002BBCED /* Data+extension.swift in Sources */,
+				47F2A2CB27A13E800079DC9A /* ProductDetailViewController.swift in Sources */,
 				470F81762782F51A006B4734 /* JSONParser.swift in Sources */,
 				470F81742782E8AC006B4734 /* ProductList.swift in Sources */,
 				EAC5F3BC278EBE9800AD2DA5 /* OpenMarketViewLayout.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -162,10 +162,10 @@
 			isa = PBXGroup;
 			children = (
 				EAC5F3B7278EA60400AD2DA5 /* ProductListCell.swift */,
-				EA8BE5E427A27653006A51CD /* ProductImageCollectionViewCell.swift */,
 				EAC5F3B8278EA60400AD2DA5 /* ProductListCell.xib */,
 				47321081278FF5E90052EEB1 /* ProductGridCell.swift */,
 				47321082278FF5E90052EEB1 /* ProductGridCell.xib */,
+				EA8BE5E427A27653006A51CD /* ProductImageCollectionViewCell.swift */,
 				47321085278FF69F0052EEB1 /* NameSpace.swift */,
 			);
 			path = CustomCell;

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		EA1FD6632789CD2A00193735 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1FD6622789CD2A00193735 /* MockURLSession.swift */; };
 		EA1FD6642789D39D00193735 /* URLSessionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB8FC0E2787DB770036A4E3 /* URLSessionError.swift */; };
 		EA1FD6652789D39F00193735 /* JSONError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB8FC102787DB850036A4E3 /* JSONError.swift */; };
+		EA8BE5E527A27653006A51CD /* ProductImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8BE5E427A27653006A51CD /* ProductImageCollectionViewCell.swift */; };
 		EAB8FBD027834AFF0036A4E3 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = EAB8FBCF27834AFF0036A4E3 /* .swiftlint.yml */; };
 		EAB8FBD22783E4780036A4E3 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB8FBD12783E4780036A4E3 /* APIManager.swift */; };
 		EAB8FBD4278417820036A4E3 /* APIManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB8FBD3278417820036A4E3 /* APIManagerTests.swift */; };
@@ -102,6 +103,7 @@
 		EA1043612797BC7F00745D64 /* NewProductInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProductInformation.swift; sourceTree = "<group>"; };
 		EA1043632797C03900745D64 /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		EA1FD6622789CD2A00193735 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
+		EA8BE5E427A27653006A51CD /* ProductImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		EAB8FBCF27834AFF0036A4E3 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		EAB8FBD12783E4780036A4E3 /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		EAB8FBD3278417820036A4E3 /* APIManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManagerTests.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 			isa = PBXGroup;
 			children = (
 				EAC5F3B7278EA60400AD2DA5 /* ProductListCell.swift */,
+				EA8BE5E427A27653006A51CD /* ProductImageCollectionViewCell.swift */,
 				EAC5F3B8278EA60400AD2DA5 /* ProductListCell.xib */,
 				47321081278FF5E90052EEB1 /* ProductGridCell.swift */,
 				47321082278FF5E90052EEB1 /* ProductGridCell.xib */,
@@ -465,6 +468,7 @@
 				47F2A2CB27A13E800079DC9A /* ProductDetailViewController.swift in Sources */,
 				470F81762782F51A006B4734 /* JSONParser.swift in Sources */,
 				470F81742782E8AC006B4734 /* ProductList.swift in Sources */,
+				EA8BE5E527A27653006A51CD /* ProductImageCollectionViewCell.swift in Sources */,
 				EAC5F3BC278EBE9800AD2DA5 /* OpenMarketViewLayout.swift in Sources */,
 				4708E50B2797E21D002BBCED /* AddProductViewController.swift in Sources */,
 				EAB8FC182787DC290036A4E3 /* Vendors.swift in Sources */,

--- a/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
@@ -285,13 +285,27 @@
                                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                 </collectionViewFlowLayout>
                                                 <cells>
-                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="RB2-dq-0bB">
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ProductImageCell" id="RB2-dq-0bB" customClass="ProductImageCollectionViewCell" customModule="OpenMarket" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="LPD-Xi-Adm">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask"/>
+                                                            <subviews>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lYe-hO-Y1D">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                                                </imageView>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="lYe-hO-Y1D" firstAttribute="leading" secondItem="LPD-Xi-Adm" secondAttribute="leading" id="8bs-MC-5zf"/>
+                                                                <constraint firstAttribute="bottom" secondItem="lYe-hO-Y1D" secondAttribute="bottom" id="ltb-8b-pfj"/>
+                                                                <constraint firstItem="lYe-hO-Y1D" firstAttribute="top" secondItem="LPD-Xi-Adm" secondAttribute="top" id="xCu-va-ifb"/>
+                                                                <constraint firstAttribute="trailing" secondItem="lYe-hO-Y1D" secondAttribute="trailing" id="zFn-s3-L6T"/>
+                                                            </constraints>
                                                         </collectionViewCellContentView>
+                                                        <connections>
+                                                            <outlet property="productImageView" destination="lYe-hO-Y1D" id="rAk-8m-NbK"/>
+                                                        </connections>
                                                     </collectionViewCell>
                                                 </cells>
                                             </collectionView>
@@ -337,22 +351,22 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="LZb-Ya-Dy4">
-                                                <rect key="frame" x="181.5" y="338.5" width="31" height="16"/>
+                                                <rect key="frame" x="183" y="338.5" width="28.5" height="16"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="udY-O4-8Bb">
-                                                        <rect key="frame" x="0.0" y="0.0" width="8.5" height="16"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="udY-O4-8Bb">
+                                                        <rect key="frame" x="0.0" y="0.0" width="6" height="16"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2eE-ek-aad">
-                                                        <rect key="frame" x="13.5" y="0.0" width="4" height="16"/>
+                                                        <rect key="frame" x="11" y="0.0" width="4" height="16"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1rp-IX-fyv">
-                                                        <rect key="frame" x="22.5" y="0.0" width="8.5" height="16"/>
+                                                        <rect key="frame" x="20" y="0.0" width="8.5" height="16"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>

--- a/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -264,14 +265,147 @@
                     <view key="view" contentMode="scaleToFill" id="5go-8d-3mB">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="k2J-nj-RJy">
+                                <rect key="frame" x="10" y="88" width="394" height="774"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NnL-58-bYu">
+                                        <rect key="frame" x="0.0" y="0.0" width="394" height="622"/>
+                                        <subviews>
+                                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="nG0-u3-UwS">
+                                                <rect key="frame" x="0.0" y="0.0" width="394" height="328.5"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="nG0-u3-UwS" secondAttribute="height" multiplier="1.2:1" id="WPn-il-YwM"/>
+                                                </constraints>
+                                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="b2H-G3-gQx">
+                                                    <size key="itemSize" width="128" height="128"/>
+                                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                </collectionViewFlowLayout>
+                                                <cells>
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="RB2-dq-0bB">
+                                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="LPD-Xi-Adm">
+                                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </collectionViewCellContentView>
+                                                    </collectionViewCell>
+                                                </cells>
+                                            </collectionView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="top" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Xve-f1-TCr">
+                                                <rect key="frame" x="0.0" y="364.5" width="394" height="64"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2DO-yc-8Qr">
+                                                        <rect key="frame" x="0.0" y="0.0" width="189.5" height="17"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="4Kb-cA-9VH">
+                                                        <rect key="frame" x="204.5" y="0.0" width="189.5" height="64"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vzt-YX-XNo">
+                                                                <rect key="frame" x="0.0" y="0.0" width="189.5" height="16"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                                <color key="textColor" systemColor="systemGrayColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPD-Nq-Xci">
+                                                                <rect key="frame" x="0.0" y="24" width="189.5" height="16"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                                <color key="textColor" systemColor="systemOrangeColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0l4-aQ-sVm">
+                                                                <rect key="frame" x="0.0" y="48" width="189.5" height="16"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3Jg-KK-bfT">
+                                                <rect key="frame" x="0.0" y="438.5" width="394" height="183.5"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="LZb-Ya-Dy4">
+                                                <rect key="frame" x="181.5" y="338.5" width="31" height="16"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="udY-O4-8Bb">
+                                                        <rect key="frame" x="0.0" y="0.0" width="8.5" height="16"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2eE-ek-aad">
+                                                        <rect key="frame" x="13.5" y="0.0" width="4" height="16"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1rp-IX-fyv">
+                                                        <rect key="frame" x="22.5" y="0.0" width="8.5" height="16"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="3Jg-KK-bfT" secondAttribute="bottom" id="1S3-LO-xZg"/>
+                                            <constraint firstAttribute="trailing" secondItem="Xve-f1-TCr" secondAttribute="trailing" id="68t-6T-8cC"/>
+                                            <constraint firstItem="3Jg-KK-bfT" firstAttribute="top" secondItem="Xve-f1-TCr" secondAttribute="bottom" constant="10" id="6rV-O7-vG8"/>
+                                            <constraint firstItem="LZb-Ya-Dy4" firstAttribute="bottom" secondItem="Xve-f1-TCr" secondAttribute="top" constant="-10" id="8Bz-ja-7hf"/>
+                                            <constraint firstItem="LZb-Ya-Dy4" firstAttribute="centerX" secondItem="nG0-u3-UwS" secondAttribute="centerX" id="K47-kM-SzV"/>
+                                            <constraint firstItem="nG0-u3-UwS" firstAttribute="leading" secondItem="NnL-58-bYu" secondAttribute="leading" id="QDN-2K-Uy4"/>
+                                            <constraint firstAttribute="trailing" secondItem="nG0-u3-UwS" secondAttribute="trailing" id="Rq5-Pt-2yH"/>
+                                            <constraint firstItem="nG0-u3-UwS" firstAttribute="width" secondItem="NnL-58-bYu" secondAttribute="width" id="b4f-Th-Tvt"/>
+                                            <constraint firstItem="3Jg-KK-bfT" firstAttribute="width" secondItem="NnL-58-bYu" secondAttribute="width" id="dCe-Jw-AZ2"/>
+                                            <constraint firstAttribute="trailing" secondItem="3Jg-KK-bfT" secondAttribute="trailing" id="dYy-Yb-2TO"/>
+                                            <constraint firstItem="3Jg-KK-bfT" firstAttribute="leading" secondItem="NnL-58-bYu" secondAttribute="leading" id="e2r-OQ-vS5"/>
+                                            <constraint firstItem="Xve-f1-TCr" firstAttribute="leading" secondItem="NnL-58-bYu" secondAttribute="leading" id="i9z-Ux-Rm5"/>
+                                            <constraint firstItem="nG0-u3-UwS" firstAttribute="top" secondItem="NnL-58-bYu" secondAttribute="top" id="kX0-te-l1h"/>
+                                            <constraint firstItem="Xve-f1-TCr" firstAttribute="width" secondItem="NnL-58-bYu" secondAttribute="width" id="ksp-O3-jAz"/>
+                                            <constraint firstItem="LZb-Ya-Dy4" firstAttribute="top" secondItem="nG0-u3-UwS" secondAttribute="bottom" constant="10" id="xdR-3S-6wT"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="NnL-58-bYu" secondAttribute="bottom" id="8fG-iP-ioA"/>
+                                    <constraint firstAttribute="trailing" secondItem="NnL-58-bYu" secondAttribute="trailing" id="kqM-qZ-XuK"/>
+                                    <constraint firstItem="NnL-58-bYu" firstAttribute="top" secondItem="k2J-nj-RJy" secondAttribute="top" id="mYE-9I-fKj"/>
+                                    <constraint firstItem="NnL-58-bYu" firstAttribute="width" secondItem="k2J-nj-RJy" secondAttribute="width" id="mqF-6g-eU4"/>
+                                    <constraint firstItem="NnL-58-bYu" firstAttribute="leading" secondItem="k2J-nj-RJy" secondAttribute="leading" id="yTv-Nn-TMi"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="gmq-0h-pUK"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="O3C-3C-RE8"/>
+                            </scrollView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="bvd-zM-7Yo"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="bvd-zM-7Yo" firstAttribute="trailing" secondItem="k2J-nj-RJy" secondAttribute="trailing" constant="10" id="Jmb-BG-tf9"/>
+                            <constraint firstItem="k2J-nj-RJy" firstAttribute="top" secondItem="bvd-zM-7Yo" secondAttribute="top" id="nwJ-lL-ykd"/>
+                            <constraint firstItem="k2J-nj-RJy" firstAttribute="leading" secondItem="bvd-zM-7Yo" secondAttribute="leading" constant="10" id="rU2-7Y-hJK"/>
+                            <constraint firstItem="bvd-zM-7Yo" firstAttribute="bottom" secondItem="k2J-nj-RJy" secondAttribute="bottom" id="v4H-aP-CB3"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="92j-v6-kpb"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LXL-lL-3ui" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="993" y="840"/>
+            <point key="canvasLocation" x="992.75362318840587" y="839.73214285714278"/>
         </scene>
     </scenes>
     <resources>
@@ -284,6 +418,12 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
@@ -71,8 +71,9 @@
         <scene sceneID="06K-FF-ZyC">
             <objects>
                 <navigationController id="gEB-bW-9bK" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="xQe-bD-d1H"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="fch-Jy-bbn">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -86,13 +87,13 @@
         <!--Add Product View Controller-->
         <scene sceneID="Pqz-4j-FBe">
             <objects>
-                <viewController id="0cc-2w-7Sp" customClass="AddProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="AddProductViewController" id="0cc-2w-7Sp" customClass="AddProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="hxD-E2-cIh">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Yh-1S-91Y">
-                                <rect key="frame" x="10" y="88" width="394" height="774"/>
+                                <rect key="frame" x="10" y="56" width="394" height="786"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oEp-hN-q5C" userLabel="Content View">
                                         <rect key="frame" x="0.0" y="0.0" width="394" height="370"/>
@@ -256,7 +257,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W3x-ad-9Pa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2471.0144927536235" y="116.51785714285714"/>
+            <point key="canvasLocation" x="2654" y="117"/>
         </scene>
         <!--Product Detail View Controller-->
         <scene sceneID="9l2-1A-TgD">
@@ -414,7 +415,13 @@
                             <constraint firstItem="bvd-zM-7Yo" firstAttribute="bottom" secondItem="k2J-nj-RJy" secondAttribute="bottom" id="v4H-aP-CB3"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="92j-v6-kpb"/>
+                    <navigationItem key="navigationItem" id="92j-v6-kpb">
+                        <barButtonItem key="rightBarButtonItem" systemItem="action" id="DbI-PI-guw">
+                            <connections>
+                                <action selector="edit:" destination="qSw-HC-sTu" id="3ab-D0-ltT"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="currentPageLabel" destination="udY-O4-8Bb" id="0OT-hM-VR0"/>
                         <outlet property="descriptionTextView" destination="3Jg-KK-bfT" id="ddr-0e-Jdh"/>
@@ -424,13 +431,17 @@
                         <outlet property="priceLabel" destination="0l4-aQ-sVm" id="8cO-Zi-e8T"/>
                         <outlet property="stockLabel" destination="Vzt-YX-XNo" id="Dp6-QC-BWt"/>
                         <outlet property="totalPageLabel" destination="1rp-IX-fyv" id="RMw-ch-0Rc"/>
+                        <segue destination="gEB-bW-9bK" kind="presentation" identifier="edit" id="Jkw-sb-bNM"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LXL-lL-3ui" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="992.75362318840587" y="839.73214285714278"/>
+            <point key="canvasLocation" x="993" y="926"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="Jkw-sb-bNM"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">

--- a/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
@@ -184,7 +184,7 @@
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" keyboardDismissMode="interactive" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="K6l-69-CVn">
                                                         <rect key="frame" x="1" y="176" width="392" height="34"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                        <color key="textColor" systemColor="labelColor"/>
+                                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                     </textView>
@@ -310,6 +310,29 @@
                                                     </collectionViewCell>
                                                 </cells>
                                             </collectionView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="LZb-Ya-Dy4">
+                                                <rect key="frame" x="183" y="338.5" width="28.5" height="16"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="udY-O4-8Bb">
+                                                        <rect key="frame" x="0.0" y="0.0" width="6" height="16"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2eE-ek-aad">
+                                                        <rect key="frame" x="11" y="0.0" width="4" height="16"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1rp-IX-fyv">
+                                                        <rect key="frame" x="20" y="0.0" width="8.5" height="16"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="top" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Xve-f1-TCr">
                                                 <rect key="frame" x="0.0" y="364.5" width="394" height="16"/>
                                                 <subviews>
@@ -351,29 +374,6 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="LZb-Ya-Dy4">
-                                                <rect key="frame" x="183" y="338.5" width="28.5" height="16"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="udY-O4-8Bb">
-                                                        <rect key="frame" x="0.0" y="0.0" width="6" height="16"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2eE-ek-aad">
-                                                        <rect key="frame" x="11" y="0.0" width="4" height="16"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1rp-IX-fyv">
-                                                        <rect key="frame" x="20" y="0.0" width="8.5" height="16"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>

--- a/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
@@ -59,6 +59,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="segmentedControl" destination="rCg-aM-Opf" id="KNB-LU-v8Z"/>
+                        <segue destination="qSw-HC-sTu" kind="show" identifier="ShowProductDetail" id="kua-vC-jKb"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -255,6 +256,22 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W3x-ad-9Pa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2471.0144927536235" y="116.51785714285714"/>
+        </scene>
+        <!--Product Detail View Controller-->
+        <scene sceneID="9l2-1A-TgD">
+            <objects>
+                <viewController id="qSw-HC-sTu" customClass="ProductDetailViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5go-8d-3mB">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="bvd-zM-7Yo"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="92j-v6-kpb"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LXL-lL-3ui" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="993" y="840"/>
         </scene>
     </scenes>
     <resources>

--- a/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
@@ -82,7 +82,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fHs-Dl-1RV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1762" y="117"/>
+            <point key="canvasLocation" x="1896" y="546"/>
         </scene>
         <!--Add Product View Controller-->
         <scene sceneID="Pqz-4j-FBe">
@@ -257,7 +257,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W3x-ad-9Pa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2654" y="117"/>
+            <point key="canvasLocation" x="2735" y="546"/>
         </scene>
         <!--Product Detail View Controller-->
         <scene sceneID="9l2-1A-TgD">
@@ -436,7 +436,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LXL-lL-3ui" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="993" y="926"/>
+            <point key="canvasLocation" x="993" y="946"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>

--- a/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
@@ -73,7 +73,7 @@
                 <navigationController id="gEB-bW-9bK" sceneMemberID="viewController">
                     <navigationItem key="navigationItem" id="xQe-bD-d1H"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="fch-Jy-bbn">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -89,11 +89,11 @@
             <objects>
                 <viewController storyboardIdentifier="AddProductViewController" id="0cc-2w-7Sp" customClass="AddProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="hxD-E2-cIh">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Yh-1S-91Y">
-                                <rect key="frame" x="10" y="56" width="394" height="786"/>
+                                <rect key="frame" x="10" y="88" width="394" height="774"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oEp-hN-q5C" userLabel="Content View">
                                         <rect key="frame" x="0.0" y="0.0" width="394" height="370"/>
@@ -418,7 +418,7 @@
                     <navigationItem key="navigationItem" id="92j-v6-kpb">
                         <barButtonItem key="rightBarButtonItem" systemItem="action" id="DbI-PI-guw">
                             <connections>
-                                <action selector="edit:" destination="qSw-HC-sTu" id="3ab-D0-ltT"/>
+                                <action selector="tapEditDeleteButton:" destination="qSw-HC-sTu" id="Rzq-8X-tek"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -431,7 +431,7 @@
                         <outlet property="priceLabel" destination="0l4-aQ-sVm" id="8cO-Zi-e8T"/>
                         <outlet property="stockLabel" destination="Vzt-YX-XNo" id="Dp6-QC-BWt"/>
                         <outlet property="totalPageLabel" destination="1rp-IX-fyv" id="RMw-ch-0Rc"/>
-                        <segue destination="gEB-bW-9bK" kind="presentation" identifier="edit" id="Jkw-sb-bNM"/>
+                        <segue destination="gEB-bW-9bK" kind="presentation" identifier="edit" modalPresentationStyle="fullScreen" id="Jkw-sb-bNM"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LXL-lL-3ui" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/Base.lproj/Main.storyboard
@@ -270,7 +270,7 @@
                                 <rect key="frame" x="10" y="88" width="394" height="774"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NnL-58-bYu">
-                                        <rect key="frame" x="0.0" y="0.0" width="394" height="622"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="394" height="423.5"/>
                                         <subviews>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="nG0-u3-UwS">
                                                 <rect key="frame" x="0.0" y="0.0" width="394" height="328.5"/>
@@ -296,31 +296,31 @@
                                                 </cells>
                                             </collectionView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="top" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Xve-f1-TCr">
-                                                <rect key="frame" x="0.0" y="364.5" width="394" height="64"/>
+                                                <rect key="frame" x="0.0" y="364.5" width="394" height="16"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2DO-yc-8Qr">
-                                                        <rect key="frame" x="0.0" y="0.0" width="189.5" height="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2DO-yc-8Qr">
+                                                        <rect key="frame" x="0.0" y="0.0" width="189.5" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="4Kb-cA-9VH">
-                                                        <rect key="frame" x="204.5" y="0.0" width="189.5" height="64"/>
+                                                        <rect key="frame" x="204.5" y="0.0" width="189.5" height="16"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vzt-YX-XNo">
-                                                                <rect key="frame" x="0.0" y="0.0" width="189.5" height="16"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vzt-YX-XNo">
+                                                                <rect key="frame" x="0.0" y="0.0" width="189.5" height="0.0"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                                 <color key="textColor" systemColor="systemGrayColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPD-Nq-Xci">
-                                                                <rect key="frame" x="0.0" y="24" width="189.5" height="16"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPD-Nq-Xci">
+                                                                <rect key="frame" x="0.0" y="8" width="189.5" height="0.0"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                                 <color key="textColor" systemColor="systemOrangeColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0l4-aQ-sVm">
-                                                                <rect key="frame" x="0.0" y="48" width="189.5" height="16"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0l4-aQ-sVm">
+                                                                <rect key="frame" x="0.0" y="16" width="189.5" height="0.0"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -330,9 +330,8 @@
                                                 </subviews>
                                             </stackView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3Jg-KK-bfT">
-                                                <rect key="frame" x="0.0" y="438.5" width="394" height="183.5"/>
+                                                <rect key="frame" x="0.0" y="390.5" width="394" height="33"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -402,6 +401,16 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="92j-v6-kpb"/>
+                    <connections>
+                        <outlet property="currentPageLabel" destination="udY-O4-8Bb" id="0OT-hM-VR0"/>
+                        <outlet property="descriptionTextView" destination="3Jg-KK-bfT" id="ddr-0e-Jdh"/>
+                        <outlet property="imageCollectionView" destination="nG0-u3-UwS" id="mWZ-Ql-TFN"/>
+                        <outlet property="nameLabel" destination="2DO-yc-8Qr" id="7Mi-8l-vpu"/>
+                        <outlet property="previousPriceLabel" destination="OPD-Nq-Xci" id="GWh-GQ-CZ3"/>
+                        <outlet property="priceLabel" destination="0l4-aQ-sVm" id="8cO-Zi-e8T"/>
+                        <outlet property="stockLabel" destination="Vzt-YX-XNo" id="Dp6-QC-BWt"/>
+                        <outlet property="totalPageLabel" destination="1rp-IX-fyv" id="RMw-ch-0Rc"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LXL-lL-3ui" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class AddProductViewController: UIViewController {
-    enum ProductInput {
+    private enum ProductInput {
         static var name: String?
         static var descriptions: String?
         static var price: Double?
@@ -11,7 +11,7 @@ class AddProductViewController: UIViewController {
         static var secret: String = "EE5ud*rBT9Nu38_d"
     }
     
-    enum AlertMessage {
+    private enum AlertMessage {
         static let title = "⚠️ 등록 정보 확인 ⚠️"
         static let invalidNameLength = "상품명 3자리 입력"
         static let priceMissed = "가격 필수 입력"
@@ -33,13 +33,13 @@ class AddProductViewController: UIViewController {
     @IBOutlet weak var productImageStackView: UIStackView!
     @IBOutlet weak var addImageButton: UIButton!
     
-    lazy var apiManager = APIManager.shared
-    let imagePicker = UIImagePickerController()
-    var newProductImages: [NewProductImage] = []
-    var newProductInformation: NewProductInformation?
-    var isButtonTapped = true
-    var selectedIndex = 0
-    var alertText = AlertMessage.title
+    private lazy var apiManager = APIManager.shared
+    private let imagePicker = UIImagePickerController()
+    private var newProductImages: [NewProductImage] = []
+    private var newProductInformation: NewProductInformation?
+    private var isButtonTapped = true
+    private var selectedIndex = 0
+    private var alertText = AlertMessage.title
     
     // MARK: - Life Cycle Method
     override func viewDidLoad() {
@@ -89,7 +89,7 @@ class AddProductViewController: UIViewController {
         }
     }
     
-    func initializeProductInput() {
+    private func initializeProductInput() {
         ProductInput.name = nil
         ProductInput.descriptions = nil
         ProductInput.price = nil
@@ -100,7 +100,7 @@ class AddProductViewController: UIViewController {
 
 extension AddProductViewController {
     // MARK: - Create Data To Post
-    func createNewProduct() {
+    private func createNewProduct() {
         newProductInformation = nil
         initializeProductInput()
         checkInputs()
@@ -110,7 +110,7 @@ extension AddProductViewController {
         newProductInformation = NewProductInformation(name: name, descriptions: description, price: price, discountedPrice: discountedPrice, currency: ProductInput.currency, stock: stock, secret: ProductInput.secret)
     }
     
-    func checkInputs() {
+    private func checkInputs() {
         checkProductName()
         checkProductPrice()
         checkCurrency()
@@ -119,7 +119,7 @@ extension AddProductViewController {
         checkProductDescription()
     }
     
-    func checkProductName() {
+    private func checkProductName() {
         guard let productName = productNameTextField.text, productName.count >= 3 else {
             ProductInput.name = nil
             alertText.appendWithLineBreak(contentsOf: AlertMessage.invalidNameLength)
@@ -128,7 +128,7 @@ extension AddProductViewController {
         ProductInput.name = productName
     }
     
-    func checkProductPrice() {
+    private func checkProductPrice() {
         guard let productPriceText = productPriceTextField.text, !productPriceText.isEmpty else {
             ProductInput.price = nil
             alertText.appendWithLineBreak(contentsOf: AlertMessage.priceMissed)
@@ -142,7 +142,7 @@ extension AddProductViewController {
         ProductInput.price = productPrice
     }
     
-    func checkCurrency() {
+    private func checkCurrency() {
         let selectedIndex = currencySegmentedControl.selectedSegmentIndex
         guard let currentTitle = currencySegmentedControl.titleForSegment(at: selectedIndex),
               let currency = Currency.init(unit: currentTitle)
@@ -150,7 +150,7 @@ extension AddProductViewController {
         ProductInput.currency = currency
     }
     
-    func checkDiscountPrice() {
+    private func checkDiscountPrice() {
         guard let discountPriceText = discountedPriceTextField.text, !discountPriceText.isEmpty else { return } // default 사용
         
         guard let discountPrice = Double(discountPriceText) else {
@@ -161,7 +161,7 @@ extension AddProductViewController {
         ProductInput.discountedPrice = discountPrice
     }
     
-    func checkProductStock() {
+    private func checkProductStock() {
         guard let productStockText = productStockTextField.text, !productStockText.isEmpty else { return } // default 사용
         guard let productStock = Int(productStockText) else {
             ProductInput.stock = nil
@@ -171,7 +171,7 @@ extension AddProductViewController {
         ProductInput.stock = productStock
     }
     
-    func checkProductDescription() {
+    private func checkProductDescription() {
         guard let productDescription = descriptionTextView.text,
               descriptionTextView.textColor == UIColor.black,
               productDescription.count >= 10 else {
@@ -181,7 +181,7 @@ extension AddProductViewController {
         ProductInput.descriptions = productDescription
     }
     
-    func addToProductImages() {
+    private func addToProductImages() {
         let lastTagNumber = productImageStackView.subviews.count - 1
         guard lastTagNumber >= 1 else {
             alertText.appendWithLineBreak(contentsOf: AlertMessage.imageMissed)
@@ -194,7 +194,7 @@ extension AddProductViewController {
 
     }
     
-    func getProductImageFromButton(with tag: Int) {
+    private func getProductImageFromButton(with tag: Int) {
         guard let imageButton = view.viewWithTag(tag) as? UIButton,
               let image = imageButton.imageView?.image,
               let imageData = image.jpegData(compressionQuality: 0.1) else { return }
@@ -206,12 +206,12 @@ extension AddProductViewController {
 
 extension AddProductViewController {
     // MARK: - Image Picker Alert Method
-    func showSelectImageAlert() {
+    private func showSelectImageAlert() {
         let alert = createSelectImageAlert()
         present(alert, animated: true, completion: nil)
     }
     
-    func createSelectImageAlert() -> UIAlertController {
+    private func createSelectImageAlert() -> UIAlertController {
         let alert = UIAlertController(title: "상품사진 선택", message: nil, preferredStyle: .actionSheet)
         let photoLibrary = UIAlertAction(title: "사진앨범", style: .default) { action in
             self.openPhotoLibrary()
@@ -228,12 +228,12 @@ extension AddProductViewController {
         return alert
     }
     
-    func openPhotoLibrary() {
+    private func openPhotoLibrary() {
         imagePicker.sourceType = .photoLibrary
         present(imagePicker, animated: false, completion: nil)
     }
     
-    func openCamera() {
+    private func openCamera() {
         imagePicker.sourceType = .camera
         present(imagePicker, animated: false, completion: nil)
     }
@@ -241,7 +241,7 @@ extension AddProductViewController {
 
 extension AddProductViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     // MARK: - Image Picker Delegate Method
-    func setupImagePrickerController() {
+    private func setupImagePrickerController() {
         imagePicker.delegate = self
         imagePicker.allowsEditing = true
     }
@@ -255,7 +255,7 @@ extension AddProductViewController: UIImagePickerControllerDelegate, UINavigatio
         dismiss(animated: true, completion: nil)
     }
     
-    func editProductImageStackView(with image: UIImage) {
+    private func editProductImageStackView(with image: UIImage) {
         guard isButtonTapped else {
             changeProductImage(with: image)
             return
@@ -266,12 +266,12 @@ extension AddProductViewController: UIImagePickerControllerDelegate, UINavigatio
         }
     }
     
-    func changeProductImage(with image: UIImage) {
+    private func changeProductImage(with image: UIImage) {
         guard let selectedImage = productImageStackView.subviews[selectedIndex] as? UIButton else { return }
         selectedImage.setImage(image, for: .normal)
     }
     
-    func addProductImage(with image: UIImage) {
+    private func addProductImage(with image: UIImage) {
         let button = UIButton()
         button.setImage(image, for: .normal)
         button.tag = productImageStackView.subviews.count
@@ -284,18 +284,18 @@ extension AddProductViewController: UIImagePickerControllerDelegate, UINavigatio
 }
 extension AddProductViewController {
     // MARK: - Text View Setup Method
-    func setupDescriptionTextView() {
+    private func setupDescriptionTextView() {
         setTextViewPlaceHolder()
         setTextViewOutLine()
     }
     
-    func setTextViewOutLine() {
+    private func setTextViewOutLine() {
         descriptionTextView.layer.borderWidth = 0.5
         descriptionTextView.layer.borderColor = UIColor.systemGray4.cgColor
         descriptionTextView.layer.cornerRadius = 5
     }
     
-    func setTextViewPlaceHolder() {
+    private func setTextViewPlaceHolder() {
         descriptionTextView.delegate = self
         descriptionTextView.text = "상품 설명(1,000자 이내)"
         descriptionTextView.textColor = .lightGray
@@ -327,17 +327,17 @@ extension AddProductViewController: UITextViewDelegate {
 
 extension AddProductViewController {
     // MARK: - Keyboard Notification Setup Method
-    func setupKeyboardNotification() {
+    private func setupKeyboardNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
-    func hideKeyboard() {
+    private func hideKeyboard() {
         let tapEmptySpace = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         view.addGestureRecognizer(tapEmptySpace)
     }
     
-    @objc func keyboardWillShow(_ sender: Notification) {
+    @objc private func keyboardWillShow(_ sender: Notification) {
         let userInfo: NSDictionary = sender.userInfo! as NSDictionary
         guard let keyboardFrame: NSValue = userInfo.value(forKey: UIResponder.keyboardFrameEndUserInfoKey) as? NSValue else { return }
 
@@ -346,19 +346,19 @@ extension AddProductViewController {
         scrollView.scrollIndicatorInsets = scrollView.contentInset
     }
 
-    @objc func keyboardWillHide(_ sender: Notification) {
+    @objc private func keyboardWillHide(_ sender: Notification) {
         scrollView.contentInset = .zero
         scrollView.scrollIndicatorInsets = .zero
     }
     
-    @objc func dismissKeyboard() {
+    @objc private func dismissKeyboard() {
         view.endEditing(true)
     }
 }
 
 extension AddProductViewController {
     // MARK: - Invalid Input Alert Method
-    func invalidInputAlert(with message: String) {
+    private func invalidInputAlert(with message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let close = UIAlertAction(title: "닫기", style: .cancel, handler: nil)
         alert.addAction(close)

--- a/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
@@ -40,35 +40,58 @@ class AddProductViewController: UIViewController {
     private var isButtonTapped = true
     private var selectedIndex = 0
     private var alertText = AlertMessage.title
-    
     var isEdit = false
-    var name: String?
-    var price: String?
-    var discount: String?
-    var stock: String?
-    var des: String?
     var images = [UIImage]()
     var product: ProductDetail?
     
     // MARK: - Life Cycle Method
     override func viewDidLoad() {
         super.viewDidLoad()
-        if isEdit {
-            addImageButton.isHidden = true
-            navigationController?.navigationBar.topItem?.title = "상품수정"
-        } else {
-            navigationController?.navigationBar.topItem?.title = "상품등록"
-        }
-        setupImagePrickerController()
-        setupDescriptionTextView()
         setupKeyboardNotification()
         hideKeyboard()
+        if isEdit {
+            setupEditProductView()
+        } else {
+            setupAddProductView()
+        }
+    }
+    
+    // MARK: - Setup View Method
+    private func setupAddProductView() {
+        navigationController?.navigationBar.topItem?.title = "상품등록"
+        setupImagePrickerController()
+        setupDescriptionTextView()
+    }
+    
+    private func setupEditProductView() {
+        addImageButton.isHidden = true
+        navigationController?.navigationBar.topItem?.title = "상품수정"
+        setTextViewOutLine()
+        setupEditViewWithData()
+        setupProductImageStackView()
+    }
+    
+    private func setupEditViewWithData() {
         productNameTextField.text = product?.name
         productPriceTextField.text = product?.price.description
         descriptionTextView.text = product?.description
         discountedPriceTextField.text = product?.discountedPrice.description
         productStockTextField.text = product?.stock.description
-
+        setupCurrencySegmentControl()
+    }
+    
+    func setupCurrencySegmentControl() {
+        let lastIndex = currencySegmentedControl.numberOfSegments - 1
+        for index in 0...lastIndex {
+            let currentTitle = currencySegmentedControl.titleForSegment(at: index)
+            if currentTitle == product?.currency.unit {
+                currencySegmentedControl.selectedSegmentIndex = index
+                break
+            }
+        }
+    }
+    
+    private func setupProductImageStackView() {
         images.forEach { image in
             let imageView = UIImageView(image: image)
             productImageStackView.addArrangedSubview(imageView)
@@ -79,11 +102,6 @@ class AddProductViewController: UIViewController {
     
     // MARK: - IBAction Method
     @IBAction func tapCancelButton(_ sender: UIBarButtonItem) {
-        if isEdit {
-            navigationController?.navigationBar.topItem?.title = ""
-            self.navigationController?.popViewController(animated: true)
-            
-        }
         dismiss(animated: true)
     }
     
@@ -222,7 +240,6 @@ extension AddProductViewController {
         for buttonTag in 1...lastTagNumber {
             getProductImageFromButton(with: buttonTag)
         }
-
     }
     
     private func getProductImageFromButton(with tag: Int) {
@@ -232,6 +249,14 @@ extension AddProductViewController {
         
         let productImage = NewProductImage(image: imageData)
         newProductImages.append(productImage)
+    }
+    
+    // MARK: - Invalid Input Alert Method
+    private func invalidInputAlert(with message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let close = UIAlertAction(title: "닫기", style: .cancel, handler: nil)
+        alert.addAction(close)
+        present(alert, animated: true)
     }
 }
 
@@ -316,10 +341,6 @@ extension AddProductViewController: UIImagePickerControllerDelegate, UINavigatio
 extension AddProductViewController {
     // MARK: - Text View Setup Method
     private func setupDescriptionTextView() {
-        if isEdit {
-            setTextViewOutLine()
-            return
-        }
         setTextViewPlaceHolder()
         setTextViewOutLine()
     }
@@ -391,12 +412,3 @@ extension AddProductViewController {
     }
 }
 
-extension AddProductViewController {
-    // MARK: - Invalid Input Alert Method
-    private func invalidInputAlert(with message: String) {
-        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let close = UIAlertAction(title: "닫기", style: .cancel, handler: nil)
-        alert.addAction(close)
-        present(alert, animated: true)
-    }
-}

--- a/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
@@ -80,7 +80,7 @@ class AddProductViewController: UIViewController {
         setupCurrencySegmentControl()
     }
     
-    func setupCurrencySegmentControl() {
+    private func setupCurrencySegmentControl() {
         let lastIndex = currencySegmentedControl.numberOfSegments - 1
         for index in 0...lastIndex {
             let currentTitle = currencySegmentedControl.titleForSegment(at: index)
@@ -137,10 +137,9 @@ class AddProductViewController: UIViewController {
         apiManager.editProduct(id: id, product: information) { result in
             switch result {
             case .success(_):
+                NotificationCenter.default.post(name: NSNotification.Name("UpdateView"), object: nil)
                 DispatchQueue.main.async {
-                    self.dismiss(animated: true) {
-                        NotificationCenter.default.post(name: NSNotification.Name("UpdateView"), object: nil)
-                    }
+                    self.dismiss(animated: true, completion: nil)
                 }
             case .failure(let error):
                 print(error.localizedDescription)
@@ -153,10 +152,9 @@ class AddProductViewController: UIViewController {
             switch result {
             case .success(let data):
                 print("\(data.name) post 성공")
+                NotificationCenter.default.post(name: NSNotification.Name("UpdateView"), object: nil)
                 DispatchQueue.main.async {
-                    self.dismiss(animated: true) {
-                        NotificationCenter.default.post(name: NSNotification.Name("UpdateView"), object: nil)
-                    }
+                    self.dismiss(animated: true, completion: nil)
                 }
             case .failure(let error):
                 print(error.localizedDescription)

--- a/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
@@ -411,4 +411,3 @@ extension AddProductViewController {
         view.endEditing(true)
     }
 }
-

--- a/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
@@ -41,18 +41,49 @@ class AddProductViewController: UIViewController {
     private var selectedIndex = 0
     private var alertText = AlertMessage.title
     
+    var isEdit = false
+    var name: String?
+    var price: String?
+    var discount: String?
+    var stock: String?
+    var des: String?
+    var images = [UIImage]()
+    var product: ProductDetail?
+    
     // MARK: - Life Cycle Method
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationController?.navigationBar.topItem?.title = "상품등록"
+        if isEdit {
+            addImageButton.isHidden = true
+            navigationController?.navigationBar.topItem?.title = "상품수정"
+        } else {
+            navigationController?.navigationBar.topItem?.title = "상품등록"
+        }
         setupImagePrickerController()
         setupDescriptionTextView()
         setupKeyboardNotification()
         hideKeyboard()
+        productNameTextField.text = product?.name
+        productPriceTextField.text = product?.price.description
+        descriptionTextView.text = product?.description
+        discountedPriceTextField.text = product?.discountedPrice.description
+        productStockTextField.text = product?.stock.description
+
+        images.forEach { image in
+            let imageView = UIImageView(image: image)
+            productImageStackView.addArrangedSubview(imageView)
+            imageView.heightAnchor.constraint(equalTo: productImageStackView.heightAnchor).isActive = true
+            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor).isActive = true
+        }
     }
     
     // MARK: - IBAction Method
     @IBAction func tapCancelButton(_ sender: UIBarButtonItem) {
+        if isEdit {
+            navigationController?.navigationBar.topItem?.title = ""
+            self.navigationController?.popViewController(animated: true)
+            
+        }
         dismiss(animated: true)
     }
     
@@ -285,6 +316,10 @@ extension AddProductViewController: UIImagePickerControllerDelegate, UINavigatio
 extension AddProductViewController {
     // MARK: - Text View Setup Method
     private func setupDescriptionTextView() {
+        if isEdit {
+            setTextViewOutLine()
+            return
+        }
         setTextViewPlaceHolder()
         setTextViewOutLine()
     }

--- a/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/AddProductViewController.swift
@@ -6,7 +6,7 @@ class AddProductViewController: UIViewController {
         static var descriptions: String?
         static var price: Double?
         static var discountedPrice: Double? = 0
-        static var currency: Currency = Currency.KRW
+        static var currency: Currency = Currency.krw
         static var stock: Int? = 0
         static var secret: String = "EE5ud*rBT9Nu38_d"
     }

--- a/OpenMarket/OpenMarket/Controller/OpenMarketViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/OpenMarketViewController.swift
@@ -1,10 +1,10 @@
 import UIKit
 
+enum Section {
+    case main
+}
+
 class OpenMarketViewController: UIViewController {
-    
-    enum Section {
-        case main
-    }
     
     @IBOutlet weak var segmentedControl: UISegmentedControl!
     private let apiManager = APIManager.shared

--- a/OpenMarket/OpenMarket/Controller/OpenMarketViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/OpenMarketViewController.swift
@@ -5,7 +5,7 @@ enum Section {
 }
 
 class OpenMarketViewController: UIViewController {
-    
+    // MARK: - Property
     @IBOutlet weak var segmentedControl: UISegmentedControl!
     private let apiManager = APIManager.shared
     private let listCollectionView = UICollectionView(frame: .zero, collectionViewLayout: OpenMarketViewLayout.list)
@@ -13,6 +13,7 @@ class OpenMarketViewController: UIViewController {
     private var listDataSource: UICollectionViewDiffableDataSource<Section, ProductDetail>?
     private var gridDataSource: UICollectionViewDiffableDataSource<Section, ProductDetail>?
     
+    // MARK: - Life Cycle Method
     override func loadView() {
         view = listCollectionView
     }
@@ -29,15 +30,29 @@ class OpenMarketViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(updateMainView), name: NSNotification.Name("UpdateView"), object: nil)
     }
     
-    @objc func updateMainView() {
+    // MARK: - Setup View Method
+    @objc private func updateMainView() {
         getProducts()
     }
     
+    @IBAction func segementChanged(_ sender: UISegmentedControl) {
+        switch sender.selectedSegmentIndex {
+        case 0:
+            view = listCollectionView
+        case 1:
+            view = gridCollectionView
+        default:
+            return
+        }
+    }
+    
+    // MARK: - Setup UI Method
     private func setupSegmentedControl() {
         segmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.systemBlue], for: .normal)
         segmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: .selected)
     }
     
+    // MARK: - Setup Colllection View Method
     private func registerCollectionViewCell() {
         listCollectionView.register(UINib(nibName: String(describing: ProductListCell.self), bundle: nil), forCellWithReuseIdentifier: ProductListCell.identifier)
         gridCollectionView.register(UINib(nibName: String(describing: ProductGridCell.self), bundle: nil), forCellWithReuseIdentifier: ProductGridCell.identifier)
@@ -83,21 +98,10 @@ class OpenMarketViewController: UIViewController {
         listDataSource?.apply(snapshot)
         gridDataSource?.apply(snapshot)
     }
-    
-    @IBAction func segementChanged(_ sender: UISegmentedControl) {
-        switch sender.selectedSegmentIndex {
-        case 0:
-            view = listCollectionView
-        case 1:
-            view = gridCollectionView
-        default:
-            return
-        }
-    }
-    
 }
 
 extension OpenMarketViewController: UICollectionViewDelegate {
+    // MARK: - Setup Segue Method
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) else { return }
         performSegue(withIdentifier: "ShowProductDetail", sender: cell)

--- a/OpenMarket/OpenMarket/Controller/OpenMarketViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/OpenMarketViewController.swift
@@ -26,6 +26,11 @@ class OpenMarketViewController: UIViewController {
         setupListCollectionView()
         setupGridCollectionView()
         getProducts()
+        NotificationCenter.default.addObserver(self, selector: #selector(updateMainView), name: NSNotification.Name("UpdateView"), object: nil)
+    }
+    
+    @objc func updateMainView() {
+        getProducts()
     }
     
     private func setupSegmentedControl() {

--- a/OpenMarket/OpenMarket/Controller/OpenMarketViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/OpenMarketViewController.swift
@@ -19,6 +19,8 @@ class OpenMarketViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        listCollectionView.delegate = self
+        gridCollectionView.delegate = self
         setupSegmentedControl()
         registerCollectionViewCell()
         setupListCollectionView()
@@ -88,4 +90,21 @@ class OpenMarketViewController: UIViewController {
         }
     }
     
+}
+
+extension OpenMarketViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) else { return }
+        performSegue(withIdentifier: "ShowProductDetail", sender: cell)
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let destination = segue.destination as? ProductDetailViewController else { return }
+        if let senderCell = sender as? ProductListCell {
+            destination.productID = senderCell.productID
+        }
+        if let senderCell = sender as? ProductGridCell {
+            destination.productID = senderCell.productID
+        }
+    }
 }

--- a/OpenMarket/OpenMarket/Controller/OpenMarketViewLayout.swift
+++ b/OpenMarket/OpenMarket/Controller/OpenMarketViewLayout.swift
@@ -18,5 +18,13 @@ struct OpenMarketViewLayout {
         return layout
     }()
     
+    static let productImages: UICollectionViewFlowLayout = {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumLineSpacing = 0
+        layout.minimumInteritemSpacing = 0
+        layout.scrollDirection = .horizontal
+        return layout
+    }()
+    
 
 }

--- a/OpenMarket/OpenMarket/Controller/OpenMarketViewLayout.swift
+++ b/OpenMarket/OpenMarket/Controller/OpenMarketViewLayout.swift
@@ -26,5 +26,4 @@ struct OpenMarketViewLayout {
         return layout
     }()
     
-
 }

--- a/OpenMarket/OpenMarket/Controller/OpenMarketViewLayout.swift
+++ b/OpenMarket/OpenMarket/Controller/OpenMarketViewLayout.swift
@@ -18,4 +18,5 @@ struct OpenMarketViewLayout {
         return layout
     }()
     
+
 }

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -24,6 +24,11 @@ class ProductDetailViewController: UIViewController {
         getProductSecret()
         getProductDetail()
         setupImageCollectionView()
+        NotificationCenter.default.addObserver(self, selector: #selector(updateDetailView), name: NSNotification.Name("UpdateView"), object: nil)
+    }
+    
+    @objc func updateDetailView() {
+        getProductDetail()
     }
     
     @IBAction func tapEditDeleteButton(_ sender: Any) {
@@ -37,9 +42,8 @@ class ProductDetailViewController: UIViewController {
             switch result {
             case .success(let data):
                 self.secret = String(decoding: data, as: UTF8.self)
-            case .failure(let error):
+            case .failure(_):
                 DispatchQueue.main.async {
-                    print(error)
                     self.navigationItem.rightBarButtonItem = nil
                 }
             }
@@ -85,7 +89,6 @@ class ProductDetailViewController: UIViewController {
         setupPriceLabel(with: product)
         setupDescriptionTextView(with: product)
         populate(with: productImages)
-        
     }
     
     private func setupTotalPageLabel(with productImages: [Image]) {

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -11,10 +11,10 @@ class ProductDetailViewController: UIViewController {
     @IBOutlet weak var priceLabel: UILabel!
     @IBOutlet weak var descriptionTextView: UITextView!
     
+    private let apiManager = APIManager.shared
+    private var imageDataSource: UICollectionViewDiffableDataSource<Section, Image>?
     var productImages = [UIImage]()
     var productDetail: ProductDetail?
-    let apiManager = APIManager.shared
-    private var imageDataSource: UICollectionViewDiffableDataSource<Section, Image>?
     var productID: Int?
 
     // MARK: - Life Cycle Method
@@ -24,16 +24,9 @@ class ProductDetailViewController: UIViewController {
         getProductDetail()
     }
     
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        guard let navigationController = segue.destination as? UINavigationController else { return }
-        let destination = navigationController.topViewController as? AddProductViewController
-        destination?.isEdit = true
-        destination?.images = productImages
-        destination?.product = productDetail
-    }
-    
-    @IBAction func edit(_ sender: Any) {
-        performSegue(withIdentifier: "edit", sender: nil)
+    @IBAction func tapEditDeleteButton(_ sender: Any) {
+        let alert = createAlert()
+        present(alert, animated: true, completion: nil)
     }
     
     // MARK: - Setup CollectionView Method
@@ -42,6 +35,7 @@ class ProductDetailViewController: UIViewController {
         imageCollectionView.delegate = self
         imageCollectionView.decelerationRate = .fast
         imageCollectionView.isPagingEnabled = true
+        imageCollectionView.showsHorizontalScrollIndicator = false
         setupImageCollectionViewDataSource()
     }
     
@@ -156,4 +150,32 @@ extension ProductDetailViewController: UICollectionViewDelegate {
         let currentPage = Int(scrollView.contentOffset.x) / Int(scrollView.frame.width) + 1
         currentPageLabel.text = String(currentPage)
     }
+}
+
+extension ProductDetailViewController {
+    private func createAlert() -> UIAlertController {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let edit = UIAlertAction(title: "수정", style: .default) { action in
+            self.performSegue(withIdentifier: "edit", sender: nil)
+        }
+        let delete = UIAlertAction(title: "삭제", style: .destructive) { action in
+            
+        }
+        let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+        
+        alert.addAction(edit)
+        alert.addAction(delete)
+        alert.addAction(cancel)
+        
+        return alert
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let navigationController = segue.destination as? UINavigationController else { return }
+        let destination = navigationController.topViewController as? AddProductViewController
+        destination?.isEdit = true
+        destination?.images = productImages
+        destination?.product = productDetail
+    }
+    
 }

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -2,11 +2,73 @@ import UIKit
 
 class ProductDetailViewController: UIViewController {
 
+    let apiManager = APIManager.shared
     var productID: Int?
     
+    @IBOutlet weak var imageCollectionView: UICollectionView!
+    @IBOutlet weak var currentPageLabel: UILabel!
+    @IBOutlet weak var totalPageLabel: UILabel!
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var stockLabel: UILabel!
+    @IBOutlet weak var previousPriceLabel: UILabel!
+    @IBOutlet weak var priceLabel: UILabel!
+    @IBOutlet weak var descriptionTextView: UITextView!
+        
     override func viewDidLoad() {
         super.viewDidLoad()
-        print(productID)
+        getProductDetail()
+    }
+    
+    private func getProductDetail() {
+        guard let productID = productID else { return }
+        apiManager.checkProductDetail(id: productID) { result in
+            switch result {
+            case .success(let product):
+                DispatchQueue.main.async {
+                    self.setup(with: product)
+                }
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
+    private func setup(with product: ProductDetail) {
+        setupNameLabel(with: product)
+        setupStockLabel(with: product)
+        setupPriceLabel(with: product)
+        setupDescriptionTextView(with: product)
+    }
+    
+    private func setupNameLabel(with product: ProductDetail) {
+        nameLabel.text = product.name
+    }
+    
+    private func setupStockLabel(with product: ProductDetail) {
+        if product.stock == 0 {
+            stockLabel.textColor = .systemOrange
+            stockLabel.text = LabelString.outOfStock
+        } else {
+            stockLabel.textColor = .systemGray
+            stockLabel.text = LabelString.stockTitle + String(product.stock.addComma())
+        }
+    }
+    
+    private func setupPriceLabel(with product: ProductDetail) {
+        let currentPriceText = product.currency.unit + StringSeparator.blank + String(product.price.addComma())
+        if product.discountedPrice == 0 {
+            previousPriceLabel.isHidden = true
+            priceLabel.text = currentPriceText
+        } else {
+            let previousPrice = currentPriceText.strikeThrough()
+            let bargainPriceText = StringSeparator.doubleBlank + product.currency.unit + StringSeparator.blank + String(product.bargainPrice.addComma())
+            previousPriceLabel.attributedText = previousPrice
+            priceLabel.text = bargainPriceText
+        }
+    }
+    
+    private func setupDescriptionTextView(with product: ProductDetail) {
+        descriptionTextView.text = product.description ?? ""
     }
     
 }

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+class ProductDetailViewController: UIViewController {
+
+    var productID: Int?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print(productID)
+    }
+    
+}

--- a/OpenMarket/OpenMarket/CustomCell/ProductGridCell.swift
+++ b/OpenMarket/OpenMarket/CustomCell/ProductGridCell.swift
@@ -8,6 +8,7 @@ class ProductGridCell: UICollectionViewCell {
     @IBOutlet weak var gridStockLabel: UILabel!
     
     static let identifier = "GridCell"
+    var productID: Int?
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -20,6 +21,7 @@ class ProductGridCell: UICollectionViewCell {
     }
     
     func setup(with product: ProductDetail) {
+        productID = product.id
         setupImage(with: product)
         setupNameLabel(with: product)
         setupPriceLabel(with: product)

--- a/OpenMarket/OpenMarket/CustomCell/ProductImageCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/CustomCell/ProductImageCollectionViewCell.swift
@@ -11,6 +11,8 @@ class ProductImageCollectionViewCell: UICollectionViewCell {
     
     @IBOutlet weak var productImageView: UIImageView!
     
+    static let identifier = "ProductImageCell"
+    
     func setupImage(with productImage: Image) {
         guard let imageURL = URL(string: productImage.url) else { return }
         URLSession.shared.dataTask(with: imageURL) { data, _, _ in

--- a/OpenMarket/OpenMarket/CustomCell/ProductImageCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/CustomCell/ProductImageCollectionViewCell.swift
@@ -1,0 +1,24 @@
+//
+//  ProductImageCollectionViewCell.swift
+//  OpenMarket
+//
+//  Created by Siwon Kim on 2022/01/27.
+//
+
+import UIKit
+
+class ProductImageCollectionViewCell: UICollectionViewCell {
+    
+    @IBOutlet weak var productImageView: UIImageView!
+    
+    func setupImage(with productImage: Image) {
+        guard let imageURL = URL(string: productImage.url) else { return }
+        URLSession.shared.dataTask(with: imageURL) { data, _, _ in
+            let image = UIImage(data: data!)!
+            DispatchQueue.main.async {
+                self.productImageView.image = image
+            }
+            
+        }.resume()
+    }
+}

--- a/OpenMarket/OpenMarket/CustomCell/ProductImageCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/CustomCell/ProductImageCollectionViewCell.swift
@@ -20,7 +20,6 @@ class ProductImageCollectionViewCell: UICollectionViewCell {
             DispatchQueue.main.async {
                 self.productImageView.image = image
             }
-            
         }.resume()
     }
 }

--- a/OpenMarket/OpenMarket/CustomCell/ProductListCell.swift
+++ b/OpenMarket/OpenMarket/CustomCell/ProductListCell.swift
@@ -8,12 +8,14 @@ class ProductListCell: UICollectionViewListCell {
     @IBOutlet var stockLabel: UILabel!
     
     static let identifier = "ListCell"
+    var productID: Int?
     
     override func awakeFromNib() {
         super.awakeFromNib()
     }
     
     func setup(with product: ProductDetail) {
+        productID = product.id
         setupImage(with: product)
         setupNameLabel(with: product)
         setupPriceLabel(with: product)

--- a/OpenMarket/OpenMarket/Extensions/String+extension.swift
+++ b/OpenMarket/OpenMarket/Extensions/String+extension.swift
@@ -14,4 +14,3 @@ extension String {
         self.append(contentsOf: string)
     }
 }
-

--- a/OpenMarket/OpenMarket/Model/APIManager.swift
+++ b/OpenMarket/OpenMarket/Model/APIManager.swift
@@ -7,6 +7,7 @@ class APIManager {
     static let shared = APIManager()
     let boundary = "Boundary-\(UUID().uuidString)"
     let urlSession: URLSessionProtocol
+    let vendorSecret = VendorSecret()
 
     init(urlSession: URLSessionProtocol = URLSession.shared) {
         self.urlSession = urlSession
@@ -15,37 +16,19 @@ class APIManager {
     func checkAPIHealth(completion: @escaping (Result<Data, Error>) -> Void) {
         guard let url = URLManager.healthChecker.url else { return }
         let request = URLRequest(url: url, method: .get)
-        let task = urlSession.dataTask(with: request) { data, response, error in
-            if let httpResponse = response as? HTTPURLResponse,
-               httpResponse.statusCode >= 300 {
-                completion(.failure(URLSessionError.responseFailed(code: httpResponse.statusCode)))
-                return
-            }
-            
-            if let error = error {
-                completion(.failure(URLSessionError.requestFailed(description: error.localizedDescription)))
-                return
-            }
-            
-            guard let data = data else {
-                completion(.failure(URLSessionError.invaildData))
-                return
-            }
-            completion(.success(data))
-        }
-        task.resume()
+        createDataTask(with: request, completion: completion)
     }
     
     func checkProductDetail(id: Int, completion: @escaping (Result<ProductDetail, Error>) -> Void) {
         guard let url = URLManager.checkProductDetail(id: id).url else { return }
         let request = URLRequest(url: url, method: .get)
-        createDataTask(with: request, completion: completion)
+        createDataTaskWithDecoding(with: request, completion: completion)
     }
     
     func checkProductList(pageNumber: Int, itemsPerPage: Int, completion: @escaping (Result<ProductList, Error>) -> Void) {
         guard let url = URLManager.checkProductList(pageNumber: pageNumber, itemsPerPage: itemsPerPage).url else { return }
         let request = URLRequest(url: url, method: .get)
-        createDataTask(with: request, completion: completion)
+        createDataTaskWithDecoding(with: request, completion: completion)
     }
     
 }
@@ -53,17 +36,12 @@ class APIManager {
 extension APIManager {
     
     func addProduct(information: NewProductInformation, images: [NewProductImage], completion: @escaping (Result<ProductDetail, Error>) -> Void) {
-        guard let request = createPostURLRequest(product: information, images: images) else { return }
-        createDataTask(with: request, completion: completion)
-    }
-    
-    func createPostURLRequest(product: NewProductInformation, images: [NewProductImage]) -> URLRequest? {
-        guard let url = URLManager.addNewProduct.url else { return nil }
+        guard let url = URLManager.addNewProduct.url else { return }
         var request = URLRequest(url: url, method: .post)
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.addValue("819efbc3-71fc-11ec-abfa-dd40b1881f4c", forHTTPHeaderField: "identifier")
-        request.httpBody = createRequestBody(product: product, images: images)
-        return request
+        request.httpBody = createRequestBody(product: information, images: images)
+        createDataTaskWithDecoding(with: request, completion: completion)
     }
     
     func createRequestBody(product: NewProductInformation, images: [NewProductImage]) -> Data {
@@ -109,7 +87,26 @@ extension APIManager {
 
 extension APIManager {
     
-    func createDataTask<T: Decodable>(with request: URLRequest, completion: @escaping (Result<T, Error>) -> Void) {
+    func deleteProduct(id: Int, secret: String, completion: @escaping (Result<ProductDetail, Error>) -> Void) {
+        guard let url = URLManager.deleteProduct(id: id, secret: secret).url else { return }
+        var request = URLRequest(url: url, method: .delete)
+        request.addValue("819efbc3-71fc-11ec-abfa-dd40b1881f4c", forHTTPHeaderField: "identifier")
+        createDataTaskWithDecoding(with: request, completion: completion)
+    }
+    
+    func checkProductSecret(id: Int, completion: @escaping (Result<Data, Error>) -> Void) {
+        guard let url = URLManager.checkProductSecret(id: id).url else { return }
+        var request = URLRequest(url: url, method: .post)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("819efbc3-71fc-11ec-abfa-dd40b1881f4c", forHTTPHeaderField: "identifier")
+        request.httpBody = JSONParser.encodeToData(with: vendorSecret)
+        createDataTask(with: request, completion: completion)
+    }
+}
+
+extension APIManager {
+    
+    func createDataTaskWithDecoding<T: Decodable>(with request: URLRequest, completion: @escaping (Result<T, Error>) -> Void) {
         let task = urlSession.dataTask(with: request) { data, response, error in
             if let httpResponse = response as? HTTPURLResponse,
                httpResponse.statusCode >= 300 {
@@ -135,4 +132,33 @@ extension APIManager {
         task.resume()
     }
     
+    func createDataTask(with request: URLRequest, completion: @escaping (Result<Data, Error>) -> Void) {
+        let task = urlSession.dataTask(with: request) { data, response, error in
+            if let httpResponse = response as? HTTPURLResponse,
+               httpResponse.statusCode >= 300 {
+                completion(.failure(URLSessionError.responseFailed(code: httpResponse.statusCode)))
+                return
+            }
+            
+            if let error = error {
+                completion(.failure(URLSessionError.requestFailed(description: error.localizedDescription)))
+                return
+            }
+            
+            guard let data = data else {
+                completion(.failure(URLSessionError.invaildData))
+                return
+            }
+
+            completion(.success(data))
+        }
+        task.resume()
+    }
+    
+}
+
+extension APIManager {
+    struct VendorSecret: Codable {
+        var secret: String = "EE5ud*rBT9Nu38_d"
+    }
 }

--- a/OpenMarket/OpenMarket/Model/APIManager.swift
+++ b/OpenMarket/OpenMarket/Model/APIManager.swift
@@ -44,6 +44,15 @@ extension APIManager {
         createDataTaskWithDecoding(with: request, completion: completion)
     }
     
+    func editProduct(id: Int, product: NewProductInformation, completion: @escaping (Result<Data, Error>) -> Void) {
+        guard let url = URLManager.checkProductDetail(id: id).url else { return }
+        var request = URLRequest(url: url, method: .patch)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("819efbc3-71fc-11ec-abfa-dd40b1881f4c", forHTTPHeaderField: "identifier")
+        request.httpBody = JSONParser.encodeToData(with: product)
+        createDataTask(with: request, completion: completion)
+    }
+    
     func createRequestBody(product: NewProductInformation, images: [NewProductImage]) -> Data {
         let parameters = createParams(with: product)
         let dataBody = createMultiPartFormData(with: parameters, images: images)

--- a/OpenMarket/OpenMarket/Model/JSONModel/Currency.swift
+++ b/OpenMarket/OpenMarket/Model/JSONModel/Currency.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 enum Currency: String, Codable {
-    case KRW
-    case USD
+    case krw = "KRW"
+    case usd = "USD"
     
     init?(unit: String) {
         self.init(rawValue: unit)

--- a/OpenMarket/OpenMarket/Model/JSONModel/NewProductInformation.swift
+++ b/OpenMarket/OpenMarket/Model/JSONModel/NewProductInformation.swift
@@ -9,7 +9,7 @@ struct NewProductInformation: Codable {
     let stock: Int
     let secret: String
     
-    init(name: String, descriptions: String, price: Double, discountedPrice: Double = 0, currency: Currency, stock: Int = 0, secret: String = "q?QZnt6zztVyw-NA") {
+    init(name: String, descriptions: String, price: Double, discountedPrice: Double = 0, currency: Currency, stock: Int = 0, secret: String = "EE5ud*rBT9Nu38_d") {
          self.name = name
          self.descriptions = descriptions
          self.price = price

--- a/OpenMarket/OpenMarket/Model/JSONModel/ProductDetail.swift
+++ b/OpenMarket/OpenMarket/Model/JSONModel/ProductDetail.swift
@@ -3,6 +3,7 @@ import Foundation
 struct ProductDetail: Codable, Hashable {
     let id, vendorID: Int
     let name: String
+    let description: String?
     let thumbnail: Data
     let currency: Currency
     let price, bargainPrice, discountedPrice: Double
@@ -14,7 +15,7 @@ struct ProductDetail: Codable, Hashable {
     enum CodingKeys: String, CodingKey {
         case id
         case vendorID = "vendor_id"
-        case name, thumbnail, currency, price
+        case name, description, thumbnail, currency, price
         case bargainPrice = "bargain_price"
         case discountedPrice = "discounted_price"
         case stock

--- a/OpenMarket/OpenMarket/Model/JSONParser.swift
+++ b/OpenMarket/OpenMarket/Model/JSONParser.swift
@@ -46,5 +46,18 @@ enum JSONParser {
 
         return dataString
     }
+    
+    static func encodeToData<T: Encodable>(with modelData: T) -> Data? {
+        let encoder = JSONEncoder()
+        
+        var data: Data?
+        do {
+            data = try encoder.encode(modelData)
+        } catch let error as NSError {
+            NSLog("Error in read(from:ofType:) domain= \(error.domain), description= \(error.localizedDescription)")
+        }
+        
+        return data
+    }
 
 }

--- a/OpenMarket/OpenMarket/Model/URLManager.swift
+++ b/OpenMarket/OpenMarket/Model/URLManager.swift
@@ -7,6 +7,8 @@ enum URLManager {
     case checkProductDetail(id: Int)
     case checkProductList(pageNumber: Int, itemsPerPage: Int)
     case addNewProduct
+    case deleteProduct(id: Int, secret: String)
+    case checkProductSecret(id: Int)
     
     var url: URL? {
         switch self {
@@ -22,6 +24,10 @@ enum URLManager {
             return components?.url
         case .addNewProduct:
             return URL(string: URLManager.apiHost + "api/products")
+        case .deleteProduct(let id, let secret):
+            return URL(string: URLManager.apiHost + "api/products/" + "\(id)/" + "\(secret)")
+        case .checkProductSecret(let id):
+            return URL(string: URLManager.apiHost + "api/products/" + "\(id)/" + "secret")
         }
     }
     

--- a/OpenMarket/OpenMarket/Model/URLManager.swift
+++ b/OpenMarket/OpenMarket/Model/URLManager.swift
@@ -4,7 +4,7 @@ enum URLManager {
     
     static let apiHost: String = "https://market-training.yagom-academy.kr/"
     case healthChecker
-    case checkProductDetail(id: Int)
+    case editOrCheckProductDetail(id: Int)
     case checkProductList(pageNumber: Int, itemsPerPage: Int)
     case addNewProduct
     case deleteProduct(id: Int, secret: String)
@@ -14,7 +14,7 @@ enum URLManager {
         switch self {
         case .healthChecker:
             return URL(string: URLManager.apiHost + "healthChecker")
-        case .checkProductDetail(let id):
+        case .editOrCheckProductDetail(let id):
             return URL(string: URLManager.apiHost + "api/products/" + "\(id)")
         case .checkProductList(let pageNumber, let itemsPerPage):
             var components = URLComponents(string: URLManager.apiHost + "api/products")


### PR DESCRIPTION
안녕하세요. 쿠마! @leejun6694
아샌(@ICS-Asan), 제인(@siwonkim0) 입니다. 
구현이 어려운 부분이 많아서 말씀드린 일정보다 조금 늦었지만,,  마지막 STEP2 리뷰도 잘 부탁드립니다 😄
작은 부분이라도 피드백 주시면 같이 고민하면서 피드백을 반영하여 코드를 개선할 수 있도록 하겠습니다!!
감사합니다!!

## 💻  주요 구현 내용

### < APIManager >

- 수정, 삭제 기능 구현을 위한 editProduct, deleteProduct, checkProductSecret 메서드 구현
- 수정 기능의 경우 상품 id를 받아서 URL을 만들고, application/json 타입으로 patch하는 방법으로 구현
- 삭제 기능의 경우 상품 id로 상품와 vendorSecret을 통해 secret 키를 가져온 후 id와 secret으로 URL을 만들어 delete하는 방법으로 구현
- 네트워킹의 결과로 받아온 Data를 디코딩하는 경우와 하지않는 경우를 구분하여 DataTask 생성 메서드를 구현
- 삭제 기능을 구현할 때 secret을 JSON타입으로 보내기 위해 VendorSecret 타입 구현

### < ProductDetailViewController >

- getProductSecret() 으로 사용자의 벤더 secret으로 상품 secret 키를 가져오는데 성공하면 네비게이션바의 수정/삭제 버튼을 보여주고, 그렇지 않으면 숨겨서 자신이 올린 상품만 수정 및 삭제 할 수 있게 구현
- getProductDetail() 로 상품 secret 키를 이용하여 상품 상세정보를 받아서 뷰를 업데이트함
- 수정 버튼을 누르면 AddProductViewController 화면전환 : 연결해놓은 segue를 타며 prepare 메서드가 실행되며 상품의 상세정보 데이터 전달
- 삭제 버튼을 누르면 상품이 삭제되며 화면이 dismiss되기전에 NotificationCenter post를 보내서 메인 뷰 업데이트

### <  AddProductViewController >

- 기존의 상품등록 기능을 구현한 뷰컨트롤러에 상품 수정 기능 추가 구현
- 상품 수정으로 뷰 전환시 받아온 product데이터를 사용하여 내용을 구현
- 기존 구현해두었던 입력값 검증 방식을 수정시에도 적용되도록 사용
- 수정/등록 시 NotificationCenter를 통해 다른 뷰를 업데이트 할 수 있도록 post를 보냄

## 💡   조언 받고 싶은 내용

### < 상속 혹은 프로토콜 기본구현을 통해 (수정/등록 과정의) 공통기능 구현 >

> STEP1의 핵심경험에서 제목과 같은 내용을 보고 STEP2를 진행하면서 구현을 해보려고 하였습니다.
저희가 기존에 상속과 프로토콜 기본구현을 배우기는 했지만 완벽하지 않은 상태에서 ViewController에 적용을 하려고 하니 어려운 부분이 많아서 구현을 하지 못했습니다.
구현을 위해 공부를 해보니 Storyboard를 사용하지 않고 코드로 MainViewController에 구현하여 해당 뷰컨을 상속받는 각각의 뷰컨을 만들어 사용하는 방법이 있었습니다.
그리고 새로운 뷰컨 안의 contents view에 기존에 만들어 둔 뷰컨을 불러와 채우는 방법도 있었습니다.
하지만 정확히 구현하는 방법이 이해가 가지 않았고 저희의 코드에 어떻게 적용할 수 있을지 고민을 해보았지만 떠오르지가 않았습니다.
저희가 이미 너무 많은 코드를 작성해버려서 어려워진 것인지 방법이 있지만 저희가 찾아내지 못한것인지 궁금합니다.
그리고 이러한 경우에 코드 구현을 어떻게 시작하는 것이 좋은지 어떠한 방법을 통해 핵심경험과 같은 코드를 구현할 수 있는지 조언을 구하고 싶습니다.
>

일정에 맞춰 구현을 하느라 깊게 고민하지 못하고 프로젝트를 진행하게 된 것 같습니다.
세세하게 놓친 부분도 많고 부족한 부분도 많겠지만 좋게 봐주시고 피드백을 주시면 저희가 더 열심히 공부해서 개선할 수 있도록 하겠습니다.
감사합니다!!