### PR TITLE
오픈마켓 I [STEP 2] Lingo, 쿼카

### DIFF
--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		AB56FB45283496B1009E6DC0 /* ProductConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB56FB44283496B1009E6DC0 /* ProductConstant.swift */; };
 		AB6E6BF8282A4C5600431717 /* APIResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF7282A4C5600431717 /* APIResponse.swift */; };
 		AB6E6BFA282A4E4A00431717 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF9282A4E4A00431717 /* Product.swift */; };
+		AB9B4DFF28367E0F007C4205 /* EmptyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9B4DFE28367E0F007C4205 /* EmptyCollectionViewCell.swift */; };
 		ABF6011B28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */; };
 		ABF6011E283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF6011D283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift */; };
 		B00E3C5F282BDA2B006AB0AC /* URLSession+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */; };
@@ -52,6 +53,7 @@
 		AB56FB44283496B1009E6DC0 /* ProductConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductConstant.swift; sourceTree = "<group>"; };
 		AB6E6BF7282A4C5600431717 /* APIResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponse.swift; sourceTree = "<group>"; };
 		AB6E6BF9282A4E4A00431717 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
+		AB9B4DFE28367E0F007C4205 /* EmptyCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCollectionViewCell.swift; sourceTree = "<group>"; };
 		ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductGridCollectionViewCell.swift; sourceTree = "<group>"; };
 		ABF6011D283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Extension.swift"; sourceTree = "<group>"; };
 		B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Extension.swift"; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 			isa = PBXGroup;
 			children = (
 				AB56FB44283496B1009E6DC0 /* ProductConstant.swift */,
+				AB9B4DFE28367E0F007C4205 /* EmptyCollectionViewCell.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -404,6 +407,7 @@
 				AB56FB45283496B1009E6DC0 /* ProductConstant.swift in Sources */,
 				ABF6011E283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift in Sources */,
 				AB56FB4228339687009E6DC0 /* UILabel+Extension.swift in Sources */,
+				AB9B4DFF28367E0F007C4205 /* EmptyCollectionViewCell.swift in Sources */,
 				B0A408DD282B933C00A388FA /* NetworkService.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,
 			);

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		B0A408E3282BA5F200A388FA /* APINetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A408E2282BA5F200A388FA /* APINetworkError.swift */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
 		C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */; };
-		C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FE25BEF61C00C9924E /* ViewController.swift */; };
+		C70FB0FF25BEF61C00C9924E /* ProductListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FE25BEF61C00C9924E /* ProductListViewController.swift */; };
 		C70FB10425BEF61D00C9924E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C70FB10325BEF61D00C9924E /* Assets.xcassets */; };
 		C70FB10725BEF61D00C9924E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C70FB10525BEF61D00C9924E /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -54,7 +54,7 @@
 		C70FB0F725BEF61C00C9924E /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C70FB0FE25BEF61C00C9924E /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C70FB0FE25BEF61C00C9924E /* ProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListViewController.swift; sourceTree = "<group>"; };
 		C70FB10325BEF61D00C9924E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C70FB10625BEF61D00C9924E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C70FB10825BEF61D00C9924E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -127,7 +127,7 @@
 		B029449A282A09CF00B9828F /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				C70FB0FE25BEF61C00C9924E /* ViewController.swift */,
+				C70FB0FE25BEF61C00C9924E /* ProductListViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -350,7 +350,7 @@
 			files = (
 				B0A408DF282B945D00A388FA /* APINetworkService.swift in Sources */,
 				B0A408E3282BA5F200A388FA /* APINetworkError.swift in Sources */,
-				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
+				C70FB0FF25BEF61C00C9924E /* ProductListViewController.swift in Sources */,
 				AB6E6BF8282A4C5600431717 /* APIResponse.swift in Sources */,
 				AB6E6BFA282A4E4A00431717 /* Product.swift in Sources */,
 				B0A408E1282B95F400A388FA /* URLSessionable.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		AB6E6BF8282A4C5600431717 /* APIResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF7282A4C5600431717 /* APIResponse.swift */; };
 		AB6E6BFA282A4E4A00431717 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF9282A4E4A00431717 /* Product.swift */; };
 		ABF6011B28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */; };
+		ABF6011E283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF6011D283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift */; };
 		B00E3C5F282BDA2B006AB0AC /* URLSession+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */; };
 		B02944A3282A430800B9828F /* DecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02944A2282A430800B9828F /* DecodeTests.swift */; };
 		B0802A4228326C670058019C /* ProductListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0802A4128326C670058019C /* ProductListCollectionViewCell.swift */; };
@@ -47,6 +48,7 @@
 		AB6E6BF7282A4C5600431717 /* APIResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponse.swift; sourceTree = "<group>"; };
 		AB6E6BF9282A4E4A00431717 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductGridCollectionViewCell.swift; sourceTree = "<group>"; };
+		ABF6011D283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Extension.swift"; sourceTree = "<group>"; };
 		B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Extension.swift"; sourceTree = "<group>"; };
 		B02944A0282A430800B9828F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B02944A2282A430800B9828F /* DecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeTests.swift; sourceTree = "<group>"; };
@@ -111,9 +113,18 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		ABF6011C283345C500E8CAC2 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				ABF6011D283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		B00E3C5D282BD9DC006AB0AC /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				ABF6011C283345C500E8CAC2 /* Extension */,
 				B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */,
 			);
 			path = Util;
@@ -372,6 +383,7 @@
 				B00E3C5F282BDA2B006AB0AC /* URLSession+Extension.swift in Sources */,
 				ABF6011B28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
+				ABF6011E283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift in Sources */,
 				B0A408DD282B933C00A388FA /* NetworkService.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,
 			);

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AB0781EB282B5E3B00887BE8 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0781EA282B5E3B00887BE8 /* MockData.swift */; };
 		AB6E6BF8282A4C5600431717 /* APIResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF7282A4C5600431717 /* APIResponse.swift */; };
 		AB6E6BFA282A4E4A00431717 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF9282A4E4A00431717 /* Product.swift */; };
+		ABF6011B28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */; };
 		B00E3C5F282BDA2B006AB0AC /* URLSession+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */; };
 		B02944A3282A430800B9828F /* DecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02944A2282A430800B9828F /* DecodeTests.swift */; };
 		B0802A4228326C670058019C /* ProductListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0802A4128326C670058019C /* ProductListCollectionViewCell.swift */; };
@@ -45,6 +46,7 @@
 		AB0781EA282B5E3B00887BE8 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		AB6E6BF7282A4C5600431717 /* APIResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponse.swift; sourceTree = "<group>"; };
 		AB6E6BF9282A4E4A00431717 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
+		ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductGridCollectionViewCell.swift; sourceTree = "<group>"; };
 		B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Extension.swift"; sourceTree = "<group>"; };
 		B02944A0282A430800B9828F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B02944A2282A430800B9828F /* DecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeTests.swift; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 			isa = PBXGroup;
 			children = (
 				B0802A4128326C670058019C /* ProductListCollectionViewCell.swift */,
+				ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -367,6 +370,7 @@
 				AB6E6BFA282A4E4A00431717 /* Product.swift in Sources */,
 				B0A408E1282B95F400A388FA /* URLSessionable.swift in Sources */,
 				B00E3C5F282BDA2B006AB0AC /* URLSession+Extension.swift in Sources */,
+				ABF6011B28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
 				B0A408DD282B933C00A388FA /* NetworkService.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		AB6E6BFA282A4E4A00431717 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF9282A4E4A00431717 /* Product.swift */; };
 		B00E3C5F282BDA2B006AB0AC /* URLSession+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */; };
 		B02944A3282A430800B9828F /* DecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02944A2282A430800B9828F /* DecodeTests.swift */; };
+		B0802A4228326C670058019C /* ProductListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0802A4128326C670058019C /* ProductListCollectionViewCell.swift */; };
 		B0A408DD282B933C00A388FA /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A408DC282B933C00A388FA /* NetworkService.swift */; };
 		B0A408DF282B945D00A388FA /* APINetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A408DE282B945D00A388FA /* APINetworkService.swift */; };
 		B0A408E1282B95F400A388FA /* URLSessionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A408E0282B95F400A388FA /* URLSessionable.swift */; };
@@ -47,6 +48,7 @@
 		B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Extension.swift"; sourceTree = "<group>"; };
 		B02944A0282A430800B9828F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B02944A2282A430800B9828F /* DecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeTests.swift; sourceTree = "<group>"; };
+		B0802A4128326C670058019C /* ProductListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListCollectionViewCell.swift; sourceTree = "<group>"; };
 		B0A408DC282B933C00A388FA /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		B0A408DE282B945D00A388FA /* APINetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APINetworkService.swift; sourceTree = "<group>"; };
 		B0A408E0282B95F400A388FA /* URLSessionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionable.swift; sourceTree = "<group>"; };
@@ -151,6 +153,14 @@
 			path = OpenMarketTests;
 			sourceTree = "<group>";
 		};
+		B0802A4028326C1C0058019C /* View */ = {
+			isa = PBXGroup;
+			children = (
+				B0802A4128326C670058019C /* ProductListCollectionViewCell.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		B0A408D9282B930900A388FA /* Network */ = {
 			isa = PBXGroup;
 			children = (
@@ -205,6 +215,7 @@
 				B0294499282A09C900B9828F /* Application */,
 				B0A408D9282B930900A388FA /* Network */,
 				AB6E6BF6282A4C3A00431717 /* Model */,
+				B0802A4028326C1C0058019C /* View */,
 				B029449A282A09CF00B9828F /* Controller */,
 				B00E3C5D282BD9DC006AB0AC /* Util */,
 				B029449B282A09D800B9828F /* Resource */,
@@ -349,6 +360,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B0A408DF282B945D00A388FA /* APINetworkService.swift in Sources */,
+				B0802A4228326C670058019C /* ProductListCollectionViewCell.swift in Sources */,
 				B0A408E3282BA5F200A388FA /* APINetworkError.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ProductListViewController.swift in Sources */,
 				AB6E6BF8282A4C5600431717 /* APIResponse.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		ABF6011E283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF6011D283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift */; };
 		B00E3C5F282BDA2B006AB0AC /* URLSession+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */; };
 		B02944A3282A430800B9828F /* DecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02944A2282A430800B9828F /* DecodeTests.swift */; };
+		B05BE63A2833CC230059CD26 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05BE6392833CC230059CD26 /* Int+Extension.swift */; };
 		B0802A4228326C670058019C /* ProductListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0802A4128326C670058019C /* ProductListCollectionViewCell.swift */; };
 		B0A408DD282B933C00A388FA /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A408DC282B933C00A388FA /* NetworkService.swift */; };
 		B0A408DF282B945D00A388FA /* APINetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A408DE282B945D00A388FA /* APINetworkService.swift */; };
@@ -54,6 +55,7 @@
 		B00E3C5E282BDA2B006AB0AC /* URLSession+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Extension.swift"; sourceTree = "<group>"; };
 		B02944A0282A430800B9828F /* OpenMarketTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenMarketTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B02944A2282A430800B9828F /* DecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeTests.swift; sourceTree = "<group>"; };
+		B05BE6392833CC230059CD26 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		B0802A4128326C670058019C /* ProductListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListCollectionViewCell.swift; sourceTree = "<group>"; };
 		B0A408DC282B933C00A388FA /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		B0A408DE282B945D00A388FA /* APINetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APINetworkService.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 			children = (
 				ABF6011D283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift */,
 				AB56FB4128339687009E6DC0 /* UILabel+Extension.swift */,
+				B05BE6392833CC230059CD26 /* Int+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -376,6 +379,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B05BE63A2833CC230059CD26 /* Int+Extension.swift in Sources */,
 				B0A408DF282B945D00A388FA /* APINetworkService.swift in Sources */,
 				B0802A4228326C670058019C /* ProductListCollectionViewCell.swift in Sources */,
 				B0A408E3282BA5F200A388FA /* APINetworkError.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AB0781E7282B555C00887BE8 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0781E6282B555C00887BE8 /* MockURLSession.swift */; };
 		AB0781E9282B5DD200887BE8 /* MockURLSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0781E8282B5DD200887BE8 /* MockURLSessionDataTask.swift */; };
 		AB0781EB282B5E3B00887BE8 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0781EA282B5E3B00887BE8 /* MockData.swift */; };
+		AB56FB4228339687009E6DC0 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB56FB4128339687009E6DC0 /* UILabel+Extension.swift */; };
 		AB6E6BF8282A4C5600431717 /* APIResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF7282A4C5600431717 /* APIResponse.swift */; };
 		AB6E6BFA282A4E4A00431717 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF9282A4E4A00431717 /* Product.swift */; };
 		ABF6011B28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */; };
@@ -45,6 +46,7 @@
 		AB0781E6282B555C00887BE8 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		AB0781E8282B5DD200887BE8 /* MockURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSessionDataTask.swift; sourceTree = "<group>"; };
 		AB0781EA282B5E3B00887BE8 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
+		AB56FB4128339687009E6DC0 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		AB6E6BF7282A4C5600431717 /* APIResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponse.swift; sourceTree = "<group>"; };
 		AB6E6BF9282A4E4A00431717 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductGridCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				ABF6011D283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift */,
+				AB56FB4128339687009E6DC0 /* UILabel+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -384,6 +387,7 @@
 				ABF6011B28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
 				ABF6011E283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift in Sources */,
+				AB56FB4228339687009E6DC0 /* UILabel+Extension.swift in Sources */,
 				B0A408DD282B933C00A388FA /* NetworkService.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,
 			);

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		AB0781E9282B5DD200887BE8 /* MockURLSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0781E8282B5DD200887BE8 /* MockURLSessionDataTask.swift */; };
 		AB0781EB282B5E3B00887BE8 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0781EA282B5E3B00887BE8 /* MockData.swift */; };
 		AB56FB4228339687009E6DC0 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB56FB4128339687009E6DC0 /* UILabel+Extension.swift */; };
+		AB56FB45283496B1009E6DC0 /* ProductConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB56FB44283496B1009E6DC0 /* ProductConstant.swift */; };
 		AB6E6BF8282A4C5600431717 /* APIResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF7282A4C5600431717 /* APIResponse.swift */; };
 		AB6E6BFA282A4E4A00431717 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E6BF9282A4E4A00431717 /* Product.swift */; };
 		ABF6011B28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */; };
@@ -48,6 +49,7 @@
 		AB0781E8282B5DD200887BE8 /* MockURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSessionDataTask.swift; sourceTree = "<group>"; };
 		AB0781EA282B5E3B00887BE8 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		AB56FB4128339687009E6DC0 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
+		AB56FB44283496B1009E6DC0 /* ProductConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductConstant.swift; sourceTree = "<group>"; };
 		AB6E6BF7282A4C5600431717 /* APIResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponse.swift; sourceTree = "<group>"; };
 		AB6E6BF9282A4E4A00431717 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductGridCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -106,6 +108,14 @@
 				AB0781EA282B5E3B00887BE8 /* MockData.swift */,
 			);
 			path = Mock;
+			sourceTree = "<group>";
+		};
+		AB56FB4328349686009E6DC0 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				AB56FB44283496B1009E6DC0 /* ProductConstant.swift */,
+			);
+			path = Common;
 			sourceTree = "<group>";
 		};
 		AB6E6BF6282A4C3A00431717 /* Model */ = {
@@ -175,6 +185,7 @@
 		B0802A4028326C1C0058019C /* View */ = {
 			isa = PBXGroup;
 			children = (
+				AB56FB4328349686009E6DC0 /* Common */,
 				B0802A4128326C670058019C /* ProductListCollectionViewCell.swift */,
 				ABF6011A28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift */,
 			);
@@ -390,6 +401,7 @@
 				B00E3C5F282BDA2B006AB0AC /* URLSession+Extension.swift in Sources */,
 				ABF6011B28333E4900E8CAC2 /* ProductGridCollectionViewCell.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
+				AB56FB45283496B1009E6DC0 /* ProductConstant.swift in Sources */,
 				ABF6011E283345DD00E8CAC2 /* UICollectionViewCell+Extension.swift in Sources */,
 				AB56FB4228339687009E6DC0 /* UILabel+Extension.swift in Sources */,
 				B0A408DD282B933C00A388FA /* NetworkService.swift in Sources */,

--- a/OpenMarket/OpenMarket/Application/SceneDelegate.swift
+++ b/OpenMarket/OpenMarket/Application/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   ) {
     guard let windowScene = (scene as? UIWindowScene) else { return }
     self.window = UIWindow(windowScene: windowScene)
-    self.window?.rootViewController = ViewController()
+    self.window?.rootViewController = ProductListViewController()
     self.window?.makeKeyAndVisible()
   }
 }

--- a/OpenMarket/OpenMarket/Application/SceneDelegate.swift
+++ b/OpenMarket/OpenMarket/Application/SceneDelegate.swift
@@ -15,7 +15,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   ) {
     guard let windowScene = (scene as? UIWindowScene) else { return }
     self.window = UIWindow(windowScene: windowScene)
-    self.window?.rootViewController = ProductListViewController()
+    let rootViewController = ProductListViewController()
+    self.window?.rootViewController = UINavigationController(
+      rootViewController: rootViewController)
     self.window?.makeKeyAndVisible()
   }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -15,9 +15,13 @@ final class ProductListViewController: UIViewController {
     }
   }
 
-  private let segmentControl: UISegmentedControl = {
+  private lazy var segmentControl: UISegmentedControl = {
     let segment = UISegmentedControl(items: ["LIST", "GRID"])
+    segment.setWidth(70, forSegmentAt: 0)
+    segment.setWidth(70, forSegmentAt: 1)
     segment.selectedSegmentIndex = .zero
+    segment.backgroundColor = .systemBackground
+    segment.addTarget(self, action: #selector(changeLayout(_:)), for: .valueChanged)
     return segment
   }()
   
@@ -49,6 +53,8 @@ final class ProductListViewController: UIViewController {
       self.productList = productList
     }
   }
+  
+  @objc func changeLayout(_ sender: UISegmentedControl) {}
   
   private func configureUI() {
     self.view.backgroundColor = .systemBackground

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -43,7 +43,7 @@ final class ProductListViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.configureUI()
-    self.loadProductListData(page: 1, itemPerPage: 10)
+    self.loadProductListData(page: 1, itemPerPage: 30)
   }
   
   private func loadProductListData(page: Int, itemPerPage: Int) {

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -45,6 +45,8 @@ final class ProductListViewController: UIViewController {
     return collectionView
   }()
   
+  private let indicator = UIActivityIndicatorView(style: .large)
+  
   override func viewDidLoad() {
     super.viewDidLoad()
     self.configureUI()
@@ -52,9 +54,13 @@ final class ProductListViewController: UIViewController {
   }
   
   private func loadProductListData(page: Int, itemPerPage: Int) {
+    self.indicator.startAnimating()
     self.networkService.fetchProductAll(pageNumber: page, itemsPerPage: itemPerPage) { result in
       guard let productList = try? result.get() else { return }
       self.productList = productList
+      DispatchQueue.main.async {
+        self.indicator.stopAnimating()
+      }
     }
   }
   
@@ -83,12 +89,18 @@ final class ProductListViewController: UIViewController {
     self.navigationItem.rightBarButtonItem = addProductButton
     self.navigationItem.titleView = segmentControl
     self.view.addSubview(collectionView)
+    self.view.addSubview(indicator)
     self.collectionView.translatesAutoresizingMaskIntoConstraints = false
+    self.indicator.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
       collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
       collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
       collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-      collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+      collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+      indicator.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+      indicator.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+      indicator.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+      indicator.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
     ])
   }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -124,7 +124,7 @@ extension ProductListViewController: UICollectionViewDataSource {
         for: indexPath) as? ProductListCollectionViewCell
       else { return ProductListCollectionViewCell() }
       
-      listCell.setup(product: self.productList[indexPath.row])
+      listCell.setUp(product: self.productList[indexPath.row])
       return listCell
     case 1:
       guard let gridCell = collectionView.dequeueReusableCell(
@@ -132,7 +132,7 @@ extension ProductListViewController: UICollectionViewDataSource {
         for: indexPath) as? ProductGridCollectionViewCell
       else { return ProductGridCollectionViewCell() }
       
-      gridCell.setup(product: self.productList[indexPath.row])
+      gridCell.setUp(product: self.productList[indexPath.row])
       return gridCell
     default:
       return UICollectionViewCell()

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -83,13 +83,13 @@ private extension ProductListViewController {
     guard let segment = SegmentIndex(rawValue: segmentControl.selectedSegmentIndex)
     else { return }
     
-    self.collectionView.reloadData()
     switch segment {
     case .list:
       self.configureListLayout()
     case .grid:
       self.configureGridLayout()
     }
+    self.collectionView.reloadData()
   }
   
   func configureListLayout() {

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -27,14 +27,14 @@ final class ProductListViewController: UIViewController {
   private lazy var addProductButton = UIBarButtonItem(
     barButtonSystemItem: .add,
     target: self,
-    action: #selector(didTapAddProductButton))
+    action: #selector(addButtonDidTap))
 
   private lazy var segmentControl: UISegmentedControl = {
     let segment = UISegmentedControl(items: ["LIST", "GRID"])
     segment.setWidth(Constant.segmentWidth, forSegmentAt: .zero)
     segment.setWidth(Constant.segmentWidth, forSegmentAt: 1)
     segment.selectedSegmentIndex = .zero
-    segment.addTarget(self, action: #selector(changeLayout), for: .valueChanged)
+    segment.addTarget(self, action: #selector(segmentControlDidTap), for: .valueChanged)
     return segment
   }()
   
@@ -73,13 +73,13 @@ final class ProductListViewController: UIViewController {
     }
   }
   
-  @objc private func didTapAddProductButton(_ sender: UIBarButtonItem) {}
+  @objc private func addButtonDidTap(_ sender: UIBarButtonItem) {}
 }
 
 // MARK: - UI
 
 private extension ProductListViewController {
-  @objc func changeLayout(_ sender: UISegmentedControl) {
+  @objc func segmentControlDidTap(_ sender: UISegmentedControl) {
     guard let segment = SegmentIndex(rawValue: segmentControl.selectedSegmentIndex)
     else { return }
     

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -44,7 +44,6 @@ final class ProductListViewController: UIViewController {
     layout.itemSize = CGSize(width: view.frame.width, height: view.frame.height / 15)
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
     collectionView.backgroundColor = .systemBackground
-    collectionView.dataSource = self
     collectionView.register(
       ProductListCollectionViewCell.self,
       forCellWithReuseIdentifier: ProductListCollectionViewCell.identifier)
@@ -59,6 +58,7 @@ final class ProductListViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.configureUI()
+    self.collectionView.dataSource = self
     self.loadProductListData(page: 1, itemPerPage: 30)
   }
   

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -24,7 +24,7 @@ final class ProductListViewController: UIViewController {
   private lazy var collectionView: UICollectionView = {
     let layout = UICollectionViewFlowLayout()
     layout.scrollDirection = .vertical
-    layout.itemSize = CGSize(width: view.frame.width, height: view.frame.height / 10)
+    layout.itemSize = CGSize(width: view.frame.width, height: view.frame.height / 15)
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
     collectionView.backgroundColor = .systemBackground
     collectionView.dataSource = self

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -60,12 +60,13 @@ final class ProductListViewController: UIViewController {
       let layout = UICollectionViewFlowLayout()
       layout.itemSize = CGSize(width: view.frame.width, height: view.frame.height / 15)
       self.collectionView.reloadData()
-      self.collectionView.setCollectionViewLayout(layout, animated: true)
+      self.collectionView.collectionViewLayout = layout
     case 1:
       let layout = UICollectionViewFlowLayout()
-      layout.itemSize = CGSize(width: view.frame.width / 2 - 10, height: view.frame.height / 5)
+      layout.itemSize = CGSize(width: view.frame.width / 2 - 20, height: view.frame.height / 3)
+      layout.sectionInset = UIEdgeInsets(top: 0, left: 10.0, bottom: 0, right: 10.0)
       self.collectionView.reloadData()
-      self.collectionView.setCollectionViewLayout(layout, animated: true)
+      self.collectionView.collectionViewLayout = layout
     default:
       break
     }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -14,6 +14,11 @@ final class ProductListViewController: UIViewController {
       }
     }
   }
+  
+  private lazy var addProductButton = UIBarButtonItem(
+    barButtonSystemItem: .add,
+    target: self,
+    action: #selector(didTapAddProductButton))
 
   private lazy var segmentControl: UISegmentedControl = {
     let segment = UISegmentedControl(items: ["LIST", "GRID"])
@@ -53,6 +58,8 @@ final class ProductListViewController: UIViewController {
     }
   }
   
+  @objc func didTapAddProductButton(_ sender: UIBarButtonItem) {}
+  
   @objc func changeLayout(_ sender: UISegmentedControl) {
     switch sender.selectedSegmentIndex {
     case 0:
@@ -73,6 +80,7 @@ final class ProductListViewController: UIViewController {
   
   private func configureUI() {
     self.view.backgroundColor = .systemBackground
+    self.navigationItem.rightBarButtonItem = addProductButton
     self.navigationItem.titleView = segmentControl
     self.view.addSubview(collectionView)
     self.collectionView.translatesAutoresizingMaskIntoConstraints = false

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -17,10 +17,9 @@ final class ProductListViewController: UIViewController {
 
   private lazy var segmentControl: UISegmentedControl = {
     let segment = UISegmentedControl(items: ["LIST", "GRID"])
-    segment.setWidth(70, forSegmentAt: 0)
-    segment.setWidth(70, forSegmentAt: 1)
+    segment.setWidth(80, forSegmentAt: 0)
+    segment.setWidth(80, forSegmentAt: 1)
     segment.selectedSegmentIndex = .zero
-    segment.backgroundColor = .systemBackground
     segment.addTarget(self, action: #selector(changeLayout(_:)), for: .valueChanged)
     return segment
   }()

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -23,10 +23,10 @@ final class ProductListViewController: UIViewController {
     collectionView.backgroundColor = .systemBackground
     collectionView.register(
       ProductListCollectionViewCell.self,
-      forCellWithReuseIdentifier: "ProductListCollectionViewCell")
+      forCellWithReuseIdentifier: ProductListCollectionViewCell.identifier)
     collectionView.register(
       ProductGridCollectionViewCell.self,
-      forCellWithReuseIdentifier: "ProductGridCollectionViewCell")
+      forCellWithReuseIdentifier: ProductGridCollectionViewCell.identifier)
     return collectionView
   }()
   

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -54,7 +54,22 @@ final class ProductListViewController: UIViewController {
     }
   }
   
-  @objc func changeLayout(_ sender: UISegmentedControl) {}
+  @objc func changeLayout(_ sender: UISegmentedControl) {
+    switch sender.selectedSegmentIndex {
+    case 0:
+      let layout = UICollectionViewFlowLayout()
+      layout.itemSize = CGSize(width: view.frame.width, height: view.frame.height / 15)
+      self.collectionView.reloadData()
+      self.collectionView.setCollectionViewLayout(layout, animated: true)
+    case 1:
+      let layout = UICollectionViewFlowLayout()
+      layout.itemSize = CGSize(width: view.frame.width / 2 - 10, height: view.frame.height / 5)
+      self.collectionView.reloadData()
+      self.collectionView.setCollectionViewLayout(layout, animated: true)
+    default:
+      break
+    }
+  }
   
   private func configureUI() {
     self.view.backgroundColor = .systemBackground

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -82,12 +82,25 @@ extension ProductListViewController: UICollectionViewDataSource {
     _ collectionView: UICollectionView,
     cellForItemAt indexPath: IndexPath
   ) -> UICollectionViewCell {
-    guard let listCell = collectionView.dequeueReusableCell(
-      withReuseIdentifier: ProductListCollectionViewCell.identifier,
-      for: indexPath) as? ProductListCollectionViewCell
-    else { return ProductListCollectionViewCell() }
-    
-    listCell.setup(product: self.productList[indexPath.row])
-    return listCell
+    switch segmentControl.selectedSegmentIndex {
+    case 0:
+      guard let listCell = collectionView.dequeueReusableCell(
+        withReuseIdentifier: ProductListCollectionViewCell.identifier,
+        for: indexPath) as? ProductListCollectionViewCell
+      else { return ProductListCollectionViewCell() }
+      
+      listCell.setup(product: self.productList[indexPath.row])
+      return listCell
+    case 1:
+      guard let gridCell = collectionView.dequeueReusableCell(
+        withReuseIdentifier: ProductGridCollectionViewCell.identifier,
+        for: indexPath) as? ProductGridCollectionViewCell
+      else { return ProductGridCollectionViewCell() }
+      
+      gridCell.setup(product: self.productList[indexPath.row])
+      return gridCell
+    default:
+      return UICollectionViewCell()
+    }
   }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -21,6 +21,7 @@ final class ProductListViewController: UIViewController {
     layout.itemSize = CGSize(width: view.frame.width, height: view.frame.height / 10)
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
     collectionView.backgroundColor = .systemBackground
+    collectionView.dataSource = self
     collectionView.register(
       ProductListCollectionViewCell.self,
       forCellWithReuseIdentifier: ProductListCollectionViewCell.identifier)
@@ -53,5 +54,26 @@ final class ProductListViewController: UIViewController {
       collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
       collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
     ])
+  }
+}
+
+extension ProductListViewController: UICollectionViewDataSource {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    return self.productList.count
+  }
+  
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: ProductListCollectionViewCell.identifier,
+      for: indexPath) as? ProductListCollectionViewCell
+    else { return ProductListCollectionViewCell() }
+    
+    return cell
   }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -50,6 +50,9 @@ final class ProductListViewController: UIViewController {
     collectionView.register(
       ProductGridCollectionViewCell.self,
       forCellWithReuseIdentifier: ProductGridCollectionViewCell.identifier)
+    collectionView.register(
+      EmptyCollectionViewCell.self,
+      forCellWithReuseIdentifier: EmptyCollectionViewCell.identifier)
     return collectionView
   }()
   
@@ -141,14 +144,22 @@ extension ProductListViewController: UICollectionViewDataSource {
     cellForItemAt indexPath: IndexPath
   ) -> UICollectionViewCell {
     guard let segment = SegmentIndex(rawValue: segmentControl.selectedSegmentIndex)
-    else { return UICollectionViewCell() }
+    else {
+      return collectionView.dequeueReusableCell(
+        withReuseIdentifier: EmptyCollectionViewCell.identifier,
+        for: indexPath)
+    }
     
     switch segment {
     case .list:
       guard let listCell = collectionView.dequeueReusableCell(
         withReuseIdentifier: ProductListCollectionViewCell.identifier,
         for: indexPath) as? ProductListCollectionViewCell
-      else { return ProductListCollectionViewCell() }
+      else {
+        return collectionView.dequeueReusableCell(
+          withReuseIdentifier: EmptyCollectionViewCell.identifier,
+          for: indexPath)
+      }
       
       listCell.setUp(product: self.productList[indexPath.row])
       return listCell
@@ -156,8 +167,11 @@ extension ProductListViewController: UICollectionViewDataSource {
       guard let gridCell = collectionView.dequeueReusableCell(
         withReuseIdentifier: ProductGridCollectionViewCell.identifier,
         for: indexPath) as? ProductGridCollectionViewCell
-      else { return ProductGridCollectionViewCell() }
-      
+      else {
+        return collectionView.dequeueReusableCell(
+          withReuseIdentifier: EmptyCollectionViewCell.identifier,
+          for: indexPath)
+      }
       gridCell.setUp(product: self.productList[indexPath.row])
       return gridCell
     }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -7,7 +7,13 @@ import UIKit
 
 final class ProductListViewController: UIViewController {
   private let networkService = APINetworkService(urlSession: URLSession.shared)
-  private var productList = [Product]()
+  private var productList = [Product]() {
+    didSet {
+      DispatchQueue.main.async {
+        self.collectionView.reloadData()
+      }
+    }
+  }
 
   private let segmentControl: UISegmentedControl = {
     let segment = UISegmentedControl(items: ["LIST", "GRID"])
@@ -34,6 +40,7 @@ final class ProductListViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.configureUI()
+    self.loadProductListData(page: 1, itemPerPage: 10)
   }
   
   private func loadProductListData(page: Int, itemPerPage: Int) {
@@ -69,11 +76,12 @@ extension ProductListViewController: UICollectionViewDataSource {
     _ collectionView: UICollectionView,
     cellForItemAt indexPath: IndexPath
   ) -> UICollectionViewCell {
-    guard let cell = collectionView.dequeueReusableCell(
+    guard let listCell = collectionView.dequeueReusableCell(
       withReuseIdentifier: ProductListCollectionViewCell.identifier,
       for: indexPath) as? ProductListCollectionViewCell
     else { return ProductListCollectionViewCell() }
     
-    return cell
+    listCell.setup(product: self.productList[indexPath.row])
+    return listCell
   }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -15,6 +15,21 @@ final class ProductListViewController: UIViewController {
     return segment
   }()
   
+  private lazy var collectionView: UICollectionView = {
+    let layout = UICollectionViewFlowLayout()
+    layout.scrollDirection = .vertical
+    layout.itemSize = CGSize(width: view.frame.width, height: view.frame.height / 10)
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+    collectionView.backgroundColor = .systemBackground
+    collectionView.register(
+      ProductListCollectionViewCell.self,
+      forCellWithReuseIdentifier: "ProductListCollectionViewCell")
+    collectionView.register(
+      ProductGridCollectionViewCell.self,
+      forCellWithReuseIdentifier: "ProductGridCollectionViewCell")
+    return collectionView
+  }()
+  
   override func viewDidLoad() {
     super.viewDidLoad()
     self.configureUI()
@@ -30,5 +45,13 @@ final class ProductListViewController: UIViewController {
   private func configureUI() {
     self.view.backgroundColor = .systemBackground
     self.navigationItem.titleView = segmentControl
+    self.view.addSubview(collectionView)
+    self.collectionView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+      collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+      collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+      collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+    ])
   }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -1,11 +1,11 @@
 //
-//  ViewController.swift
+//  ProductListViewController.swift
 //  Created by Lingo, Quokka
 // 
 
 import UIKit
 
-final class ViewController: UIViewController {
+final class ProductListViewController: UIViewController {
   private let networkService = APINetworkService(urlSession: URLSession.shared)
   private var productList = [Product]()
 

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -9,8 +9,15 @@ final class ProductListViewController: UIViewController {
   private let networkService = APINetworkService(urlSession: URLSession.shared)
   private var productList = [Product]()
 
+  private let segmentControl: UISegmentedControl = {
+    let segment = UISegmentedControl(items: ["LIST", "GRID"])
+    segment.selectedSegmentIndex = .zero
+    return segment
+  }()
+  
   override func viewDidLoad() {
     super.viewDidLoad()
+    self.configureUI()
   }
   
   private func loadProductListData(page: Int, itemPerPage: Int) {
@@ -18,5 +25,10 @@ final class ProductListViewController: UIViewController {
       guard let productList = try? result.get() else { return }
       self.productList = productList
     }
+  }
+  
+  private func configureUI() {
+    self.view.backgroundColor = .systemBackground
+    self.navigationItem.titleView = segmentControl
   }
 }

--- a/OpenMarket/OpenMarket/Controller/ViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ViewController.swift
@@ -6,7 +6,17 @@
 import UIKit
 
 final class ViewController: UIViewController {
+  private let networkService = APINetworkService(urlSession: URLSession.shared)
+  private var productList = [Product]()
+
   override func viewDidLoad() {
     super.viewDidLoad()
+  }
+  
+  private func loadProductListData(page: Int, itemPerPage: Int) {
+    self.networkService.fetchProductAll(pageNumber: page, itemsPerPage: itemPerPage) { result in
+      guard let productList = try? result.get() else { return }
+      self.productList = productList
+    }
   }
 }

--- a/OpenMarket/OpenMarket/Util/Extension/Int+Extension.swift
+++ b/OpenMarket/OpenMarket/Util/Extension/Int+Extension.swift
@@ -6,3 +6,11 @@
 //
 
 import Foundation
+
+extension Int {
+  var toDecimal: String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    return formatter.string(for: self) ?? ""
+  }
+}

--- a/OpenMarket/OpenMarket/Util/Extension/Int+Extension.swift
+++ b/OpenMarket/OpenMarket/Util/Extension/Int+Extension.swift
@@ -1,0 +1,8 @@
+//
+//  Int+Extension.swift
+//  OpenMarket
+//
+//  Created by Lingo, Quokka on 2022/05/17.
+//
+
+import Foundation

--- a/OpenMarket/OpenMarket/Util/Extension/UICollectionViewCell+Extension.swift
+++ b/OpenMarket/OpenMarket/Util/Extension/UICollectionViewCell+Extension.swift
@@ -5,4 +5,10 @@
 //  Created by Lingo, Quokka on 2022/05/17.
 //
 
-import Foundation
+import UIKit
+
+extension UICollectionViewCell {
+  static var identifier: String {
+    return String(describing: self)
+  }
+}

--- a/OpenMarket/OpenMarket/Util/Extension/UICollectionViewCell+Extension.swift
+++ b/OpenMarket/OpenMarket/Util/Extension/UICollectionViewCell+Extension.swift
@@ -1,0 +1,8 @@
+//
+//  UICollectionViewCell+Extension.swift
+//  OpenMarket
+//
+//  Created by Lingo, Quokka on 2022/05/17.
+//
+
+import Foundation

--- a/OpenMarket/OpenMarket/Util/Extension/UILabel+Extension.swift
+++ b/OpenMarket/OpenMarket/Util/Extension/UILabel+Extension.swift
@@ -1,0 +1,9 @@
+//
+//  UILabel+Extension.swift
+//  OpenMarket
+//
+//  Created by Lingo, Quokka on 2022/05/17.
+//
+
+import Foundation
+

--- a/OpenMarket/OpenMarket/Util/Extension/UILabel+Extension.swift
+++ b/OpenMarket/OpenMarket/Util/Extension/UILabel+Extension.swift
@@ -5,5 +5,15 @@
 //  Created by Lingo, Quokka on 2022/05/17.
 //
 
-import Foundation
+import UIKit
 
+extension UILabel {
+  func setStrike(text: String) {
+    let attributedString = NSMutableAttributedString(string: text)
+    attributedString.addAttribute(
+      NSAttributedString.Key.strikethroughStyle,
+      value: 1,
+      range: NSRange(location: .zero, length: attributedString.length))
+    self.attributedText = attributedString
+  }
+}

--- a/OpenMarket/OpenMarket/View/Common/EmptyCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/Common/EmptyCollectionViewCell.swift
@@ -1,0 +1,10 @@
+//
+//  EmptyCollectionViewCell.swift
+//  OpenMarket
+//
+//  Created by Lingo, Quokka on 2022/05/19.
+//
+
+import UIKit
+
+final class EmptyCollectionViewCell: UICollectionViewCell {}

--- a/OpenMarket/OpenMarket/View/Common/ProductConstant.swift
+++ b/OpenMarket/OpenMarket/View/Common/ProductConstant.swift
@@ -2,7 +2,10 @@
 //  ProductConstant.swift
 //  OpenMarket
 //
-//  Created by LIMGAUI on 2022/05/18.
+//  Created by Lingo, Quokka on 2022/05/18.
 //
 
-import Foundation
+enum ProductConstant {
+  static let soldOut = "품절"
+  static let remainStock = "잔여수량:"
+}

--- a/OpenMarket/OpenMarket/View/Common/ProductConstant.swift
+++ b/OpenMarket/OpenMarket/View/Common/ProductConstant.swift
@@ -1,0 +1,8 @@
+//
+//  ProductConstant.swift
+//  OpenMarket
+//
+//  Created by LIMGAUI on 2022/05/18.
+//
+
+import Foundation

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -73,7 +73,7 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     self.configureUI()
   }
   
-  func setup(product: Product) {
+  func setUp(product: Product) {
     self.setPriceLabel(product)
     self.setStockLabel(product)
     self.titleLabel.text = product.name
@@ -81,8 +81,19 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice.toDecimal)"
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
   }
-  
-  private func setPriceLabel(_ product: Product) {
+
+  private func convertImageFromData(url urlString: String) -> Data {
+    guard let url = URL(string: urlString),
+          let data = try? Data(contentsOf: url)
+    else { return Data() }
+    return data
+  }
+}
+
+// MARK: - UI
+
+private extension ProductGridCollectionViewCell {
+  func setPriceLabel(_ product: Product) {
     if product.discountedPrice == .zero {
       self.informationStackView.spacing = 20.0
       self.priceLabel.isHidden = true
@@ -92,31 +103,23 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     }
   }
   
-  private func setStockLabel(_ product: Product) {
-    if product.stock == 0 {
+  func setStockLabel(_ product: Product) {
+    if product.stock == .zero {
       self.stockLabel.textColor = .systemOrange
-      self.stockLabel.text = "품절"
+      self.stockLabel.text = ProductConstant.soldOut
     } else {
       self.stockLabel.textColor = .secondaryLabel
-      self.stockLabel.text = "잔여수량: \(product.stock)"
+      self.stockLabel.text = "\(ProductConstant.remainStock) \(product.stock)"
     }
   }
   
-  private func convertImageFromData(url urlString: String) -> Data {
-    guard let url = URL(string: urlString),
-          let data = try? Data(contentsOf: url)
-    else { return Data() }
-    return data
-  }
-  
-  private func configureUI() {
+  func configureUI() {
     self.contentView.layer.borderWidth = 1.0
     self.contentView.layer.cornerRadius = 10.0
     self.contentView.layer.borderColor = UIColor.systemGray.cgColor
     self.contentView.addSubview(containerStackView)
     self.containerStackView.addArrangedSubview(productImageView)
     self.containerStackView.addArrangedSubview(informationStackView)
-    //self.containerStackView.addArrangedSubview(stockLabel)
     
     self.informationStackView.addArrangedSubview(titleLabel)
     self.informationStackView.addArrangedSubview(priceStackView)
@@ -135,4 +138,3 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     ])
   }
 }
-

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -19,7 +19,7 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   private let informationStackView: UIStackView = {
     let stackView = UIStackView()
     stackView.axis = .vertical
-    stackView.spacing = 6.0
+    stackView.spacing = 20.0
     return stackView
   }()
   
@@ -74,11 +74,22 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   }
   
   func setup(product: Product) {
+    self.setPriceLabel(product)
+    self.setStockLabel(product)
     self.titleLabel.text = product.name
     self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price.toDecimal)")
     self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice.toDecimal)"
-    self.setStockLabel(product)
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
+  }
+  
+  private func setPriceLabel(_ product: Product) {
+    if product.discountedPrice == .zero {
+      self.informationStackView.spacing = 20.0
+      self.priceLabel.isHidden = true
+    } else {
+      self.informationStackView.spacing = 10.0
+      self.priceLabel.isHidden = false
+    }
   }
   
   private func setStockLabel(_ product: Product) {
@@ -105,10 +116,11 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     self.contentView.addSubview(containerStackView)
     self.containerStackView.addArrangedSubview(productImageView)
     self.containerStackView.addArrangedSubview(informationStackView)
-    self.containerStackView.addArrangedSubview(stockLabel)
+    //self.containerStackView.addArrangedSubview(stockLabel)
     
     self.informationStackView.addArrangedSubview(titleLabel)
     self.informationStackView.addArrangedSubview(priceStackView)
+    self.informationStackView.addArrangedSubview(stockLabel)
     self.priceStackView.addArrangedSubview(priceLabel)
     self.priceStackView.addArrangedSubview(bargainPriceLabel)
     

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -5,3 +5,54 @@
 //  Created by Lingo, Quokka on 2022/05/17.
 //
 
+import UIKit
+
+final class ProductGridCollectionViewCell: UICollectionViewCell {
+  private let containerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    return stackView
+  }()
+  
+  private let informationStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    return stackView
+  }()
+  
+  private let priceStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    return stackView
+  }()
+  
+  private let productImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+  
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.font = .preferredFont(forTextStyle: .headline)
+    return label
+  }()
+  
+  private let priceLabel: UILabel = {
+    let label = UILabel()
+    label.textColor = .systemRed
+    return label
+  }()
+  
+  private let bargainPriceLabel: UILabel = {
+    let label = UILabel()
+    label.textColor = .systemGray
+    return label
+  }()
+  
+  private let stockLabel: UILabel = {
+    let label = UILabel()
+    label.textColor = .systemGray
+    return label
+  }()
+}

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -1,0 +1,7 @@
+//
+//  ProductGridCollectionViewCell.swift
+//  OpenMarket
+//
+//  Created by Lingo, Quokka on 2022/05/17.
+//
+

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -75,8 +75,8 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   
   func setup(product: Product) {
     self.titleLabel.text = product.name
-    self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price)")
-    self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice)"
+    self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price.toDecimal)")
+    self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice.toDecimal)"
     self.setStockLabel(product)
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
   }

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -11,12 +11,15 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   private let containerStackView: UIStackView = {
     let stackView = UIStackView()
     stackView.axis = .vertical
+    stackView.alignment = .center
+    stackView.distribution = .equalSpacing
     return stackView
   }()
   
   private let informationStackView: UIStackView = {
     let stackView = UIStackView()
     stackView.axis = .vertical
+    stackView.spacing = 6.0
     return stackView
   }()
   
@@ -41,12 +44,14 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   private let priceLabel: UILabel = {
     let label = UILabel()
     label.textColor = .systemRed
+    label.textAlignment = .center
     return label
   }()
   
   private let bargainPriceLabel: UILabel = {
     let label = UILabel()
     label.textColor = .systemGray
+    label.textAlignment = .center
     return label
   }()
   
@@ -82,6 +87,9 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   }
   
   private func configureUI() {
+    self.contentView.layer.borderWidth = 1.0
+    self.contentView.layer.cornerRadius = 10.0
+    self.contentView.layer.borderColor = UIColor.systemGray.cgColor
     self.contentView.addSubview(containerStackView)
     self.containerStackView.addArrangedSubview(productImageView)
     self.containerStackView.addArrangedSubview(informationStackView)
@@ -95,9 +103,11 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     self.containerStackView.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
       containerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-      containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
       containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-      containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+      containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+      containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10.0),
+      productImageView.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.6),
+      productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.8)
     ])
   }
 }

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -133,7 +133,6 @@ private extension ProductGridCollectionViewCell {
       containerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
       containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
       containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-      containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10.0),
       productImageView.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.6),
       productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.8)
     ])

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -55,4 +55,35 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     label.textColor = .systemGray
     return label
   }()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    self.configureUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.configureUI()
+  }
+  
+  private func configureUI() {
+    self.contentView.addSubview(containerStackView)
+    self.containerStackView.addArrangedSubview(productImageView)
+    self.containerStackView.addArrangedSubview(informationStackView)
+    self.containerStackView.addArrangedSubview(stockLabel)
+    
+    self.informationStackView.addArrangedSubview(titleLabel)
+    self.informationStackView.addArrangedSubview(priceStackView)
+    self.priceStackView.addArrangedSubview(priceLabel)
+    self.priceStackView.addArrangedSubview(bargainPriceLabel)
+    
+    self.containerStackView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      containerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+      containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+      containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+      containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+    ])
+  }
 }
+

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -73,8 +73,8 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   
   func setup(product: Product) {
     self.titleLabel.text = product.name
-    self.priceLabel.setStrike(text: "\(product.price)")
-    self.bargainPriceLabel.text = "\(product.bargainPrice)"
+    self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price)")
+    self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice)"
     self.stockLabel.text = "잔여수량: \(product.stock)"
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
   }

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -128,10 +128,12 @@ private extension ProductGridCollectionViewCell {
     self.priceStackView.addArrangedSubview(bargainPriceLabel)
     
     self.containerStackView.translatesAutoresizingMaskIntoConstraints = false
+    self.productImageView.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
       containerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
       containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
       containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+      containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10.0),
       productImageView.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.6),
       productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.8)
     ])

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -37,6 +37,7 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   
   private let titleLabel: UILabel = {
     let label = UILabel()
+    label.textAlignment = .center
     label.font = .preferredFont(forTextStyle: .headline)
     return label
   }()
@@ -58,6 +59,7 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   private let stockLabel: UILabel = {
     let label = UILabel()
     label.textColor = .systemGray
+    label.textAlignment = .center
     return label
   }()
   
@@ -75,7 +77,16 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     self.titleLabel.text = product.name
     self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price)")
     self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice)"
-    self.stockLabel.text = "잔여수량: \(product.stock)"
+    
+    if product.stock == 0 {
+      self.stockLabel.textColor = .systemOrange
+      self.stockLabel.text = "품절"
+    } else {
+      self.stockLabel.textColor = .secondaryLabel
+      self.stockLabel.text = "잔여수량: \(product.stock)"
+    }
+    
+
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
   }
   

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -132,7 +132,6 @@ private extension ProductGridCollectionViewCell {
       containerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
       containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
       containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-      containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10.0),
       productImageView.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.6),
       productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.8)
     ])

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -73,7 +73,7 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
   
   func setup(product: Product) {
     self.titleLabel.text = product.name
-    self.priceLabel.text = "\(product.price)"
+    self.priceLabel.setStrike(text: "\(product.price)")
     self.bargainPriceLabel.text = "\(product.bargainPrice)"
     self.stockLabel.text = "잔여수량: \(product.stock)"
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -77,7 +77,11 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     self.titleLabel.text = product.name
     self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price)")
     self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice)"
-    
+    self.setStockLabel(product)
+    self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
+  }
+  
+  private func setStockLabel(_ product: Product) {
     if product.stock == 0 {
       self.stockLabel.textColor = .systemOrange
       self.stockLabel.text = "품절"
@@ -85,9 +89,6 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
       self.stockLabel.textColor = .secondaryLabel
       self.stockLabel.text = "잔여수량: \(product.stock)"
     }
-    
-
-    self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
   }
   
   private func convertImageFromData(url urlString: String) -> Data {

--- a/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductGridCollectionViewCell.swift
@@ -66,6 +66,21 @@ final class ProductGridCollectionViewCell: UICollectionViewCell {
     self.configureUI()
   }
   
+  func setup(product: Product) {
+    self.titleLabel.text = product.name
+    self.priceLabel.text = "\(product.price)"
+    self.bargainPriceLabel.text = "\(product.bargainPrice)"
+    self.stockLabel.text = "잔여수량: \(product.stock)"
+    self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
+  }
+  
+  private func convertImageFromData(url urlString: String) -> Data {
+    guard let url = URL(string: urlString),
+          let data = try? Data(contentsOf: url)
+    else { return Data() }
+    return data
+  }
+  
   private func configureUI() {
     self.contentView.addSubview(containerStackView)
     self.containerStackView.addArrangedSubview(productImageView)

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -87,8 +87,8 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
   
   func setup(product: Product) {
     self.titleLabel.text = product.name
-    self.priceLabel.setStrike(text: "\(product.price)")
-    self.bargainPriceLabel.text = "\(product.bargainPrice)"
+    self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price)")
+    self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice)"
     self.stockLabel.text = "잔여수량: \(product.stock)"
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
   }

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -81,6 +81,21 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     self.configureUI()
   }
   
+  func setup(product: Product) {
+    self.titleLabel.text = product.name
+    self.priceLabel.text = "\(product.price)"
+    self.bargainPriceLabel.text = "\(product.bargainPrice)"
+    self.stockLabel.text = "잔여수량: \(product.stock)"
+    self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
+  }
+  
+  private func convertImageFromData(url urlString: String) -> Data {
+    guard let url = URL(string: urlString),
+          let data = try? Data(contentsOf: url)
+    else { return Data() }
+    return data
+  }
+  
   private func configureUI() {
     self.contentView.addSubview(containerStackView)
     self.containerStackView.addArrangedSubview(productImageView)

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -87,8 +87,8 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
   
   func setup(product: Product) {
     self.titleLabel.text = product.name
-    self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price)")
-    self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice)"
+    self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price.toDecimal)")
+    self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice.toDecimal)"
     self.setStockLabel(product)
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
   }

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -53,7 +53,6 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
   private let priceLabel: UILabel = {
     let label = UILabel()
     label.textColor = .systemRed
-    label.adjustsFontSizeToFitWidth = true
     label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     return label
   }()
@@ -68,6 +67,7 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
   private let stockLabel: UILabel = {
     let label = UILabel()
     label.textColor = .systemGray
+    label.textAlignment = .right
     return label
   }()
   
@@ -140,11 +140,14 @@ private extension ProductListCollectionViewCell {
       containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
       containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
       containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-      
+      stockLabel.widthAnchor.constraint(equalTo: disclosureImageView.widthAnchor, multiplier: 9.0),
       productImageView.heightAnchor.constraint(equalTo: contentView.heightAnchor),
       productImageView.widthAnchor.constraint(
         equalTo: productImageView.heightAnchor,
-        multiplier: 1.0)
+        multiplier: 1.0),
+      informationStackView.widthAnchor.constraint(
+        lessThanOrEqualToConstant: contentView.bounds.width * 0.5
+      )
     ])
   }
   

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -52,9 +52,34 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
   
   override init(frame: CGRect) {
     super.init(frame: frame)
+    self.configureUI()
   }
   
   required init?(coder: NSCoder) {
     super.init(coder: coder)
+    self.configureUI()
+  }
+  
+  private func configureUI() {
+    self.contentView.addSubview(containerStackView)
+    self.containerStackView.addArrangedSubview(productImageView)
+    self.containerStackView.addArrangedSubview(informationStackView)
+    self.containerStackView.addArrangedSubview(quantityStackView)
+    
+    self.informationStackView.addArrangedSubview(titleLabel)
+    self.informationStackView.addArrangedSubview(priceStackView)
+    self.priceStackView.addArrangedSubview(bargainPriceLabel)
+    self.priceStackView.addArrangedSubview(priceLabel)
+    
+    self.quantityStackView.addArrangedSubview(stockLabel)
+    self.quantityStackView.addArrangedSubview(disclosureImageView)
+    
+    self.containerStackView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      containerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+      containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+      containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+      containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+    ])
   }
 }

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -85,23 +85,13 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     self.configureUI()
   }
   
-  func setup(product: Product) {
+  func setUp(product: Product) {
+    self.setStockLabel(product)
     self.titleLabel.text = product.name
     self.priceLabel.isHidden = product.discountedPrice == .zero
     self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price.toDecimal)")
     self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice.toDecimal)"
-    self.setStockLabel(product)
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
-  }
-  
-  private func setStockLabel(_ product: Product) {
-    if product.stock == 0 {
-      self.stockLabel.textColor = .systemOrange
-      self.stockLabel.text = "품절"
-    } else {
-      self.stockLabel.textColor = .secondaryLabel
-      self.stockLabel.text = "잔여수량: \(product.stock)"
-    }
   }
   
   private func convertImageFromData(url urlString: String) -> Data {
@@ -110,19 +100,22 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     else { return Data() }
     return data
   }
-  
-  private func addBottomBorder(thickness: CGFloat) {
-    let border = CALayer()
-    border.frame = CGRect(
-      x: 0,
-      y: contentView.frame.height - thickness,
-      width: contentView.frame.width,
-      height: thickness)
-    border.backgroundColor = UIColor.systemGray4.cgColor
-    self.contentView.layer.addSublayer(border)
+}
+
+// MARK: - UI
+
+private extension ProductListCollectionViewCell {
+  func setStockLabel(_ product: Product) {
+    if product.stock == .zero {
+      self.stockLabel.textColor = .systemOrange
+      self.stockLabel.text = ProductConstant.soldOut
+    } else {
+      self.stockLabel.textColor = .secondaryLabel
+      self.stockLabel.text = "\(ProductConstant.remainStock) \(product.stock)"
+    }
   }
   
-  private func configureUI() {
+  func configureUI() {
     self.addBottomBorder(thickness: 1.0)
     self.contentView.addSubview(containerStackView)
     self.containerStackView.addArrangedSubview(productImageView)
@@ -150,5 +143,16 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
         equalTo: productImageView.heightAnchor,
         multiplier: 1.0)
     ])
+  }
+  
+  func addBottomBorder(thickness: CGFloat) {
+    let border = CALayer()
+    border.frame = CGRect(
+      x: .zero,
+      y: contentView.frame.height - thickness,
+      width: contentView.frame.width,
+      height: thickness)
+    border.backgroundColor = UIColor.systemGray4.cgColor
+    self.contentView.layer.addSublayer(border)
   }
 }

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -8,10 +8,31 @@
 import UIKit
 
 final class ProductListCollectionViewCell: UICollectionViewCell {
-  private let containerStackView = UIStackView()
-  private let informationStackView = UIStackView()
-  private let priceStackView = UIStackView()
-  private let quantityStackView = UIStackView()
+  private let containerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    return stackView
+  }()
+  
+  private let informationStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .leading
+    return stackView
+  }()
+  
+  private let priceStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    return stackView
+  }()
+  
+  private let quantityStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .top
+    return stackView
+  }()
 
   private let productImageView: UIImageView = {
     let imageView = UIImageView()
@@ -68,8 +89,8 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     
     self.informationStackView.addArrangedSubview(titleLabel)
     self.informationStackView.addArrangedSubview(priceStackView)
-    self.priceStackView.addArrangedSubview(bargainPriceLabel)
     self.priceStackView.addArrangedSubview(priceLabel)
+    self.priceStackView.addArrangedSubview(bargainPriceLabel)
     
     self.quantityStackView.addArrangedSubview(stockLabel)
     self.quantityStackView.addArrangedSubview(disclosureImageView)

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -87,6 +87,7 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
   
   func setup(product: Product) {
     self.titleLabel.text = product.name
+    self.priceLabel.isHidden = product.discountedPrice == .zero
     self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price.toDecimal)")
     self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice.toDecimal)"
     self.setStockLabel(product)

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -53,12 +53,15 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
   private let priceLabel: UILabel = {
     let label = UILabel()
     label.textColor = .systemRed
+    label.adjustsFontSizeToFitWidth = true
+    label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     return label
   }()
   
   private let bargainPriceLabel: UILabel = {
     let label = UILabel()
     label.textColor = .systemGray
+    label.adjustsFontSizeToFitWidth = true
     return label
   }()
   

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -89,7 +89,11 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     self.titleLabel.text = product.name
     self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price)")
     self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice)"
-    
+    self.setStockLabel(product)
+    self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
+  }
+  
+  private func setStockLabel(_ product: Product) {
     if product.stock == 0 {
       self.stockLabel.textColor = .systemOrange
       self.stockLabel.text = "품절"
@@ -97,8 +101,6 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
       self.stockLabel.textColor = .secondaryLabel
       self.stockLabel.text = "잔여수량: \(product.stock)"
     }
-    
-    self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
   }
   
   private func convertImageFromData(url urlString: String) -> Data {

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -89,7 +89,15 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     self.titleLabel.text = product.name
     self.priceLabel.setStrike(text: "\(product.currency.rawValue) \(product.price)")
     self.bargainPriceLabel.text = "\(product.currency.rawValue) \(product.bargainPrice)"
-    self.stockLabel.text = "잔여수량: \(product.stock)"
+    
+    if product.stock == 0 {
+      self.stockLabel.textColor = .systemOrange
+      self.stockLabel.text = "품절"
+    } else {
+      self.stockLabel.textColor = .secondaryLabel
+      self.stockLabel.text = "잔여수량: \(product.stock)"
+    }
+    
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))
   }
   

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -110,7 +110,19 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     return data
   }
   
+  private func addBottomBorder(thickness: CGFloat) {
+    let border = CALayer()
+    border.frame = CGRect(
+      x: 0,
+      y: contentView.frame.height - thickness,
+      width: contentView.frame.width,
+      height: thickness)
+    border.backgroundColor = UIColor.systemGray4.cgColor
+    self.contentView.layer.addSublayer(border)
+  }
+  
   private func configureUI() {
+    self.addBottomBorder(thickness: 1.0)
     self.contentView.addSubview(containerStackView)
     self.containerStackView.addArrangedSubview(productImageView)
     self.containerStackView.addArrangedSubview(informationStackView)

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -7,4 +7,54 @@
 
 import UIKit
 
-class ProductListCollectionViewCell: UICollectionViewCell {}
+final class ProductListCollectionViewCell: UICollectionViewCell {
+  private let containerStackView = UIStackView()
+  private let informationStackView = UIStackView()
+  private let priceStackView = UIStackView()
+  private let quantityStackView = UIStackView()
+
+  private let productImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+  
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.font = .preferredFont(forTextStyle: .headline)
+    return label
+  }()
+  
+  private let priceLabel: UILabel = {
+    let label = UILabel()
+    label.textColor = .systemRed
+    return label
+  }()
+  
+  private let bargainPriceLabel: UILabel = {
+    let label = UILabel()
+    label.textColor = .systemGray
+    return label
+  }()
+  
+  private let stockLabel: UILabel = {
+    let label = UILabel()
+    label.textColor = .systemGray
+    return label
+  }()
+  
+  private let disclosureImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.tintColor = .systemGray
+    imageView.image = UIImage(systemName: "chevron.right")
+    return imageView
+  }()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+}

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -87,7 +87,7 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
   
   func setup(product: Product) {
     self.titleLabel.text = product.name
-    self.priceLabel.text = "\(product.price)"
+    self.priceLabel.setStrike(text: "\(product.price)")
     self.bargainPriceLabel.text = "\(product.bargainPrice)"
     self.stockLabel.text = "잔여수량: \(product.stock)"
     self.productImageView.image = UIImage(data: convertImageFromData(url: product.thumbnail))

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -11,6 +11,7 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
   private let containerStackView: UIStackView = {
     let stackView = UIStackView()
     stackView.axis = .horizontal
+    stackView.spacing = 6.0
     return stackView
   }()
   
@@ -18,12 +19,15 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     let stackView = UIStackView()
     stackView.axis = .vertical
     stackView.alignment = .leading
+    stackView.distribution = .fillEqually
     return stackView
   }()
   
   private let priceStackView: UIStackView = {
     let stackView = UIStackView()
     stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.spacing = 6.0
     return stackView
   }()
   
@@ -111,11 +115,17 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
     self.quantityStackView.addArrangedSubview(disclosureImageView)
     
     self.containerStackView.translatesAutoresizingMaskIntoConstraints = false
+    self.productImageView.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
       containerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
       containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
       containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-      containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+      containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+      
+      productImageView.heightAnchor.constraint(equalTo: contentView.heightAnchor),
+      productImageView.widthAnchor.constraint(
+        equalTo: productImageView.heightAnchor,
+        multiplier: 1.0)
     ])
   }
 }

--- a/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/View/ProductListCollectionViewCell.swift
@@ -1,0 +1,10 @@
+//
+//  ProductListCollectionViewCell.swift
+//  OpenMarket
+//
+//  Created by Lingo, Quokka on 2022/05/16.
+//
+
+import UIKit
+
+class ProductListCollectionViewCell: UICollectionViewCell {}

--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@
 ## 목차
 
 - [키워드](#키워드)
-- [STEP 1](#step-1)
-    + [고민 및 해결한 점](#고민_및_해결한_점)
-- [STEP 2](#step-2)
-    + [고민 및 해결한 점](#고민_및_해결한_점)
+- [STEP 1](#STEP-1)
+    + [고민 및 해결한 점](#고민-및-해결한-점)
+    + [조언받고 싶은 점](#조언받고-싶은-점)
+- [STEP 2](#STEP-2)
+    + [고민 및 알게된 점](#고민-및-알게된-점)
+    + [해결한 점](#해결한-점)
+    + [조언받고 싶은 점](#조언받고-싶은-점)
 - [그라운드 룰](#그라운드-룰)
     + [활동시간](#활동시간)
     + [코딩 컨벤션](#코딩-컨벤션) 
@@ -22,6 +25,10 @@
 - `HTTP Request / Response`
 - `Result 타입`
 - `@escaping Closure`
+- `UICollectionView`
+- `UIActivityIndicator`
+- `UISegmentControl`
+- `AutoLayout`
 
 ---
 
@@ -49,8 +56,139 @@ URLSession과 서버와의 데이터 통신이라는 개념 이해를 위해 계
 ---
 
 ## STEP 2
-### 고민 및 해결한 점
+### 고민 및 알게된 점
+
+- UICollectionViewLayout과 UICollectionViewFlowLayout의 개념과 차이점에 대해 공부했고 UICollectionViewLayout은 추상 클래스이므로 서브클래싱하여 구현해야한다는 것을 알게되었습니다.
+- minimumInterItemSpacing, minimumLineSpacing의 개념과 Scroll 방향에 따라 차이점을 알게되었습니다.
+(vertical의 interitemSpacing은 가로방향이고 lineSpacing은 세로라인의 간격을 말한다. horizental일 경우에는 vertical과 반대로 적용됨)
+- UICollectionViewDataSource는 컬렉션 뷰에서 필수로 제공해야하며 Data를 관리하고 해당 content를 표현하는데 필요한 View를 만든다는 것을 알게되었습니다.
+- .systemColor와 color의 차이점을 알게되었습니다.
+- 기본의 FlowLayout은 `Section-Item`으로 구현되어있어 하나의 Section안에 다른 레이아웃을 적용하기 힘들었지만 iOS 13부터 CompositionalLayout에서 `Section-Group-Item`의 Group 계층을 추가하여 한 Section에서 여러 그룹을 가지고 각 그룹별로 다른 레이아웃을 적용할 수 있도록 변경된 것을 알 수 있었습니다.
+- FlowLayout을 사용하여 CollectionView를 TableView 같은 리스트의 형태로 구성할 수 있을지에 대해 고민했습니다.
+- UICollectionViewCell의 크기를 조절하는 방법을 고민했고 itemSize 프로퍼티를 변경하는 방법으로 진행했습니다. 공식 문서에는 FlowLayout Delegate의 [collectionView:sizeForItemAt](https://developer.apple.com/documentation/uikit/uicollectionviewdelegateflowlayout/1617708-collectionview) 메서드를 구현하지 않으면 itemSize 프로퍼티를 통해 크기를 구성하게된다는 것과 Cell의 크기를 조절하는 방법에는 여러가지 방법이 있다는 사실을 알 수 있었습니다. [참고) 셀 크기를 조절하는 방법](https://gyuios.tistory.com/124)
+- 네비게이션 바에는 View를 넣을 수 있는 설정이 있으며 구현된 segmentControl을 네비게이션 바의 `navigationItem.titleView = segmentControl`로 할당하였습니다.
+- lazy var와 let에 대해 고민했습니다. lazy var로 프로퍼티를 생성하면 내부에 self를 사용할 수 있습니다. 그래서 내부에 self 넣어야하거나 부가적인 설정이 많을 경우에는 lazy var로 설정해주었고 그 외에는 let으로 설정해주었습니다. 왜냐하면 멀티스레드 환경에서 두번이상의 초기화가 될 수 있다는 단점이 존재하기 때문에 구분했습니다.
+- cell의 테두리에 실선을 적용하는 방법, bolder적용하는 방법에 대해 학습하였습니다.
+	- border 적용시 볼더색상, 볼더의 두께, 볼더의 굴곡 이 3가지를 적용
+- init(frame: ), init?(coder: ) 이 두 가지에서 코드로 생성하면 init(frame:)이 보통 실행되는데 실패했을경우 init?(coder:)도 호출이 될 수 있기 때문에 양측 init에 모두 UI를 구성하는 메서드를 넣어주는게 안전하다는 것을 알게되었습니다.
+
+
+**DispatchQueue.main.async 안에 reloadData를 해줘야하는 이유**
+
+![](https://i.imgur.com/ik0mPNP.png)
+![](https://i.imgur.com/iBEPXoe.png)
+
+`loadProductListData` 메서드내에서 비동기방식으로 처리가되기때문에 다른 Thread에서 
+`self.productList = productList ` 코드와 같이 값을 할당해준다. 
+이 처리하는 Thread를 6번 Thread라고 가정하면 6번이 didSet을 불러잃으킨것이고 
+그런데 19 번줄에 있는 `productList`의 didSet프로퍼티는 Thread 6번에서 호출이되었기때문에 main이 아닌 다른스레드에 있는상황이다. 고로 main에 전달을 해주어야하는 상황인 것이다.
+
+만일 `DispatchQueue.main.async{}`로 처리가 되지않았다면 6번 Thread가 `self.collectionView.reloadData()`인 UI작업을 처리하게되기때문에 에러가 발생할 것이다.
+
+**콘솔 로그에 아래의 메시지 대해**
+```
+Will attempt to recover by breaking constraint 
+<NSLayoutConstraint:0x600003d27020 UIStackView:0x14e50d800.bottom == OpenMarket.MyCollectionViewCell:0x14e50d580.bottom   (active)>
+
+Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
+The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
+```
+오토레이아웃을 코드로 작성할 때 `translatesAutoresizingMaskIntoConstraints = false`로 하지 않으면 나타나는 문제인 것을 알 수 있었습니다.
+
+**SegmentControl의 스타일 변경에 대해**
+과거 SegmentControl은 파란 테두리의 형태로 되어있고 요구사항도 파란 테두리의 과거 형태로 되어있었습니다. 애플에서 iOS 버전을 올리면서 SegmentControl의 기본 UI를 변경한 것을 알 수 있었고 이번 프로젝트에서는 제공하는 형태를 사용했습니다.
+
+**CollectionView의 List와 Grid 레이아웃 변경에 대해**
+List와 Grid를 클릭했을때 UI 구성이 바뀌는 로직을 어떻게 구성할지 고민했고 List, Grid 형태의 2개의 셀을 구현하여 SegmentControl의 값이 변경될 때 선택된 Index에 따라 Layout과 셀을 변경하고 collectionView를 reload 해주는 방식으로 구현했습니다.
+
+---
+
+### 해결한 점
+**itemSize 프로퍼티와 Delegate 메서드애 대해**
+itemSize 프로퍼티를 변경하여도 고정된 List 크기만 나오는 문제가 있었습니다. Delegate로 셀의 크기를 정해주는 메서드로 사이즈를 정해주게 되면 itemSize 프로퍼티를 변경하더라도 Delegate메서드가 우선적으로 적용된다는 것을 알게되어 Delegate에 구현된 메서드를 제거하여 해결할 수 있었습니다.
+
+**ReloadData를 하지 않았을 때 발생하는 에러**
+List에서 Grid로 변경 후 다시 List로 돌아올 때 아래 첨부된 사진처럼 Layout은 변경이 되었지만 Cell의 구성, 오토레이아웃이 변경되지 않는 문제가 있었습니다. 
+
+<img width="200px" src="https://i.imgur.com/vPEYwjP.png"/> <br/>
+
+이를 해결하기 위해 collectionView.reloadData()를 해줘 DataSource 메서드의 재호출을 통해 모든 셀을 갱신하도록 변경하여 해결할 수 있었습니다.
+
+**가격 및 할인 가격 Label의 길이가 길어질 때 오류에 대해**
+List 목록 화면에서 priceLabel 1,2의 문자열 길이가 길어질 경우에 대한 오류 해결
+![](https://i.imgur.com/AuhPce5.png)
+=> 어떤 레이블의 크기를 줄여야하는지 모르겠다는 에러로 파악했습니다. 그래서 label.setContentCompressionResistancePriority(_,for:)메서드로 중요하지 않은 label의 priority를
+낮춰주는 방식으로 해결하였습니다.
+
+---
+
 ### 조언받고 싶은 점
+
+**🔥 @escaping 클로저 내부에서 self를 참조하는 것에 대해**
+loadProductListData 메서드의 클로저 내부에서 self를 캡처하기 때문에 강한 참조가 발생할 수 있는 가능성이 있을 것이라고 생각했고 `weak self` 캡처리스트를 사용해야할지 말지를 고민했습니다.
+[You don't (always) need [weak self]](https://medium.com/@almalehdev/you-dont-always-need-weak-self-a778bec505ef) 글을 참고하여 캡처된 self가 클로저 자체를 소유하고 있지 않기 때문에 강한참조 문제가 없을 거라고 판단하였고 `Xcode -> Instrument`의 Leaks를 통해 메모리 누수 및 강한 참조가 발생하는 지 확인해본 결과 메모리 누수가 발생하지 않기 때문에 `weak self`를 써주지 않기로 판단했습니다. 저희의 생각을 맞는 것인지 놓친 점이 없는지 궁금합니다.
+
+**셀(Cell) 재사용에 대해**
+List셀일 때의 StackView axis가 horizental이고 Grid셀일 때는 verical인 점과 중복되는 코드가 많아보였습니다. 그래서 셀을 재사용할 수 있지 않을까? 라는 아이디어로 하나의 셀에 StackView의 설정을 바꾸는 방법을 시도해보았습니다. 하나의 셀의 StackView의 설정을 변경하도록 했을때 장단점이 무엇일지 고민해보았으며 크게 `가독성 vs 재사용성`으로 정의할 수 있었습니다.
+
+> 재사용을 위해 List, Grid를 하나의 셀로 합칠 것이냐, 가독성을 위해 List, Grid 셀을 구분해줄 것이냐! 🤔
+
+**1) 셀이 1개일 경우**
+
+- 장점
+    - 코드의 재사용성 증가
+- 단점
+    - 사이드이펙트가 발생
+    - 코드를 리펙토링할때 번거로울 것 같다.
+
+**2) 셀이 2개일 경우**
+- 장점
+	- list와 grid cell의 구분이 명확해져 가독성이 좋다.
+	- 보편적으로 cell을 두개로 구분하여 구현을 하고있기에 문제가 발생할때 캠퍼들과 얘기를 나눠볼 수 있을것같다.
+- 단점
+	- 중복 코드 발생
+
+저희가 생각했을때는 재사용을 위해 하나의 셀로 구현하면 List일 때와 Grid일 때의 로직을 하나의 셀이 처리하기 때문에 조건식에 따른 설정을 변경해야하므로 사이드이펙트가 발생하는 것 같았으며 확장성과 유지보수 측면에서도 기능이 추가되었을때 수정하기 까다롭지 않을까?라고 판단했습니다. 따라서, List와 Grid 셀을 구분해서 진행했습니다.
+
+- 1. 스택 뷰의 Axis 설정을 변경하여 하나의 셀에 두가지 기능을 하는 방법에 대해 어떻게 생각하시는 지
+- 2. 현업에서는 재사용과 가독성에 대해 고민할 때 우선하는 것이나 결정하는 기준이 있으신지 
+
+궁금합니다.
+
+**UI의 하드코딩에 대해**
+View와 ViewController을 분리를 시도해보면서 View를 초기화할 때 frame의 width와 height를 390pt와 같이 상수로 입력하는 것은 UI의 하드코딩이라고 생각했고 UIScreen.main.bounds의 Width와 height를 할당해주었습니다.현직에서는 오토레이아웃이나 frame을 설정할 때 
+
+- 1. UI를 구현할 때 일부분은 상수로 구현하시는 지
+- 2. 상수를 사용하지 않는다면 주로 어떤 방식으로 사용하시는 지
+
+궁금합니다.
+
+**layout 변경시 발생하는 Animation 에러에 대해**
+layout을 setCollectionViewLayout의 animated을 true로 설정하여 변경하면 아래의 에러메세지가 발생했습니다.
+```
+2022-05-17 17:14:46.948737+0900 OpenMarket[66055:10091602] [Snapshotting] 
+Snapshotting a view (0x15b914200, OpenMarket.ProductGridCollectionViewCell) 
+that has not been rendered at least once requires afterScreenUpdates:YES.
+```
+false로 변경해주며 발생하지 않기 때문에 Animation 과정에서 발생한 문제로 판단했지만 정확한 이유를 찾지 못했습니다.
+
+**RealodData시 1초미만의 멈춤현상에 대해**
+
+reLoadData list -> grid, grid -> list로 변경할때 약 1초미만의  정지가 발생하였습니다. 이게 동작하는 내부적인 로직에 대해 잘 이해하고있는지 확인을 받고 싶어서 질문드립니다.🤔 🤔
+
+```
+ViewController 초기화 시 collectionView를 생성함
+ColletionView: 어이~ DataSource씨 화면에 셀 몇개 만들어야 돼유?
+DataSource: productList.count개요.
+ColletionView: ㅇㅋ 그러면 각 Cell 어떻게 만들까유?
+DataSource: segmentControl에 따라 list와 grid셀 다르니깐 구분해서 만들어줘!
+ColletionView: ㅇㅋ 
+
+=> reloadData 실행시
+ColletionView: 현재 보여지고 있는 화면의 item들을 다 삭제하고 다시 cell 만들게~ (위 과정을 반복)
+```
+
+> realodData를 실행하면 컬렉션뷰에 현재 표시되는 항목을 삭제하고 DataSource의 현재상태를 기준으로 다시 Cell을 만듭니다. 효율성을 위해 컬렉션뷰는 보이는 cell과 cell의 보조 view만 표시합니다.라는 공식문서의 내용을 참고해보았습니다.
 
 ---
 


### PR DESCRIPTION
안녕하세요 @hyunable
STEP 2 PR 보내드립니다. 잘부탁드립니다. 🙇🏻🙇🏻

## 고민 및 알게된 점

- UICollectionViewLayout과 UICollectionViewFlowLayout의 개념과 차이점에 대해 공부했고 UICollectionViewLayout은 추상 클래스이므로 서브클래싱하여 구현해야한다는 것을 알게되었습니다.
- minimumInterItemSpacing, minimumLineSpacing의 개념과 Scroll 방향에 따라 차이점을 알게되었습니다.
(vertical의 interitemSpacing은 가로방향이고 lineSpacing은 세로라인의 간격을 말한다. horizental일 경우에는 vertical과 반대로 적용됨)
- UICollectionViewDataSource는 컬렉션 뷰에서 필수로 제공해야하며 Data를 관리하고 해당 content를 표현하는데 필요한 View를 만든다는 것을 알게되었습니다.
- .systemColor와 color의 차이점을 알게되었습니다.
- 기본의 FlowLayout은 `Section-Item`으로 구현되어있어 하나의 Section안에 다른 레이아웃을 적용하기 힘들었지만 iOS 13부터 CompositionalLayout에서 `Section-Group-Item`의 Group 계층을 추가하여 한 Section에서 여러 그룹을 가지고 각 그룹별로 다른 레이아웃을 적용할 수 있도록 변경된 것을 알 수 있었습니다.
- FlowLayout을 사용하여 CollectionView를 TableView 같은 리스트의 형태로 구성할 수 있을지에 대해 고민했습니다.
- UICollectionViewCell의 크기를 조절하는 방법을 고민했고 itemSize 프로퍼티를 변경하는 방법으로 진행했습니다. 공식 문서에는 FlowLayout Delegate의 [collectionView:sizeForItemAt](https://developer.apple.com/documentation/uikit/uicollectionviewdelegateflowlayout/1617708-collectionview) 메서드를 구현하지 않으면 itemSize 프로퍼티를 통해 크기를 구성하게된다는 것과 Cell의 크기를 조절하는 방법에는 여러가지 방법이 있다는 사실을 알 수 있었습니다. [참고) 셀 크기를 조절하는 방법](https://gyuios.tistory.com/124)
- 네비게이션 바에는 View를 넣을 수 있는 설정이 있으며 구현된 segmentControl을 네비게이션 바의 `navigationItem.titleView = segmentControl`로 할당하였습니다.
- lazy var와 let에 대해 고민했습니다. lazy var로 프로퍼티를 생성하면 내부에 self를 사용할 수 있습니다. 그래서 내부에 self 넣어야하거나 부가적인 설정이 많을 경우에는 lazy var로 설정해주었고 그 외에는 let으로 설정해주었습니다. 왜냐하면 멀티스레드 환경에서 두번이상의 초기화가 될 수 있다는 단점이 존재하기 때문에 구분했습니다.
- cell의 테두리에 실선을 적용하는 방법, bolder적용하는 방법에 대해 학습하였습니다.
	- border 적용시 볼더색상, 볼더의 두께, 볼더의 굴곡 이 3가지를 적용
- init(frame: ), init?(coder: ) 이 두 가지에서 코드로 생성하면 init(frame:)이 보통 실행되는데 실패했을경우 init?(coder:)도 호출이 될 수 있기 때문에 양측 init에 모두 UI를 구성하는 메서드를 넣어주는게 안전하다는 것을 알게되었습니다.

**DispatchQueue.main.async 안에 reloadData를 해줘야하는 이유** 🤔

![](https://i.imgur.com/ik0mPNP.png)
![](https://i.imgur.com/iBEPXoe.png)

`loadProductListData` 메서드내에서 비동기방식으로 처리가되기때문에 다른 Thread에서 
`self.productList = productList ` 코드와 같이 값을 할당해준다. 
이 처리하는 Thread를 6번 Thread라고 가정하면 6번이 didSet을 불러잃으킨것이고 
그런데 19 번줄에 있는 `productList`의 didSet프로퍼티는 Thread 6번에서 호출이되었기때문에 main이 아닌 다른스레드에 있는상황이다. 고로 main에 전달을 해주어야하는 상황인 것이다.

만일 `DispatchQueue.main.async{}`로 처리가 되지않았다면 6번 Thread가 `self.collectionView.reloadData()`인 UI작업을 처리하게되기때문에 에러가 발생할 것이다.

**콘솔 로그에 아래의 메시지 대해** 🤔
```
Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600003d27020 UIStackView:0x14e50d800.bottom == OpenMarket.MyCollectionViewCell:0x14e50d580.bottom   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
```
오토레이아웃을 코드로 작성할 때 `translatesAutoresizingMaskIntoConstraints = false`로 하지 않으면 나타나는 문제인 것을 알 수 있었습니다.

**SegmentControl의 스타일 변경에 대해**  🤔
과거 SegmentControl은 파란 테두리의 형태로 되어있고 요구사항도 파란 테두리의 과거 형태로 되어있었습니다. 애플에서 iOS 버전을 올리면서 SegmentControl의 기본 UI를 변경한 것을 알 수 있었고 이번 프로젝트에서는 제공하는 형태를 사용했습니다.

**CollectionView의 List와 Grid 레이아웃 변경에 대해** 🤔
List와 Grid를 클릭했을때 UI 구성이 바뀌는 로직을 어떻게 구성할지 고민했고 List, Grid 형태의 2개의 셀을 구현하여 SegmentControl의 값이 변경될 때 선택된 Index에 따라 Layout과 셀을 변경하고 collectionView를 reload 해주는 방식으로 구현했습니다.

---

## 해결한 점
**itemSize 프로퍼티와 Delegate 메서드애 대해**  🤔
itemSize 프로퍼티를 변경하여도 고정된 List 크기만 나오는 문제가 있었습니다. Delegate로 셀의 크기를 정해주는 메서드로 사이즈를 정해주게 되면 itemSize 프로퍼티를 변경하더라도 Delegate메서드가 우선적으로 적용된다는 것을 알게되어 Delegate에 구현된 메서드를 제거하여 해결할 수 있었습니다.

**ReloadData를 하지 않았을 때 발생하는 에러** 🤔
List에서 Grid로 변경 후 다시 List로 돌아올 때 아래 첨부된 사진처럼 Layout은 변경이 되었지만 Cell의 구성, 오토레이아웃이 변경되지 않는 문제가 있었습니다. 

<img width="200px" src="https://i.imgur.com/vPEYwjP.png"/> <br/>

이를 해결하기 위해 collectionView.reloadData()를 해줘 DataSource 메서드의 재호출을 통해 모든 셀을 갱신하도록 변경하여 해결할 수 있었습니다.

**가격 및 할인 가격 Label의 길이가 길어질 때 오류에 대해** 🤔
List 목록 화면에서 priceLabel 1,2의 문자열 길이가 길어질 경우에 대한 오류 해결
![](https://i.imgur.com/AuhPce5.png)
=> 어떤 레이블의 크기를 줄여야하는지 모르겠다는 에러로 파악했습니다. 그래서 label.setContentCompressionResistancePriority(_,for:)메서드로 중요하지 않은 label의 priority를
낮춰주는 방식으로 해결하였습니다.

---

## 조언받고 싶은 점

**🔥 @escaping 클로저 내부에서 self를 참조하는 것에 대해** 🤔
loadProductListData 메서드의 클로저 내부에서 self를 캡처하기 때문에 강한 참조가 발생할 수 있는 가능성이 있을 것이라고 생각했고 `weak self` 캡처리스트를 사용해야할지 말지를 고민했습니다.
[You don't (always) need [weak self]](https://medium.com/@almalehdev/you-dont-always-need-weak-self-a778bec505ef) 글을 참고하여 캡처된 self가 클로저 자체를 소유하고 있지 않기 때문에 강한참조 문제가 없을 거라고 판단하였고 `Xcode -> Instrument`의 Leaks를 통해 메모리 누수 및 강한 참조가 발생하는 지 확인해본 결과 메모리 누수가 발생하지 않기 때문에 `weak self`를 써주지 않기로 판단했습니다. 저희의 생각을 맞는 것인지 놓친 점이 없는지 궁금합니다.

**셀(Cell) 재사용에 대해** 🤔
List셀일 때의 StackView axis가 horizental이고 Grid셀일 때는 verical인 점과 중복되는 코드가 많아보였습니다. 그래서 셀을 재사용할 수 있지 않을까? 라는 아이디어로 하나의 셀에 StackView의 설정을 바꾸는 방법을 시도해보았습니다. 하나의 셀의 StackView의 설정을 변경하도록 했을때 장단점이 무엇일지 고민해보았으며 크게 `가독성 vs 재사용성`으로 정의할 수 있었습니다.

> 재사용을 위해 List, Grid를 하나의 셀로 합칠 것이냐, 가독성을 위해 List, Grid 셀을 구분해줄 것이냐! 

**1) 셀이 1개일 경우** 

- 장점
    - 코드의 재사용성 증가
- 단점
    - 사이드이펙트가 발생
    - 코드를 리펙토링할때 번거로울 것 같다.

**2) 셀이 2개일 경우**
- 장점
	- list와 grid cell의 구분이 명확해져 가독성이 좋다.
	- 보편적으로 cell을 두개로 구분하여 구현을 하고있기에 문제가 발생할때 캠퍼들과 얘기를 나눠볼 수 있을것같다.
- 단점
	- 중복 코드 발생

저희가 생각했을때는 재사용을 위해 하나의 셀로 구현하면 List일 때와 Grid일 때의 로직을 하나의 셀이 처리하기 때문에 조건식에 따른 설정을 변경해야하므로 사이드이펙트가 발생하는 것 같았으며 확장성과 유지보수 측면에서도 기능이 추가되었을때 수정하기 까다롭지 않을까?라고 판단했습니다. 따라서, List와 Grid 셀을 구분해서 진행했습니다.

- 1. 스택 뷰의 Axis 설정을 변경하여 하나의 셀에 두가지 기능을 하는 방법에 대해 어떻게 생각하시는 지
- 2. 현업에서는 재사용과 가독성에 대해 고민할 때 우선하는 것이나 결정하는 기준이 있으신지 

궁금합니다.

**UI의 하드코딩에 대해** 🤔
View와 ViewController을 분리를 시도해보면서 View를 초기화할 때 frame의 width와 height를 390pt와 같이 상수로 입력하는 것은 UI의 하드코딩이라고 생각했고 UIScreen.main.bounds의 Width와 height를 할당해주었습니다.현직에서는 오토레이아웃이나 frame을 설정할 때 

- 1. UI를 구현할 때 일부분은 상수로 구현하시는 지
- 2. 상수를 사용하지 않는다면 주로 어떤 방식으로 사용하시는 지

궁금합니다.

**layout 변경시 발생하는 Animation 에러에 대해** 🤔
layout을 setCollectionViewLayout의 animated을 true로 설정하여 변경하면 아래의 에러메세지가 발생했습니다.
```
2022-05-17 17:14:46.948737+0900 OpenMarket[66055:10091602] [Snapshotting] 
Snapshotting a view (0x15b914200, OpenMarket.ProductGridCollectionViewCell) 
that has not been rendered at least once requires afterScreenUpdates:YES.
```
false로 변경해주며 발생하지 않기 때문에 Animation 과정에서 발생한 문제로 판단했지만 정확한 이유를 찾지 못했습니다.

**RealodData시 1초미만의 멈춤현상에 대해** 🤔

reLoadData list -> grid, grid -> list로 변경할때 약 1초미만의  정지가 발생하였습니다. 이게 동작하는 내부적인 로직에 대해 잘 이해하고있는지 확인을 받고 싶어서 질문드립니다.

```
ViewController 초기화 시 collectionView를 생성함
ColletionView: 어이~ DataSource씨 화면에 셀 몇개 만들어야 돼유?
DataSource: productList.count개요.
ColletionView: ㅇㅋ 그러면 각 Cell 어떻게 만들까유?
DataSource: segmentControl에 따라 list와 grid셀 다르니깐 구분해서 만들어줘!
ColletionView: ㅇㅋ 

=> reloadData 실행시
ColletionView: 현재 보여지고 있는 화면의 item들을 다 삭제하고 다시 cell 만들게~ (위 과정을 반복)
```

> realodData를 실행하면 컬렉션뷰에 현재 표시되는 항목을 삭제하고 DataSource의 현재상태를 기준으로 다시 Cell을 만듭니다. 효율성을 위해 컬렉션뷰는 보이는 cell과 cell의 보조 view만 표시합니다.라는 공식문서의 내용을 참고해보았습니다.