### PR TITLE
오픈마켓 II [STEP 2] Mangdi, Woong

### DIFF
--- a/OpenMarket/.swiftlint.yml
+++ b/OpenMarket/.swiftlint.yml
@@ -10,4 +10,5 @@ disabled_rules: # 실행에서 제외할 룰 식별자들
 - legacy_random
 - unused_closure_parameter
 - mark
+- void_function_in_ternary
 opt_in_rules: # 일부 룰은 옵트 인 형태로 제공

--- a/OpenMarket/.swiftlint.yml
+++ b/OpenMarket/.swiftlint.yml
@@ -11,4 +11,5 @@ disabled_rules: # 실행에서 제외할 룰 식별자들
 - unused_closure_parameter
 - mark
 - void_function_in_ternary
+- type_body_length
 opt_in_rules: # 일부 룰은 옵트 인 형태로 제공

--- a/OpenMarket/.swiftlint.yml
+++ b/OpenMarket/.swiftlint.yml
@@ -7,4 +7,7 @@ disabled_rules: # 실행에서 제외할 룰 식별자들
 - function_body_length
 - function_parameter_count
 - legacy_constructor
+- legacy_random
+- unused_closure_parameter
+- mark
 opt_in_rules: # 일부 룰은 옵트 인 형태로 제공

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		D27FA6362923293E004E3B38 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = D27FA6352923293E004E3B38 /* .swiftlint.yml */; };
 		D27FA6402924839D004E3B38 /* SearchListProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27FA63F2924839D004E3B38 /* SearchListProducts.swift */; };
 		D27FA642292483F9004E3B38 /* DetailProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27FA641292483F9004E3B38 /* DetailProduct.swift */; };
+		D2AF64A9293F218300CA507F /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AF64A8293F218300CA507F /* ImageCacheManager.swift */; };
 		D2B4188E292C694800874541 /* CustomCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */; };
 		D2C0A4CF2938A84D00AB3D2D /* PostRequestParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */; };
 /* End PBXBuildFile section */
@@ -63,6 +64,7 @@
 		D27FA6352923293E004E3B38 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		D27FA63F2924839D004E3B38 /* SearchListProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListProducts.swift; sourceTree = "<group>"; };
 		D27FA641292483F9004E3B38 /* DetailProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProduct.swift; sourceTree = "<group>"; };
+		D2AF64A8293F218300CA507F /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCollectionViewCell.swift; sourceTree = "<group>"; };
 		D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRequestParams.swift; sourceTree = "<group>"; };
 		E2FDD5EB470EE761553CBF9F /* Pods-OpenMarket.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenMarket.debug.xcconfig"; path = "Target Support Files/Pods-OpenMarket/Pods-OpenMarket.debug.xcconfig"; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 				D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */,
 				09D2BC202938A21F009E0895 /* Data+Extensions.swift */,
 				D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */,
+				D2AF64A8293F218300CA507F /* ImageCacheManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -347,6 +350,7 @@
 				09D8602F2928C3AF008FBE56 /* APIError.swift.swift in Sources */,
 				D2B4188E292C694800874541 /* CustomCollectionViewCell.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
+				D2AF64A9293F218300CA507F /* ImageCacheManager.swift in Sources */,
 				09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */,
 				09D8602D2928BF8E008FBE56 /* ApiUrl.swift.swift in Sources */,
 				09D2BC212938A21F009E0895 /* Data+Extensions.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		D27FA642292483F9004E3B38 /* DetailProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27FA641292483F9004E3B38 /* DetailProduct.swift */; };
 		D292E1CD29431FA7007DEE20 /* CustomCollectionViewPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D292E1CC29431FA7007DEE20 /* CustomCollectionViewPageCell.swift */; };
 		D292E1CF29431FF7007DEE20 /* CustomCollectionViewPageCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D292E1CE29431FF7007DEE20 /* CustomCollectionViewPageCell.xib */; };
+		D292E1D129435C0D007DEE20 /* PatchRequestParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = D292E1D029435C0D007DEE20 /* PatchRequestParams.swift */; };
+		D292E1D329435C3D007DEE20 /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = D292E1D229435C3D007DEE20 /* Secret.swift */; };
 		D2AF64A9293F218300CA507F /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AF64A8293F218300CA507F /* ImageCacheManager.swift */; };
 		D2B4188E292C694800874541 /* CustomCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */; };
 		D2C0A4CF2938A84D00AB3D2D /* PostRequestParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */; };
@@ -70,6 +72,8 @@
 		D27FA641292483F9004E3B38 /* DetailProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProduct.swift; sourceTree = "<group>"; };
 		D292E1CC29431FA7007DEE20 /* CustomCollectionViewPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCollectionViewPageCell.swift; sourceTree = "<group>"; };
 		D292E1CE29431FF7007DEE20 /* CustomCollectionViewPageCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomCollectionViewPageCell.xib; sourceTree = "<group>"; };
+		D292E1D029435C0D007DEE20 /* PatchRequestParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchRequestParams.swift; sourceTree = "<group>"; };
+		D292E1D229435C3D007DEE20 /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
 		D2AF64A8293F218300CA507F /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCollectionViewCell.swift; sourceTree = "<group>"; };
 		D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRequestParams.swift; sourceTree = "<group>"; };
@@ -111,6 +115,8 @@
 				D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */,
 				D2AF64A8293F218300CA507F /* ImageCacheManager.swift */,
 				D292E1CC29431FA7007DEE20 /* CustomCollectionViewPageCell.swift */,
+				D292E1D029435C0D007DEE20 /* PatchRequestParams.swift */,
+				D292E1D229435C3D007DEE20 /* Secret.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -359,8 +365,10 @@
 				D27FA6402924839D004E3B38 /* SearchListProducts.swift in Sources */,
 				D2C0A4CF2938A84D00AB3D2D /* PostRequestParams.swift in Sources */,
 				09D8602F2928C3AF008FBE56 /* APIError.swift.swift in Sources */,
+				D292E1D329435C3D007DEE20 /* Secret.swift in Sources */,
 				D2B4188E292C694800874541 /* CustomCollectionViewCell.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
+				D292E1D129435C0D007DEE20 /* PatchRequestParams.swift in Sources */,
 				D2AF64A9293F218300CA507F /* ImageCacheManager.swift in Sources */,
 				09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */,
 				09D8602D2928BF8E008FBE56 /* ApiUrl.swift.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		D27FA6362923293E004E3B38 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = D27FA6352923293E004E3B38 /* .swiftlint.yml */; };
 		D27FA6402924839D004E3B38 /* SearchListProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27FA63F2924839D004E3B38 /* SearchListProducts.swift */; };
 		D27FA642292483F9004E3B38 /* DetailProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27FA641292483F9004E3B38 /* DetailProduct.swift */; };
+		D292E1CD29431FA7007DEE20 /* CustomCollectionViewPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D292E1CC29431FA7007DEE20 /* CustomCollectionViewPageCell.swift */; };
+		D292E1CF29431FF7007DEE20 /* CustomCollectionViewPageCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D292E1CE29431FF7007DEE20 /* CustomCollectionViewPageCell.xib */; };
 		D2AF64A9293F218300CA507F /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AF64A8293F218300CA507F /* ImageCacheManager.swift */; };
 		D2B4188E292C694800874541 /* CustomCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */; };
 		D2C0A4CF2938A84D00AB3D2D /* PostRequestParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */; };
@@ -66,6 +68,8 @@
 		D27FA6352923293E004E3B38 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		D27FA63F2924839D004E3B38 /* SearchListProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListProducts.swift; sourceTree = "<group>"; };
 		D27FA641292483F9004E3B38 /* DetailProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProduct.swift; sourceTree = "<group>"; };
+		D292E1CC29431FA7007DEE20 /* CustomCollectionViewPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCollectionViewPageCell.swift; sourceTree = "<group>"; };
+		D292E1CE29431FF7007DEE20 /* CustomCollectionViewPageCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomCollectionViewPageCell.xib; sourceTree = "<group>"; };
 		D2AF64A8293F218300CA507F /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCollectionViewCell.swift; sourceTree = "<group>"; };
 		D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRequestParams.swift; sourceTree = "<group>"; };
@@ -106,6 +110,7 @@
 				09D2BC202938A21F009E0895 /* Data+Extensions.swift */,
 				D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */,
 				D2AF64A8293F218300CA507F /* ImageCacheManager.swift */,
+				D292E1CC29431FA7007DEE20 /* CustomCollectionViewPageCell.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -117,6 +122,7 @@
 				C70FB10525BEF61D00C9924E /* LaunchScreen.storyboard */,
 				09D432EC292C6B04003C51A7 /* CustomCollectionViewGridCell.xib */,
 				09D39AEF292DBF020039F1B9 /* CustomCollectionViewListCell.xib */,
+				D292E1CE29431FF7007DEE20 /* CustomCollectionViewPageCell.xib */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -281,6 +287,7 @@
 			files = (
 				09D39AF0292DBF020039F1B9 /* CustomCollectionViewListCell.xib in Resources */,
 				D27FA6362923293E004E3B38 /* .swiftlint.yml in Resources */,
+				D292E1CF29431FF7007DEE20 /* CustomCollectionViewPageCell.xib in Resources */,
 				C70FB10725BEF61D00C9924E /* LaunchScreen.storyboard in Resources */,
 				C70FB10425BEF61D00C9924E /* Assets.xcassets in Resources */,
 				C70FB10225BEF61C00C9924E /* Main.storyboard in Resources */,
@@ -357,6 +364,7 @@
 				D2AF64A9293F218300CA507F /* ImageCacheManager.swift in Sources */,
 				09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */,
 				09D8602D2928BF8E008FBE56 /* ApiUrl.swift.swift in Sources */,
+				D292E1CD29431FA7007DEE20 /* CustomCollectionViewPageCell.swift in Sources */,
 				09D2BC212938A21F009E0895 /* Data+Extensions.swift in Sources */,
 				09DB0F8A292333C10038DE45 /* TestJsonProducts.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		09940CA829398F1100562037 /* ProductPostAndPatchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09940CA729398F1100562037 /* ProductPostAndPatchViewController.swift */; };
 		09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09987EB629248D48006B9922 /* NetworkCommunication.swift */; };
 		09CE2749294314B900BF18B3 /* ProductDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CE2748294314B900BF18B3 /* ProductDetailViewController.swift */; };
+		09CE8FA62944802B0050A955 /* Mode.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CE8FA52944802B0050A955 /* Mode.swift.swift */; };
 		09D2BC212938A21F009E0895 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D2BC202938A21F009E0895 /* Data+Extensions.swift */; };
 		09D39AF0292DBF020039F1B9 /* CustomCollectionViewListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09D39AEF292DBF020039F1B9 /* CustomCollectionViewListCell.xib */; };
 		09D432ED292C6B04003C51A7 /* CustomCollectionViewGridCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09D432EC292C6B04003C51A7 /* CustomCollectionViewGridCell.xib */; };
@@ -50,6 +51,7 @@
 		09940CA729398F1100562037 /* ProductPostAndPatchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPostAndPatchViewController.swift; sourceTree = "<group>"; };
 		09987EB629248D48006B9922 /* NetworkCommunication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCommunication.swift; sourceTree = "<group>"; };
 		09CE2748294314B900BF18B3 /* ProductDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailViewController.swift; sourceTree = "<group>"; };
+		09CE8FA52944802B0050A955 /* Mode.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mode.swift.swift; sourceTree = "<group>"; };
 		09D2BC202938A21F009E0895 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		09D39AEF292DBF020039F1B9 /* CustomCollectionViewListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomCollectionViewListCell.xib; sourceTree = "<group>"; };
 		09D432EC292C6B04003C51A7 /* CustomCollectionViewGridCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomCollectionViewGridCell.xib; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				D292E1CC29431FA7007DEE20 /* CustomCollectionViewPageCell.swift */,
 				D292E1D029435C0D007DEE20 /* PatchRequestParams.swift */,
 				D292E1D229435C3D007DEE20 /* Secret.swift */,
+				09CE8FA52944802B0050A955 /* Mode.swift.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -371,6 +374,7 @@
 				D292E1D129435C0D007DEE20 /* PatchRequestParams.swift in Sources */,
 				D2AF64A9293F218300CA507F /* ImageCacheManager.swift in Sources */,
 				09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */,
+				09CE8FA62944802B0050A955 /* Mode.swift.swift in Sources */,
 				09D8602D2928BF8E008FBE56 /* ApiUrl.swift.swift in Sources */,
 				D292E1CD29431FA7007DEE20 /* CustomCollectionViewPageCell.swift in Sources */,
 				09D2BC212938A21F009E0895 /* Data+Extensions.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09940CA829398F1100562037 /* RegisterProductViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09940CA729398F1100562037 /* RegisterProductViewController.swift */; };
 		09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09987EB629248D48006B9922 /* NetworkCommunication.swift */; };
 		09D2BC212938A21F009E0895 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D2BC202938A21F009E0895 /* Data+Extensions.swift */; };
 		09D39AF0292DBF020039F1B9 /* CustomCollectionViewListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09D39AEF292DBF020039F1B9 /* CustomCollectionViewListCell.xib */; };
@@ -40,6 +41,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		09940CA729398F1100562037 /* RegisterProductViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProductViewController.swift; sourceTree = "<group>"; };
 		09987EB629248D48006B9922 /* NetworkCommunication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCommunication.swift; sourceTree = "<group>"; };
 		09D2BC202938A21F009E0895 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		09D39AEF292DBF020039F1B9 /* CustomCollectionViewListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomCollectionViewListCell.xib; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				C70FB0FE25BEF61C00C9924E /* ViewController.swift */,
+				09940CA729398F1100562037 /* RegisterProductViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -337,6 +340,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D27FA642292483F9004E3B38 /* DetailProduct.swift in Sources */,
+				09940CA829398F1100562037 /* RegisterProductViewController.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				D27FA6402924839D004E3B38 /* SearchListProducts.swift in Sources */,
 				D2C0A4CF2938A84D00AB3D2D /* PostRequestParams.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		09940CA829398F1100562037 /* RegisterProductViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09940CA729398F1100562037 /* RegisterProductViewController.swift */; };
+		09940CA829398F1100562037 /* ProductPostAndPatchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09940CA729398F1100562037 /* ProductPostAndPatchViewController.swift */; };
 		09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09987EB629248D48006B9922 /* NetworkCommunication.swift */; };
 		09CE2749294314B900BF18B3 /* ProductDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CE2748294314B900BF18B3 /* ProductDetailViewController.swift */; };
 		09D2BC212938A21F009E0895 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D2BC202938A21F009E0895 /* Data+Extensions.swift */; };
@@ -20,7 +20,7 @@
 		7395F48AD40B7B21CB79D542 /* Pods_OpenMarket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF48DF131E6FB9CCACBA90D0 /* Pods_OpenMarket.framework */; };
 		C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */; };
 		C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */; };
-		C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FE25BEF61C00C9924E /* ViewController.swift */; };
+		C70FB0FF25BEF61C00C9924E /* ProductListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70FB0FE25BEF61C00C9924E /* ProductListViewController.swift */; };
 		C70FB10225BEF61C00C9924E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C70FB10025BEF61C00C9924E /* Main.storyboard */; };
 		C70FB10425BEF61D00C9924E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C70FB10325BEF61D00C9924E /* Assets.xcassets */; };
 		C70FB10725BEF61D00C9924E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C70FB10525BEF61D00C9924E /* LaunchScreen.storyboard */; };
@@ -47,7 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		09940CA729398F1100562037 /* RegisterProductViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProductViewController.swift; sourceTree = "<group>"; };
+		09940CA729398F1100562037 /* ProductPostAndPatchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPostAndPatchViewController.swift; sourceTree = "<group>"; };
 		09987EB629248D48006B9922 /* NetworkCommunication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCommunication.swift; sourceTree = "<group>"; };
 		09CE2748294314B900BF18B3 /* ProductDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailViewController.swift; sourceTree = "<group>"; };
 		09D2BC202938A21F009E0895 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
@@ -62,7 +62,7 @@
 		C70FB0F725BEF61C00C9924E /* OpenMarket.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenMarket.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70FB0FA25BEF61C00C9924E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C70FB0FC25BEF61C00C9924E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C70FB0FE25BEF61C00C9924E /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C70FB0FE25BEF61C00C9924E /* ProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListViewController.swift; sourceTree = "<group>"; };
 		C70FB10125BEF61C00C9924E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C70FB10325BEF61D00C9924E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C70FB10625BEF61D00C9924E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -136,8 +136,8 @@
 		09DB0F8D292334220038DE45 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				C70FB0FE25BEF61C00C9924E /* ViewController.swift */,
-				09940CA729398F1100562037 /* RegisterProductViewController.swift */,
+				C70FB0FE25BEF61C00C9924E /* ProductListViewController.swift */,
+				09940CA729398F1100562037 /* ProductPostAndPatchViewController.swift */,
 				09CE2748294314B900BF18B3 /* ProductDetailViewController.swift */,
 			);
 			path = Controller;
@@ -359,9 +359,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				D27FA642292483F9004E3B38 /* DetailProduct.swift in Sources */,
-				09940CA829398F1100562037 /* RegisterProductViewController.swift in Sources */,
+				09940CA829398F1100562037 /* ProductPostAndPatchViewController.swift in Sources */,
 				09CE2749294314B900BF18B3 /* ProductDetailViewController.swift in Sources */,
-				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
+				C70FB0FF25BEF61C00C9924E /* ProductListViewController.swift in Sources */,
 				D27FA6402924839D004E3B38 /* SearchListProducts.swift in Sources */,
 				D2C0A4CF2938A84D00AB3D2D /* PostRequestParams.swift in Sources */,
 				09D8602F2928C3AF008FBE56 /* APIError.swift.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09987EB629248D48006B9922 /* NetworkCommunication.swift */; };
+		09D2BC212938A21F009E0895 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D2BC202938A21F009E0895 /* Data+Extensions.swift */; };
 		09D39AF0292DBF020039F1B9 /* CustomCollectionViewListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09D39AEF292DBF020039F1B9 /* CustomCollectionViewListCell.xib */; };
 		09D432ED292C6B04003C51A7 /* CustomCollectionViewGridCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09D432EC292C6B04003C51A7 /* CustomCollectionViewGridCell.xib */; };
 		09D8602D2928BF8E008FBE56 /* ApiUrl.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D8602C2928BF8E008FBE56 /* ApiUrl.swift.swift */; };
@@ -39,6 +40,7 @@
 
 /* Begin PBXFileReference section */
 		09987EB629248D48006B9922 /* NetworkCommunication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCommunication.swift; sourceTree = "<group>"; };
+		09D2BC202938A21F009E0895 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		09D39AEF292DBF020039F1B9 /* CustomCollectionViewListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomCollectionViewListCell.xib; sourceTree = "<group>"; };
 		09D432EC292C6B04003C51A7 /* CustomCollectionViewGridCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomCollectionViewGridCell.xib; sourceTree = "<group>"; };
 		09D8602C2928BF8E008FBE56 /* ApiUrl.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiUrl.swift.swift; sourceTree = "<group>"; };
@@ -93,6 +95,7 @@
 				09D8602C2928BF8E008FBE56 /* ApiUrl.swift.swift */,
 				09D8602E2928C3AF008FBE56 /* APIError.swift.swift */,
 				D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */,
+				09D2BC202938A21F009E0895 /* Data+Extensions.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -338,6 +341,7 @@
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
 				09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */,
 				09D8602D2928BF8E008FBE56 /* ApiUrl.swift.swift in Sources */,
+				09D2BC212938A21F009E0895 /* Data+Extensions.swift in Sources */,
 				09DB0F8A292333C10038DE45 /* TestJsonProducts.swift in Sources */,
 				C70FB0FD25BEF61C00C9924E /* SceneDelegate.swift in Sources */,
 			);

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		09940CA829398F1100562037 /* RegisterProductViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09940CA729398F1100562037 /* RegisterProductViewController.swift */; };
 		09987EB729248D48006B9922 /* NetworkCommunication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09987EB629248D48006B9922 /* NetworkCommunication.swift */; };
+		09CE2749294314B900BF18B3 /* ProductDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CE2748294314B900BF18B3 /* ProductDetailViewController.swift */; };
 		09D2BC212938A21F009E0895 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D2BC202938A21F009E0895 /* Data+Extensions.swift */; };
 		09D39AF0292DBF020039F1B9 /* CustomCollectionViewListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09D39AEF292DBF020039F1B9 /* CustomCollectionViewListCell.xib */; };
 		09D432ED292C6B04003C51A7 /* CustomCollectionViewGridCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09D432EC292C6B04003C51A7 /* CustomCollectionViewGridCell.xib */; };
@@ -44,6 +45,7 @@
 /* Begin PBXFileReference section */
 		09940CA729398F1100562037 /* RegisterProductViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProductViewController.swift; sourceTree = "<group>"; };
 		09987EB629248D48006B9922 /* NetworkCommunication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCommunication.swift; sourceTree = "<group>"; };
+		09CE2748294314B900BF18B3 /* ProductDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailViewController.swift; sourceTree = "<group>"; };
 		09D2BC202938A21F009E0895 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		09D39AEF292DBF020039F1B9 /* CustomCollectionViewListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomCollectionViewListCell.xib; sourceTree = "<group>"; };
 		09D432EC292C6B04003C51A7 /* CustomCollectionViewGridCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomCollectionViewGridCell.xib; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 			children = (
 				C70FB0FE25BEF61C00C9924E /* ViewController.swift */,
 				09940CA729398F1100562037 /* RegisterProductViewController.swift */,
+				09CE2748294314B900BF18B3 /* ProductDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -344,6 +347,7 @@
 			files = (
 				D27FA642292483F9004E3B38 /* DetailProduct.swift in Sources */,
 				09940CA829398F1100562037 /* RegisterProductViewController.swift in Sources */,
+				09CE2749294314B900BF18B3 /* ProductDetailViewController.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				D27FA6402924839D004E3B38 /* SearchListProducts.swift in Sources */,
 				D2C0A4CF2938A84D00AB3D2D /* PostRequestParams.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		D27FA6402924839D004E3B38 /* SearchListProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27FA63F2924839D004E3B38 /* SearchListProducts.swift */; };
 		D27FA642292483F9004E3B38 /* DetailProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27FA641292483F9004E3B38 /* DetailProduct.swift */; };
 		D2B4188E292C694800874541 /* CustomCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */; };
+		D2C0A4CF2938A84D00AB3D2D /* PostRequestParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,7 @@
 		D27FA63F2924839D004E3B38 /* SearchListProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListProducts.swift; sourceTree = "<group>"; };
 		D27FA641292483F9004E3B38 /* DetailProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProduct.swift; sourceTree = "<group>"; };
 		D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCollectionViewCell.swift; sourceTree = "<group>"; };
+		D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRequestParams.swift; sourceTree = "<group>"; };
 		E2FDD5EB470EE761553CBF9F /* Pods-OpenMarket.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenMarket.debug.xcconfig"; path = "Target Support Files/Pods-OpenMarket/Pods-OpenMarket.debug.xcconfig"; sourceTree = "<group>"; };
 		F06FB544A4AB71C261A0D948 /* Pods-OpenMarket.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenMarket.release.xcconfig"; path = "Target Support Files/Pods-OpenMarket/Pods-OpenMarket.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -96,6 +98,7 @@
 				09D8602E2928C3AF008FBE56 /* APIError.swift.swift */,
 				D2B4188D292C694800874541 /* CustomCollectionViewCell.swift */,
 				09D2BC202938A21F009E0895 /* Data+Extensions.swift */,
+				D2C0A4CE2938A84D00AB3D2D /* PostRequestParams.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -336,6 +339,7 @@
 				D27FA642292483F9004E3B38 /* DetailProduct.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ViewController.swift in Sources */,
 				D27FA6402924839D004E3B38 /* SearchListProducts.swift in Sources */,
+				D2C0A4CF2938A84D00AB3D2D /* PostRequestParams.swift in Sources */,
 				09D8602F2928C3AF008FBE56 /* APIError.swift.swift in Sources */,
 				D2B4188E292C694800874541 /* CustomCollectionViewCell.swift in Sources */,
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -24,11 +24,13 @@ final class ProductDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        collectionView.delegate = self
         collectionView.dataSource = self
-        collectionView.register(UINib(nibName: "CustomCollectionViewPageCell", bundle: nil), forCellWithReuseIdentifier: "customCollectionViewPageCell")
-        
-        let barButtonItem = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"), style: .plain, target: self, action: #selector(selectModifyOrDeleteProduct))
+        collectionView.register(UINib(nibName: "CustomCollectionViewPageCell", bundle: nil),
+                                forCellWithReuseIdentifier: "customCollectionViewPageCell")
+        let barButtonItem = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"),
+                                            style: .plain,
+                                            target: self,
+                                            action: #selector(selectModifyOrDeleteProduct))
         barButtonItem.customView?.translatesAutoresizingMaskIntoConstraints = false
         navigationController?.navigationBar.topItem?.title = ""
         navigationItem.rightBarButtonItem = barButtonItem
@@ -40,9 +42,13 @@ final class ProductDetailViewController: UIViewController {
     }
     
     @objc private func selectModifyOrDeleteProduct() {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        let modifyAction = UIAlertAction(title: "수정", style: .default) { [weak self] _ in
-            let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        let alert = UIAlertController(title: nil,
+                                      message: nil,
+                                      preferredStyle: .actionSheet)
+        let modifyAction = UIAlertAction(title: "수정",
+                                         style: .default) { [weak self] _ in
+            let storyboard = UIStoryboard(name: "Main",
+                                          bundle: nil)
             guard let registerProductViewController = storyboard.instantiateViewController(
                 withIdentifier: "registerProductViewController") as? ProductPostAndPatchViewController,
                   let id = self?.productID,
@@ -54,11 +60,13 @@ final class ProductDetailViewController: UIViewController {
             self?.present(registerProductViewController, animated: true)
         }
         
-        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+        let deleteAction = UIAlertAction(title: "삭제",
+                                         style: .destructive) { [weak self] _ in
             print("삭제 선택")
             self?.showDeleteAlert()
         }
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let cancelAction = UIAlertAction(title: "취소",
+                                         style: .cancel)
         alert.addAction(modifyAction)
         alert.addAction(deleteAction)
         alert.addAction(cancelAction)
@@ -66,9 +74,13 @@ final class ProductDetailViewController: UIViewController {
     }
     
     private func showDeleteAlert() {
-        let requestDeleteAlert = UIAlertController(title: "암호를 입력해주세요", message: nil, preferredStyle: .alert)
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+        let requestDeleteAlert = UIAlertController(title: "암호를 입력해주세요",
+                                                   message: nil,
+                                                   preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "취소",
+                                         style: .cancel)
+        let deleteAction = UIAlertAction(title: "삭제",
+                                         style: .destructive) { [weak self] _ in
             let inputValue = requestDeleteAlert.textFields?[0].text
             guard inputValue == Secret.password else {
                 self?.showAlert(message: "암호가 일치하지 않습니다.", isBack: false)
@@ -85,26 +97,29 @@ final class ProductDetailViewController: UIViewController {
     }
     
     private func showAlert(message: String, isBack: Bool) {
-        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let okAction = isBack ?
-        UIAlertAction(title: "확인", style: .default, handler: { [weak self] _ in
+        let alert = UIAlertController(title: nil,
+                                      message: message,
+                                      preferredStyle: .alert)
+        let okAction = isBack ? UIAlertAction(title: "확인",
+                                              style: .default,
+                                              handler: { [weak self] _ in
             self?.navigationController?.popViewController(animated: true)
-        })
-        :
-        UIAlertAction(title: "확인", style: .default)
+        }) : UIAlertAction(title: "확인",
+                           style: .default)
         alert.addAction(okAction)
         present(alert, animated: true)
     }
     
     private func getProductDeleteUriDataAndRequestDeleteProduct() {
-        networkCommunication.requestPostUriInqueryData(
-            url: ApiUrl.Path.detailProduct + String(productID) + ApiUrl.Path.uriInquery,
-            secret: Secret.password
-        ) { [weak self] result in
+        networkCommunication.requestPostUriInqueryData(url: ApiUrl.Path.detailProduct
+                                                       + String(productID)
+                                                       + ApiUrl.Path.uriInquery,
+                                                       secret: Secret.password) { [weak self] result in
             switch result {
             case .success(let data):
                 guard let address = String(data: data, encoding: .utf8) else { return }
-                self?.requestDeleteProduct(url: ApiUrl.host + address)
+                self?.requestDeleteProduct(url: ApiUrl.host
+                                           + address)
             case .failure(let error):
                 DispatchQueue.main.async {
                     self?.showAlert(message: "<<\(error.rawValue)>>\n자신이 등록한 상품만 삭제할 수 있습니다.",
@@ -129,10 +144,8 @@ final class ProductDetailViewController: UIViewController {
     
     private func getProductDetailData(productID: Int) {
         let url = ApiUrl.Path.detailProduct + String(productID)
-        networkCommunication.requestProductsInformation(
-            url: url,
-            type: DetailProduct.self
-        ) { [weak self] data in
+        networkCommunication.requestProductsInformation(url: url,
+                                                        type: DetailProduct.self) { [weak self] data in
             switch data {
             case .success(let data):
                 self?.detailProductData = data
@@ -151,7 +164,6 @@ final class ProductDetailViewController: UIViewController {
     private func settingDetailData() {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
-        
         guard let detailProductData = detailProductData,
               let priceText = numberFormatter.string(for: detailProductData.price),
               let bargainPriceText = numberFormatter.string(for: detailProductData.bargainPrice) else { return }
@@ -172,7 +184,6 @@ final class ProductDetailViewController: UIViewController {
             bargainPrice.text = "\(detailProductData.currency) \(bargainPriceText)"
             price.textColor = UIColor.systemRed
         }
-        
         if detailProductData.stock > 0 {
             stock.text = "잔여수량 : \(detailProductData.stock)"
             stock.textColor = UIColor.systemGray
@@ -180,7 +191,6 @@ final class ProductDetailViewController: UIViewController {
             stock.text = "품절"
             stock.textColor = UIColor.systemYellow
         }
-        
         productDescription.text = detailProductData.description
     }
     
@@ -206,7 +216,4 @@ extension ProductDetailViewController: UICollectionViewDataSource {
         customCell.configureCell(image: image, index: indexPath.item, totalCount: detailProductImages.count)
         return customCell
     }
-}
-
-extension ProductDetailViewController: UICollectionViewDelegate {
 }

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -2,7 +2,7 @@
 //  ProductDetailViewController.swift
 //  OpenMarket
 //
-//  Created by Mangdi on 2022/12/09.
+//  Created by Mangdi, Woong on 2022/12/09.
 //
 
 import UIKit

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -30,6 +30,8 @@ class ProductDetailViewController: UIViewController {
         
         let barButtonItem = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"), style: .plain, target: self, action: #selector(selectModifyOrDeleteProduct))
         barButtonItem.customView?.translatesAutoresizingMaskIntoConstraints = false
+        navigationController?.navigationBar.topItem?.title = ""
+        navigationItem.rightBarButtonItem = barButtonItem
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -42,7 +44,7 @@ class ProductDetailViewController: UIViewController {
         let modifyAction = UIAlertAction(title: "수정", style: .default) { [weak self] _ in
             let storyboard = UIStoryboard(name: "Main", bundle: nil)
             guard let registerProductViewController = storyboard.instantiateViewController(
-                withIdentifier: "registerProductViewController") as? RegisterProductViewController
+                withIdentifier: "registerProductViewController") as? RegisterProductViewController,
                   let id = self?.productID,
                   let images = self?.detailProductImages else { return }
             registerProductViewController.mode = "patch"

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -7,19 +7,19 @@
 
 import UIKit
 
-class ProductDetailViewController: UIViewController {
+final class ProductDetailViewController: UIViewController {
     
-    @IBOutlet weak var productName: UILabel!
-    @IBOutlet weak var stock: UILabel!
-    @IBOutlet weak var bargainPrice: UILabel!
-    @IBOutlet weak var price: UILabel!
-    @IBOutlet weak var productDescription: UITextView!
-    @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet private weak var productName: UILabel!
+    @IBOutlet private weak var stock: UILabel!
+    @IBOutlet private weak var bargainPrice: UILabel!
+    @IBOutlet private weak var price: UILabel!
+    @IBOutlet private weak var productDescription: UITextView!
+    @IBOutlet private weak var collectionView: UICollectionView!
     
     private let collectionViewFlowLayout = UICollectionViewFlowLayout()
     private let networkCommunication = NetworkCommunication()
-    var detailProductData: DetailProduct?
-    var detailProductImages: [Image] = []
+    private var detailProductData: DetailProduct?
+    private var detailProductImages: [Image] = []
     var productID: Int = 0
     
     override func viewDidLoad() {

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -44,7 +44,7 @@ class ProductDetailViewController: UIViewController {
         let modifyAction = UIAlertAction(title: "수정", style: .default) { [weak self] _ in
             let storyboard = UIStoryboard(name: "Main", bundle: nil)
             guard let registerProductViewController = storyboard.instantiateViewController(
-                withIdentifier: "registerProductViewController") as? RegisterProductViewController,
+                withIdentifier: "registerProductViewController") as? ProductPostAndPatchViewController,
                   let id = self?.productID,
                   let images = self?.detailProductImages else { return }
             registerProductViewController.mode = "patch"

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -56,7 +56,7 @@ class ProductDetailViewController: UIViewController {
         
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
             print("삭제 선택")
-            //            self?.showDeleteAlert()
+            self?.showDeleteAlert()
         }
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         alert.addAction(modifyAction)
@@ -64,6 +64,37 @@ class ProductDetailViewController: UIViewController {
         alert.addAction(cancelAction)
         present(alert, animated: true)
     }
+    
+    private func showDeleteAlert() {
+        let requestDeleteAlert = UIAlertController(title: "암호를 입력해주세요", message: nil, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+            let inputValue = requestDeleteAlert.textFields?[0].text
+            guard inputValue == Secret.password else {
+                self?.showAlert(message: "암호가 일치하지 않습니다.", isBack: false)
+                return
+            }
+//            self?.getProductDeleteUriDataAndRequestDeleteProduct()
+        }
+        requestDeleteAlert.addTextField { passwordTextField in
+            passwordTextField.placeholder = "암호 입력"
+        }
+        requestDeleteAlert.addAction(cancelAction)
+        requestDeleteAlert.addAction(deleteAction)
+        present(requestDeleteAlert, animated: true)
+    }
+    
+    private func showAlert(message: String, isBack: Bool) {
+            let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+            let okAction = isBack ?
+            UIAlertAction(title: "확인", style: .default, handler: { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
+            })
+            :
+            UIAlertAction(title: "확인", style: .default)
+            alert.addAction(okAction)
+            present(alert, animated: true)
+        }
     
     private func getProductDetailData(productID: Int) {
         let url = ApiUrl.Path.detailProduct + String(productID)

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -1,0 +1,18 @@
+//
+//  ProductDetailViewController.swift
+//  OpenMarket
+//
+//  Created by Mangdi on 2022/12/09.
+//
+
+import UIKit
+
+class ProductDetailViewController: UIViewController {
+    
+    var productID: Int = 0
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+}

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -47,7 +47,7 @@ class ProductDetailViewController: UIViewController {
                 withIdentifier: "registerProductViewController") as? ProductPostAndPatchViewController,
                   let id = self?.productID,
                   let images = self?.detailProductImages else { return }
-            registerProductViewController.mode = "patch"
+            registerProductViewController.mode = .patch
             registerProductViewController.productID = id
             registerProductViewController.patchImages = images
             registerProductViewController.modalPresentationStyle = .fullScreen

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -9,10 +9,32 @@ import UIKit
 
 class ProductDetailViewController: UIViewController {
     
+    @IBOutlet weak var collectionView: UICollectionView!
+    private let collectionViewFlowLayout = UICollectionViewFlowLayout()
     var productID: Int = 0
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.isPagingEnabled = true
+        collectionView.decelerationRate = .fast
+        collectionView.register(UINib(nibName: "CustomCollectionViewPageCell", bundle: nil), forCellWithReuseIdentifier: "customCollectionViewPageCell")
+        collectionView.collectionViewLayout = collectionViewFlowLayout
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionViewFlowLayout.scrollDirection = .horizontal
+        collectionViewFlowLayout.itemSize = CGSize(width: collectionView.bounds.width, height: collectionView.bounds.height)
+        collectionViewFlowLayout.minimumLineSpacing = 0
+    }
+}
+
+extension ProductDetailViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let customCell = collectionView.dequeueReusableCell(withReuseIdentifier: "customCollectionViewPageCell", for: indexPath) as? CustomCollectionViewPageCell ?? CustomCollectionViewPageCell()
+        return customCell
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductDetailViewController.swift
@@ -24,15 +24,17 @@ class ProductDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(UINib(nibName: "CustomCollectionViewPageCell", bundle: nil), forCellWithReuseIdentifier: "customCollectionViewPageCell")
         
         let barButtonItem = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"), style: .plain, target: self, action: #selector(selectModifyOrDeleteProduct))
         barButtonItem.customView?.translatesAutoresizingMaskIntoConstraints = false
-        settingCollectionView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         getProductDetailData(productID: productID)
+        settingCollectionView()
     }
     
     @objc private func selectModifyOrDeleteProduct() {
@@ -40,7 +42,7 @@ class ProductDetailViewController: UIViewController {
         let modifyAction = UIAlertAction(title: "수정", style: .default) { [weak self] _ in
             let storyboard = UIStoryboard(name: "Main", bundle: nil)
             guard let registerProductViewController = storyboard.instantiateViewController(
-                withIdentifier: "registerProductViewController") as? RegisterProductViewController,
+                withIdentifier: "registerProductViewController") as? RegisterProductViewController
                   let id = self?.productID,
                   let images = self?.detailProductImages else { return }
             registerProductViewController.mode = "patch"
@@ -52,7 +54,7 @@ class ProductDetailViewController: UIViewController {
         
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
             print("삭제 선택")
-//            self?.showDeleteAlert()
+            //            self?.showDeleteAlert()
         }
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         alert.addAction(modifyAction)
@@ -89,9 +91,9 @@ class ProductDetailViewController: UIViewController {
         guard let detailProductData = detailProductData,
               let priceText = numberFormatter.string(for: detailProductData.price),
               let bargainPriceText = numberFormatter.string(for: detailProductData.bargainPrice) else { return }
-            navigationItem.title = detailProductData.name
-            productName.text = detailProductData.name
-            price.text = "\(detailProductData.currency) \(priceText)"
+        navigationItem.title = detailProductData.name
+        productName.text = detailProductData.name
+        price.text = "\(detailProductData.currency) \(priceText)"
         
         if detailProductData.bargainPrice <= 0 || detailProductData.price <= detailProductData.bargainPrice {
             bargainPrice.text = ""
@@ -119,26 +121,28 @@ class ProductDetailViewController: UIViewController {
     }
     
     private func settingCollectionView() {
-        collectionView.delegate = self
-        collectionView.dataSource = self
-        collectionView.isPagingEnabled = true
-        collectionView.decelerationRate = .fast
-        collectionView.register(UINib(nibName: "CustomCollectionViewPageCell", bundle: nil), forCellWithReuseIdentifier: "customCollectionViewPageCell")
-        collectionView.collectionViewLayout = collectionViewFlowLayout
-        collectionView.showsHorizontalScrollIndicator = false
         collectionViewFlowLayout.scrollDirection = .horizontal
         collectionViewFlowLayout.itemSize = CGSize(width: collectionView.bounds.width, height: collectionView.bounds.height)
         collectionViewFlowLayout.minimumLineSpacing = 0
+        collectionView.collectionViewLayout = collectionViewFlowLayout
+        collectionView.isPagingEnabled = true
+        collectionView.decelerationRate = .fast
+        collectionView.showsHorizontalScrollIndicator = false
     }
 }
 
-extension ProductDetailViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+extension ProductDetailViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 0
+        return detailProductImages.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let customCell = collectionView.dequeueReusableCell(withReuseIdentifier: "customCollectionViewPageCell", for: indexPath) as? CustomCollectionViewPageCell ?? CustomCollectionViewPageCell()
+        let customCell: CustomCollectionViewPageCell = collectionView.dequeueReusableCell(withReuseIdentifier: "customCollectionViewPageCell", for: indexPath) as? CustomCollectionViewPageCell ?? CustomCollectionViewPageCell()
+        let image = detailProductImages[indexPath.item]
+        customCell.configureCell(image: image, index: indexPath.item, totalCount: detailProductImages.count)
         return customCell
     }
+}
+
+extension ProductDetailViewController: UICollectionViewDelegate {
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -50,14 +50,12 @@ final class ProductListViewController: UIViewController {
     }
     
     private func getProductsListData(pageNumber: String = "1", itemPerPage: String = "100") {
-        networkCommunication.requestProductsInformation(
-            url: ApiUrl.Path.products +
-            ApiUrl.Query.pageNumber +
-            pageNumber +
-            ApiUrl.Query.itemsPerPage +
-            itemPerPage,
-            type: SearchListProducts.self
-        ) { [weak self] data in
+        networkCommunication.requestProductsInformation(url: ApiUrl.Path.products
+                                                        + ApiUrl.Query.pageNumber
+                                                        + pageNumber
+                                                        + ApiUrl.Query.itemsPerPage
+                                                        + itemPerPage,
+                                                        type: SearchListProducts.self) { [weak self] data in
             switch data {
             case .success(let data):
                 self?.searchListPages = data.pages
@@ -75,8 +73,10 @@ final class ProductListViewController: UIViewController {
         segmentedControl.layer.borderWidth = CGFloat(2)
         segmentedControl.selectedSegmentTintColor = UIColor.systemBlue
         segmentedControl.backgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha: 0)
-        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: UIControl.State.selected)
-        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.systemBlue], for: UIControl.State.normal)
+        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white],
+                                                for: UIControl.State.selected)
+        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.systemBlue],
+                                                for: UIControl.State.normal)
     }
     
     private func settingCollectionViewLayoutList() {
@@ -97,10 +97,15 @@ final class ProductListViewController: UIViewController {
         let layoutSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                 heightDimension: .fractionalHeight(1))
         let layoutItem = NSCollectionLayoutItem(layoutSize: layoutSize)
-        layoutItem.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+        layoutItem.contentInsets = NSDirectionalEdgeInsets(top: 8,
+                                                           leading: 8,
+                                                           bottom: 8,
+                                                           trailing: 8)
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                heightDimension: .fractionalHeight(0.4))
-        let layoutGruop = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: layoutItem, count: 2)
+        let layoutGruop = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
+                                                             subitem: layoutItem,
+                                                             count: 2)
         let layoutSection = NSCollectionLayoutSection(group: layoutGruop)
         let compositionalLayout = UICollectionViewCompositionalLayout(section: layoutSection)
         collectionView.collectionViewLayout = compositionalLayout
@@ -114,17 +119,17 @@ extension ProductListViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        
         let customCell: CustomCollectionViewCell
         if segmentedControl.selectedSegmentIndex == 0 {
-            customCell = collectionView.dequeueReusableCell(withReuseIdentifier: "customCollectionViewListCell", for: indexPath) as? CustomCollectionViewCell ?? CustomCollectionViewCell()
+            customCell = collectionView.dequeueReusableCell(withReuseIdentifier: "customCollectionViewListCell",
+                                                            for: indexPath) as? CustomCollectionViewCell ?? CustomCollectionViewCell()
         } else {
-            customCell = collectionView.dequeueReusableCell(withReuseIdentifier: "customCollectionViewGridCell", for: indexPath) as? CustomCollectionViewCell ?? CustomCollectionViewCell()
+            customCell = collectionView.dequeueReusableCell(withReuseIdentifier: "customCollectionViewGridCell",
+                                                            for: indexPath) as? CustomCollectionViewCell ?? CustomCollectionViewCell()
             customCell.layer.cornerRadius = CGFloat(10)
             customCell.layer.borderWidth = CGFloat(3)
             customCell.layer.borderColor = UIColor.systemGray3.cgColor
         }
-        
         customCell.configureCell(imageSource: searchListPages[indexPath.item].thumbnail,
                                  name: searchListPages[indexPath.item].name,
                                  currency: searchListPages[indexPath.item].currency,
@@ -144,7 +149,6 @@ extension ProductListViewController: UICollectionViewDelegate {
             withIdentifier: "productDetailViewController"
         ) as? ProductDetailViewController else { return }
         productDetailViewController.productID = searchListPages[indexPath.item].id
-        
         self.navigationController?.pushViewController(productDetailViewController, animated: true)
     }
 }

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -1,5 +1,5 @@
 //
-//  OpenMarket - ViewController.swift
+//  OpenMarket - ProductListViewController.swift
 //  Created by yagom. 
 //  Copyright © yagom. All rights reserved.
 //  Created by Mangdi, Woong on 2022/11/15.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class ProductListViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var segmentedControl: UISegmentedControl!
     var networkCommunication = NetworkCommunication()
@@ -108,7 +108,7 @@ class ViewController: UIViewController {
     }
 }
 
-extension ViewController: UICollectionViewDataSource {
+extension ProductListViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return searchListPages.count
     }
@@ -135,7 +135,7 @@ extension ViewController: UICollectionViewDataSource {
     }
 }
 
-extension ViewController: UICollectionViewDelegate {
+extension ProductListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print("클릭 \(indexPath.item)")
         collectionView.deselectItem(at: indexPath, animated: true)

--- a/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductListViewController.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-class ProductListViewController: UIViewController {
-    @IBOutlet weak var collectionView: UICollectionView!
-    @IBOutlet weak var segmentedControl: UISegmentedControl!
-    var networkCommunication = NetworkCommunication()
-    var searchListPages: [SearchListPage] = []
+final class ProductListViewController: UIViewController {
+    @IBOutlet private weak var collectionView: UICollectionView!
+    @IBOutlet private weak var segmentedControl: UISegmentedControl!
+    private var networkCommunication = NetworkCommunication()
+    private var searchListPages: [SearchListPage] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/OpenMarket/OpenMarket/Controller/ProductPostAndPatchViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductPostAndPatchViewController.swift
@@ -16,7 +16,7 @@ class ProductPostAndPatchViewController: UIViewController {
         return indicator
     }()
     var imageSet: [UIImage] = []
-    var mode: String = ""
+    var mode: Mode?
     var productID: Int = 0
     var patchImages: [Image] = []
     var productData: DetailProduct?
@@ -40,7 +40,7 @@ class ProductPostAndPatchViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        if mode == "patch" {
+        if mode == .patch {
             navigationBar.topItem?.title = "상품수정"
             imagePlusButton.isHidden = true
             requestImageDataWhenPatchMode()
@@ -85,7 +85,7 @@ class ProductPostAndPatchViewController: UIViewController {
     }
     
     @IBAction func touchUpDoneBarButtonItem(_ sender: UIBarButtonItem) {
-        if mode == "patch" {
+        if mode == .patch {
             requestPatchProductWhenPatchMode()
         } else {
             postProductWhenRegisterMode()

--- a/OpenMarket/OpenMarket/Controller/ProductPostAndPatchViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductPostAndPatchViewController.swift
@@ -7,35 +7,35 @@
 
 import UIKit
 
-class ProductPostAndPatchViewController: UIViewController {
-    var networkCommunication = NetworkCommunication()
-    let loadingIndicator: UIActivityIndicatorView = {
+final class ProductPostAndPatchViewController: UIViewController {
+    private var networkCommunication = NetworkCommunication()
+    private let loadingIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 100, height: 100)) as UIActivityIndicatorView
         indicator.hidesWhenStopped = true
         indicator.style = .large
         return indicator
     }()
-    var imageSet: [UIImage] = []
+    private var imageSet: [UIImage] = []
+    private var productData: DetailProduct?
     var mode: Mode?
     var productID: Int = 0
     var patchImages: [Image] = []
-    var productData: DetailProduct?
     
-    @IBOutlet weak var navigationBar: UINavigationBar!
-    @IBOutlet weak var cancelBarButtonItem: UIBarButtonItem!
-    @IBOutlet weak var doneBarButtonItem: UIBarButtonItem!
+    @IBOutlet private weak var navigationBar: UINavigationBar!
+    @IBOutlet private weak var cancelBarButtonItem: UIBarButtonItem!
+    @IBOutlet private weak var doneBarButtonItem: UIBarButtonItem!
     
-    @IBOutlet weak var scrollView: UIScrollView!
-    @IBOutlet weak var imagePlusButton: UIButton!
-    @IBOutlet weak var imageStackView: UIStackView!
+    @IBOutlet private weak var scrollView: UIScrollView!
+    @IBOutlet private weak var imagePlusButton: UIButton!
+    @IBOutlet private weak var imageStackView: UIStackView!
     
-    @IBOutlet weak var productInformationStackView: UIStackView!
-    @IBOutlet weak var productNameTextField: UITextField!
-    @IBOutlet weak var productPriceTextField: UITextField!
-    @IBOutlet weak var productBargainPriceTextField: UITextField!
-    @IBOutlet weak var productStockTextField: UITextField!
-    @IBOutlet weak var productCurrencySegmentedControl: UISegmentedControl!
-    @IBOutlet weak var productDescriptionTextView: UITextView!
+    @IBOutlet private weak var productInformationStackView: UIStackView!
+    @IBOutlet private weak var productNameTextField: UITextField!
+    @IBOutlet private weak var productPriceTextField: UITextField!
+    @IBOutlet private weak var productBargainPriceTextField: UITextField!
+    @IBOutlet private weak var productStockTextField: UITextField!
+    @IBOutlet private weak var productCurrencySegmentedControl: UISegmentedControl!
+    @IBOutlet private weak var productDescriptionTextView: UITextView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -80,11 +80,11 @@ class ProductPostAndPatchViewController: UIViewController {
         productDescriptionTextView.resignFirstResponder()
     }
     
-    @IBAction func touchUpCancelBarButtonItem(_ sender: UIBarButtonItem) {
+    @IBAction private func touchUpCancelBarButtonItem(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true)
     }
     
-    @IBAction func touchUpDoneBarButtonItem(_ sender: UIBarButtonItem) {
+    @IBAction private func touchUpDoneBarButtonItem(_ sender: UIBarButtonItem) {
         if mode == .patch {
             requestPatchProductWhenPatchMode()
         } else {
@@ -92,7 +92,7 @@ class ProductPostAndPatchViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpImagePlusButton(_ sender: UIButton) {
+    @IBAction private func touchUpImagePlusButton(_ sender: UIButton) {
         let imagePickerController = UIImagePickerController()
         imagePickerController.sourceType = .photoLibrary
         imagePickerController.delegate = self

--- a/OpenMarket/OpenMarket/Controller/ProductPostAndPatchViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductPostAndPatchViewController.swift
@@ -10,7 +10,10 @@ import UIKit
 final class ProductPostAndPatchViewController: UIViewController {
     private var networkCommunication = NetworkCommunication()
     private let loadingIndicator: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 100, height: 100)) as UIActivityIndicatorView
+        let indicator = UIActivityIndicatorView(frame: CGRect(x: 0,
+                                                              y: 0,
+                                                              width: 100,
+                                                              height: 100)) as UIActivityIndicatorView
         indicator.hidesWhenStopped = true
         indicator.style = .large
         return indicator
@@ -39,7 +42,6 @@ final class ProductPostAndPatchViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         if mode == .patch {
             navigationBar.topItem?.title = "상품수정"
             imagePlusButton.isHidden = true
@@ -156,10 +158,9 @@ final class ProductPostAndPatchViewController: UIViewController {
     }
     
     private func requestDetailDataWhenPatchMode() {
-        networkCommunication.requestProductsInformation(
-            url: ApiUrl.Path.detailProduct + String(productID),
-            type: DetailProduct.self
-        ) { [weak self] result in
+        networkCommunication.requestProductsInformation(url: ApiUrl.Path.detailProduct
+                                                        + String(productID),
+                                                        type: DetailProduct.self) { [weak self] result in
             switch result {
             case .success(let data):
                 DispatchQueue.main.async {
@@ -183,7 +184,6 @@ final class ProductPostAndPatchViewController: UIViewController {
     
     private func showProductDataWhenPatchMode() {
         guard let productData = productData else { return }
-        
         productNameTextField.text = productData.name
         productPriceTextField.text = String(productData.price)
         productBargainPriceTextField.text = String(productData.bargainPrice)
@@ -198,24 +198,19 @@ final class ProductPostAndPatchViewController: UIViewController {
               let productDescription = productDescriptionTextView.text,
               let discountedPriceText = productBargainPriceTextField.text,
               let stockText = productStockTextField.text else { return }
-        
         let productCurrency: Currency =
         productCurrencySegmentedControl.selectedSegmentIndex == 0 ? .KRW : .USD
-        
         guard let productPrice = Double(priceText),
               let productDiscountedPrice = Double(discountedPriceText) else { return }
         let productStock = Int(stockText) ?? 0
-        
         if productName.count < 3 ||  productName.count > 100 {
             resisterProductAlert(message: "상품명은 3~100자를 입력하셔야합니다.", success: false)
             return
         }
-        
         if productDescription.count < 10 || productDescription.count > 1000 {
             resisterProductAlert(message: "상품상세정보는 10~1000자를 입력하셔야합니다.", success: false)
             return
         }
-        
         if productDiscountedPrice < 0 || productDiscountedPrice > productPrice {
             resisterProductAlert(message: "할인가는 0보다 높거나 상품가보다 낮아야 합니다.", success: false)
             return
@@ -228,7 +223,6 @@ final class ProductPostAndPatchViewController: UIViewController {
                      currency: productCurrency,
                      discountedPrice: productDiscountedPrice,
                      stock: productStock)
-
         loadingIndicator.center = view.center
         view.addSubview(loadingIndicator)
         loadingIndicator.startAnimating()
@@ -240,16 +234,13 @@ final class ProductPostAndPatchViewController: UIViewController {
               let productDescription = productDescriptionTextView.text,
               let discountedPriceText = productBargainPriceTextField.text,
               let stockText = productStockTextField.text else { return }
-        
         let productCurrency: Currency =
         productCurrencySegmentedControl.selectedSegmentIndex == 0 ? .KRW : .USD
-        
         let stackFirstView = imageStackView.arrangedSubviews.first
         guard let _ = stackFirstView as? UIImageView else {
             resisterProductAlert(message: "이미지가 등록되지 않았습니다.\n 확인해주세요.", success: false)
             return
         }
-        
         if productName == "" || priceText == "" || productDescription == "" {
             resisterProductAlert(message: "입력되지 않은 필드가 있습니다.\n 확인해주세요.", success: false)
         } else {
@@ -259,11 +250,9 @@ final class ProductPostAndPatchViewController: UIViewController {
                     imageSet.append(image)
                 }
             }
-            
             guard let productPrice = Int(priceText) else { return }
             let productDiscountedPrice = Int(discountedPriceText) ?? 0
             let productStock = Int(stockText) ?? 0
-            
             requestPost(name: productName,
                         description: productDescription,
                         price: productPrice,
@@ -271,11 +260,9 @@ final class ProductPostAndPatchViewController: UIViewController {
                         discountPrice: productDiscountedPrice,
                         stock: productStock,
                         secret: Secret.password)
-            
             loadingIndicator.center = view.center
             view.addSubview(loadingIndicator)
             loadingIndicator.startAnimating()
-            
         }
         imageSet = []
     }
@@ -292,12 +279,15 @@ final class ProductPostAndPatchViewController: UIViewController {
     }
     
     private func resisterProductAlert(message: String, success: Bool) {
-        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "닫기", style: .default) { [weak self] _ in
+        let alert = UIAlertController(title: nil,
+                                      message: message,
+                                      preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "닫기",
+                                     style: .default) { [weak self] _ in
             self?.dismiss(animated: true)
         }
-        let noAction = UIAlertAction(title: "닫기", style: .default)
-        
+        let noAction = UIAlertAction(title: "닫기",
+                                     style: .default)
         alert.addAction(success ? okAction : noAction)
         present(alert, animated: true)
     }
@@ -343,7 +333,8 @@ final class ProductPostAndPatchViewController: UIViewController {
                               currency: Currency,
                               discountedPrice: Double,
                               stock: Int) {
-        networkCommunication.requestPatchData(url: ApiUrl.Path.detailProduct+String(productID),
+        networkCommunication.requestPatchData(url: ApiUrl.Path.detailProduct
+                                              + String(productID),
                                               name: name,
                                               description: description,
                                               thumbnailID: thumbnailID,

--- a/OpenMarket/OpenMarket/Controller/ProductPostAndPatchViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ProductPostAndPatchViewController.swift
@@ -1,5 +1,5 @@
 //
-//  RegisterProductViewController.swift
+//  ProductPostAndPatchViewController.swift
 //  OpenMarket
 //
 //  Created by Mangdi, woong on 2022/12/02.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class RegisterProductViewController: UIViewController {
+class ProductPostAndPatchViewController: UIViewController {
     var networkCommunication = NetworkCommunication()
     let loadingIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 100, height: 100)) as UIActivityIndicatorView
@@ -370,7 +370,7 @@ class RegisterProductViewController: UIViewController {
     }
 }
 
-extension RegisterProductViewController: UIImagePickerControllerDelegate,
+extension ProductPostAndPatchViewController: UIImagePickerControllerDelegate,
                                          UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -102,32 +102,18 @@ class RegisterProductViewController: UIViewController {
             let productDiscountedPrice = Int(discountedPriceText) ?? 0
             let productStock = Int(stockText) ?? 0
             
+            requestPost(name: productName,
+                        description: productDescription,
+                        price: productPrice,
+                        currency: productCurrency,
+                        discountPrice: productDiscountedPrice,
+                        stock: productStock,
+                        secret: "fne3fgu2k6a4r9wu")
+            
             loadingIndicator.center = view.center
             view.addSubview(loadingIndicator)
             loadingIndicator.startAnimating()
             
-            networkCommunication.requestPostData(url: ApiUrl.Path.products,
-                                                 images: imageSet,
-                                                 name: productName,
-                                                 description: productDescription,
-                                                 price: productPrice,
-                                                 currency: productCurrency,
-                                                 discountPrice: productDiscountedPrice,
-                                                 stock: productStock,
-                                                 secret: "fne3fgu2k6a4r9wu") { [weak self] result in
-                switch result {
-                case .success(let statusCode):
-                    DispatchQueue.main.async {
-                        self?.loadingIndicator.stopAnimating()
-                        self?.resisterProductAlert(message: "\(statusCode):\n 상품이 성공적으로 등록되었습니다.", success: true)
-                    }
-                case .failure(let error):
-                    DispatchQueue.main.async {
-                        self?.loadingIndicator.stopAnimating()
-                        self?.resisterProductAlert(message: "\(error.rawValue)", success: false)
-                    }
-                }
-            }
         }
         imageSet = []
     }
@@ -146,7 +132,7 @@ class RegisterProductViewController: UIViewController {
         
         if productDescriptionTextView.isFirstResponder {
             guard let keyboardFrame: NSValue =
-                notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+                    notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
                 return
             }
             let keyboardHeight = keyboardFrame.cgRectValue.height
@@ -191,6 +177,37 @@ class RegisterProductViewController: UIViewController {
         
         alert.addAction(success ? okAction : noAction)
         present(alert, animated: true)
+    }
+    
+    private func requestPost(name: String,
+                             description: String,
+                             price: Int,
+                             currency: Currency,
+                             discountPrice: Int,
+                             stock: Int,
+                             secret: String) {
+        networkCommunication.requestPostData(url: ApiUrl.Path.products,
+                                             images: imageSet,
+                                             name: name,
+                                             description: description,
+                                             price: price,
+                                             currency: currency,
+                                             discountPrice: discountPrice,
+                                             stock: stock,
+                                             secret: secret) { [weak self] result in
+            switch result {
+            case .success(let statusCode):
+                DispatchQueue.main.async {
+                    self?.loadingIndicator.stopAnimating()
+                    self?.resisterProductAlert(message: "\(statusCode):\n 상품이 성공적으로 등록되었습니다.", success: true)
+                }
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    self?.loadingIndicator.stopAnimating()
+                    self?.resisterProductAlert(message: "\(error.rawValue)", success: false)
+                }
+            }
+        }
     }
 }
 

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -16,6 +16,10 @@ class RegisterProductViewController: UIViewController {
         return indicator
     }()
     var imageSet: [UIImage] = []
+    var mode: String = ""
+    var productID: Int = 0
+    var patchImages: [Image] = []
+    var productData: DetailProduct?
     
     @IBOutlet weak var navigationBar: UINavigationBar!
     @IBOutlet weak var cancelBarButtonItem: UIBarButtonItem!

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -1,0 +1,20 @@
+//
+//  RegisterProductViewController.swift
+//  OpenMarket
+//
+//  Created by Mangdi on 2022/12/02.
+//
+
+import UIKit
+
+class RegisterProductViewController: UIViewController {
+    
+    @IBOutlet weak var cancelBarButtonItem: UIBarButtonItem!
+    @IBOutlet weak var doneBarButtonItem: UIBarButtonItem!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    
+}

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -260,7 +260,7 @@ class RegisterProductViewController: UIViewController {
                         currency: productCurrency,
                         discountPrice: productDiscountedPrice,
                         stock: productStock,
-                        secret: "fne3fgu2k6a4r9wu")
+                        secret: Secret.password)
             
             loadingIndicator.center = view.center
             view.addSubview(loadingIndicator)

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -2,7 +2,7 @@
 //  RegisterProductViewController.swift
 //  OpenMarket
 //
-//  Created by Mangdi on 2022/12/02.
+//  Created by Mangdi, woong on 2022/12/02.
 //
 
 import UIKit

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -16,7 +16,7 @@ class RegisterProductViewController: UIViewController {
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var imagePlusButton: UIButton!
     @IBOutlet weak var imageStackView: UIStackView!
-
+    
     @IBOutlet weak var productNameTextField: UITextField!
     @IBOutlet weak var productPriceTextField: UITextField!
     @IBOutlet weak var productDiscountedPriceTextField: UITextField!
@@ -35,14 +35,21 @@ class RegisterProductViewController: UIViewController {
     }
     
     @IBAction func touchUpDoneBarButtonItem(_ sender: UIBarButtonItem) {
-        self.dismiss(animated: true)
+        let productCurrency = productCurrencySegmentedControl.selectedSegmentIndex
+        if productNameTextField.text == "" ||
+            productPriceTextField.text == "" ||
+            productDescriptionTextView.text == "" {
+            resisterProductAlert(message: "입력되지 않은 필드가 있습니다.\n 확인해주세요.", success: false)
+        } else {
+            resisterProductAlert(message: "상품이 성공적으로 등록되었습니다.", success: true)
+        }
     }
     
     @IBAction func touchUpImagePlusButton(_ sender: UIButton) {
         presentAlbum()
     }
     
-    func presentAlbum() {
+    private func presentAlbum() {
         let imagePickerController = UIImagePickerController()
         imagePickerController.sourceType = .photoLibrary
         imagePickerController.delegate = self
@@ -61,6 +68,17 @@ class RegisterProductViewController: UIViewController {
         }()
         return imageView
     }
+    
+    private func resisterProductAlert(message: String, success: Bool) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "닫기", style: .default) { [weak self] _ in
+            self?.dismiss(animated: true)}
+        let noAction = UIAlertAction(title: "닫기", style: .default)
+        
+        alert.addAction(success ? okAction : noAction)
+        present(alert, animated: true)
+    }
+    
 }
 
 extension RegisterProductViewController: UIImagePickerControllerDelegate,
@@ -75,7 +93,7 @@ extension RegisterProductViewController: UIImagePickerControllerDelegate,
             imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor,
                                              multiplier: 1).isActive = true
             imageStackView.insertArrangedSubview(imagePlusButton,
-                                            at: imageStackView.arrangedSubviews.endIndex)
+                                                 at: imageStackView.arrangedSubviews.endIndex)
         }
         
         if imageStackView.arrangedSubviews.count >= 6 {

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -69,6 +69,7 @@ class RegisterProductViewController: UIViewController {
             let productDiscountedPrice = Int(discountedPriceText) ?? 0
             let productStock = Int(stockText) ?? 0
             
+            // 이미지5장 안보내지는거 확인!!!
             networkCommunication.requestPostData(url: ApiUrl.Path.products,
                                                  images: imageSet,
                                                  name: productName,
@@ -110,9 +111,6 @@ class RegisterProductViewController: UIViewController {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let okAction = UIAlertAction(title: "닫기", style: .default) { [weak self] _ in
             self?.dismiss(animated: true)
-//            self?.dismiss(animated: true, completion: {
-//                ViewController.getProductsListData()
-//            })
         }
         let noAction = UIAlertAction(title: "닫기", style: .default)
         
@@ -129,6 +127,7 @@ extension RegisterProductViewController: UIImagePickerControllerDelegate,
         if let image = info[.editedImage] as? UIImage {
             let imageView = makeImageView(image: image)
             imageStackView.addArrangedSubview(imageView)
+            // constraints를 stackview에 추가하기전에 써주면 왜 에러가 나는가
             imageView.heightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.heightAnchor,
                                               multiplier: 0.15).isActive = true
             imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor,

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -35,13 +35,11 @@ class RegisterProductViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         imagePlusButton.setTitle("", for: .normal)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(keyboardWillShow(_:)),
                                                name: UIResponder.keyboardWillShowNotification,
@@ -107,7 +105,7 @@ class RegisterProductViewController: UIViewController {
             loadingIndicator.center = view.center
             view.addSubview(loadingIndicator)
             loadingIndicator.startAnimating()
-
+            
             networkCommunication.requestPostData(url: ApiUrl.Path.products,
                                                  images: imageSet,
                                                  name: productName,
@@ -116,13 +114,22 @@ class RegisterProductViewController: UIViewController {
                                                  currency: productCurrency,
                                                  discountPrice: productDiscountedPrice,
                                                  stock: productStock,
-                                                 secret: "fne3fgu2k6a4r9wu") { [weak self] in
-                DispatchQueue.main.async {
-                    self?.loadingIndicator.stopAnimating()
-                    self?.resisterProductAlert(message: "상품이 성공적으로 등록되었습니다.", success: true)
+                                                 secret: "fne3fgu2k6a4r9wu") { [weak self] result in
+                switch result {
+                case .success(let statusCode):
+                    DispatchQueue.main.async {
+                        self?.loadingIndicator.stopAnimating()
+                        self?.resisterProductAlert(message: "\(statusCode):\n 상품이 성공적으로 등록되었습니다.", success: true)
+                    }
+                case .failure(let error):
+                    DispatchQueue.main.async {
+                        self?.loadingIndicator.stopAnimating()
+                        self?.resisterProductAlert(message: "\(error.rawValue)", success: false)
+                    }
                 }
             }
         }
+        imageSet = []
     }
     
     @IBAction func touchUpImagePlusButton(_ sender: UIButton) {

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -8,13 +8,30 @@
 import UIKit
 
 class RegisterProductViewController: UIViewController {
+    let networkCommunication = NetworkCommunication()
     
     @IBOutlet weak var cancelBarButtonItem: UIBarButtonItem!
     @IBOutlet weak var doneBarButtonItem: UIBarButtonItem!
 
+    @IBOutlet weak var productNameTextField: UITextField!
+    @IBOutlet weak var productPriceTextField: UITextField!
+    @IBOutlet weak var productDiscountedPriceTextField: UITextField!
+    @IBOutlet weak var productStockTextField: UITextField!
+    @IBOutlet weak var productCurrencySegmentedControl: UISegmentedControl!
+    @IBOutlet weak var productDescriptionTextView: UITextView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+    }
+    
+    @IBAction func touchUpCancelBarButtonItem(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true)
+    }
+    
+    @IBAction func touchUpDoneBarButtonItem(_ sender: UIBarButtonItem) {
+
+        self.dismiss(animated: true)
     }
     
 }

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -12,6 +12,10 @@ class RegisterProductViewController: UIViewController {
     
     @IBOutlet weak var cancelBarButtonItem: UIBarButtonItem!
     @IBOutlet weak var doneBarButtonItem: UIBarButtonItem!
+    
+    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet weak var imagePlusButton: UIButton!
+    @IBOutlet weak var imageStackView: UIStackView!
 
     @IBOutlet weak var productNameTextField: UITextField!
     @IBOutlet weak var productPriceTextField: UITextField!
@@ -23,6 +27,7 @@ class RegisterProductViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        imagePlusButton.setTitle("", for: .normal)
     }
     
     @IBAction func touchUpCancelBarButtonItem(_ sender: UIBarButtonItem) {
@@ -30,8 +35,52 @@ class RegisterProductViewController: UIViewController {
     }
     
     @IBAction func touchUpDoneBarButtonItem(_ sender: UIBarButtonItem) {
-
         self.dismiss(animated: true)
     }
     
+    @IBAction func touchUpImagePlusButton(_ sender: UIButton) {
+        presentAlbum()
+    }
+    
+    func presentAlbum() {
+        let imagePickerController = UIImagePickerController()
+        imagePickerController.sourceType = .photoLibrary
+        imagePickerController.delegate = self
+        imagePickerController.allowsEditing = true
+        imagePickerController.modalPresentationStyle = .fullScreen
+        present(imagePickerController, animated: true, completion: nil)
+    }
+    
+    private func makeImageView(image: UIImage) -> UIImageView {
+        let imageView: UIImageView = {
+            let imageView = UIImageView()
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            imageView.contentMode = .scaleAspectFit
+            imageView.image = image
+            return imageView
+        }()
+        return imageView
+    }
+}
+
+extension RegisterProductViewController: UIImagePickerControllerDelegate,
+                                         UINavigationControllerDelegate {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        
+        if let image = info[.editedImage] as? UIImage {
+            let imageView = makeImageView(image: image)
+            imageStackView.addArrangedSubview(imageView)
+            imageView.heightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.heightAnchor,
+                                              multiplier: 0.15).isActive = true
+            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor,
+                                             multiplier: 1).isActive = true
+            imageStackView.insertArrangedSubview(imagePlusButton,
+                                            at: imageStackView.arrangedSubviews.endIndex)
+        }
+        
+        if imageStackView.arrangedSubviews.count >= 6 {
+            imagePlusButton.isHidden = true
+        }
+        dismiss(animated: true)
+    }
 }

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -220,8 +220,6 @@ class RegisterProductViewController: UIViewController {
             resisterProductAlert(message: "할인가는 0보다 높거나 상품가보다 낮아야 합니다.", success: false)
             return
         }
-        
-        // 썸네일 ID 전해주는거 수정 (썸네일 이미지 바꾸는거 아직 안함)
         requestPatch(productID: productID,
                      name: productName,
                      description: productDescription,
@@ -230,7 +228,7 @@ class RegisterProductViewController: UIViewController {
                      currency: productCurrency,
                      discountedPrice: productDiscountedPrice,
                      stock: productStock)
-        
+
         loadingIndicator.center = view.center
         view.addSubview(loadingIndicator)
         loadingIndicator.startAnimating()

--- a/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/RegisterProductViewController.swift
@@ -78,8 +78,11 @@ class RegisterProductViewController: UIViewController {
                                                  currency: productCurrency,
                                                  discountPrice: productDiscountedPrice,
                                                  stock: productStock,
-                                                 secret: "fne3fgu2k6a4r9wu")
-            resisterProductAlert(message: "상품이 성공적으로 등록되었습니다.", success: true)
+                                                 secret: "fne3fgu2k6a4r9wu") { [weak self] in
+                DispatchQueue.main.async {
+                    self?.resisterProductAlert(message: "상품이 성공적으로 등록되었습니다.", success: true)
+                }
+            }
         }
     }
     

--- a/OpenMarket/OpenMarket/Controller/ViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ViewController.swift
@@ -71,8 +71,6 @@ class ViewController: UIViewController {
     }
     
     private func settingSegmentedControll() {
-        segmentedControl.setWidth(view.bounds.width/4, forSegmentAt: 0)
-        segmentedControl.setWidth(view.bounds.width/4, forSegmentAt: 1)
         segmentedControl.layer.borderColor = UIColor.systemBlue.cgColor
         segmentedControl.layer.borderWidth = CGFloat(2)
         segmentedControl.selectedSegmentTintColor = UIColor.systemBlue
@@ -138,4 +136,15 @@ extension ViewController: UICollectionViewDataSource {
 }
 
 extension ViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print("클릭 \(indexPath.item)")
+        collectionView.deselectItem(at: indexPath, animated: true)
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        guard let productDetailViewController = storyboard.instantiateViewController(
+            withIdentifier: "productDetailViewController"
+        ) as? ProductDetailViewController else { return }
+        productDetailViewController.productID = searchListPages[indexPath.item].id
+        
+        self.navigationController?.pushViewController(productDetailViewController, animated: true)
+    }
 }

--- a/OpenMarket/OpenMarket/Controller/ViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 class ViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var segmentedControl: UISegmentedControl!
-    @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
     var networkCommunication = NetworkCommunication()
     var searchListPages: [SearchListPage] = []
     
@@ -117,7 +116,6 @@ extension ViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        activityIndicatorView.stopAnimating()
         
         let customCell: CustomCollectionViewCell
         if segmentedControl.selectedSegmentIndex == 0 {

--- a/OpenMarket/OpenMarket/Controller/ViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ViewController.swift
@@ -19,21 +19,10 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         collectionView.dataSource = self
         collectionView.delegate = self
-        
         getResponseAboutHealChecker()
-//        networkCommunication.requestPostData(url: ApiUrl.Path.products,
-//                                             images: testImages,
-//                                             name: "testName",
-//                                             description: "testDesc",
-//                                             price: 10,
-//                                             currency: .KRW,
-//                                             discountPrice: 100,
-//                                             stock: 10,
-//                                             secret: "fne3fgu2k6a4r9wu")
         getCollectionViewCellNib()
         settingCollectionViewLayoutList()
         settingSegmentedControll()
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/OpenMarket/OpenMarket/Controller/ViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ViewController.swift
@@ -13,6 +13,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
     var networkCommunication = NetworkCommunication()
     var searchListPages: [SearchListPage] = []
+    let testImages = [UIImage(systemName: "cloud")!, UIImage(systemName: "hammer")!]
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -20,10 +21,20 @@ class ViewController: UIViewController {
         collectionView.delegate = self
         
         getResponseAboutHealChecker()
+        networkCommunication.requestPostData(url: ApiUrl.Path.products,
+                                             images: testImages,
+                                             name: "testName",
+                                             description: "testDesc",
+                                             price: 10,
+                                             currency: .KRW,
+                                             discountPrice: 100,
+                                             stock: 10,
+                                             secret: "fne3fgu2k6a4r9wu")
         getProductsListData()
         getCollectionViewCellNib()
         settingCollectionViewLayoutList()
         settingSegmentedControll()
+        
     }
     
     @IBAction func tapSegmentedControl(_ sender: UISegmentedControl) {

--- a/OpenMarket/OpenMarket/Controller/ViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
             }
     }
     
-    func getProductsListData(pageNumber: String = "1", itemPerPage: String = "100") {
+    private func getProductsListData(pageNumber: String = "1", itemPerPage: String = "100") {
         networkCommunication.requestProductsInformation(
             url: ApiUrl.Path.products +
             ApiUrl.Query.pageNumber +

--- a/OpenMarket/OpenMarket/Controller/ViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ViewController.swift
@@ -30,11 +30,16 @@ class ViewController: UIViewController {
 //                                             discountPrice: 100,
 //                                             stock: 10,
 //                                             secret: "fne3fgu2k6a4r9wu")
-        getProductsListData()
         getCollectionViewCellNib()
         settingCollectionViewLayoutList()
         settingSegmentedControll()
         
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        getProductsListData()
     }
     
     @IBAction func tapSegmentedControl(_ sender: UISegmentedControl) {
@@ -62,7 +67,7 @@ class ViewController: UIViewController {
             }
     }
     
-    private func getProductsListData(pageNumber: String = "1", itemPerPage: String = "100") {
+    func getProductsListData(pageNumber: String = "1", itemPerPage: String = "100") {
         networkCommunication.requestProductsInformation(
             url: ApiUrl.Path.products +
             ApiUrl.Query.pageNumber +

--- a/OpenMarket/OpenMarket/Controller/ViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ViewController.swift
@@ -21,15 +21,15 @@ class ViewController: UIViewController {
         collectionView.delegate = self
         
         getResponseAboutHealChecker()
-        networkCommunication.requestPostData(url: ApiUrl.Path.products,
-                                             images: testImages,
-                                             name: "testName",
-                                             description: "testDesc",
-                                             price: 10,
-                                             currency: .KRW,
-                                             discountPrice: 100,
-                                             stock: 10,
-                                             secret: "fne3fgu2k6a4r9wu")
+//        networkCommunication.requestPostData(url: ApiUrl.Path.products,
+//                                             images: testImages,
+//                                             name: "testName",
+//                                             description: "testDesc",
+//                                             price: 10,
+//                                             currency: .KRW,
+//                                             discountPrice: 100,
+//                                             stock: 10,
+//                                             secret: "fne3fgu2k6a4r9wu")
         getProductsListData()
         getCollectionViewCellNib()
         settingCollectionViewLayoutList()

--- a/OpenMarket/OpenMarket/Controller/ViewController.swift
+++ b/OpenMarket/OpenMarket/Controller/ViewController.swift
@@ -13,7 +13,6 @@ class ViewController: UIViewController {
     @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
     var networkCommunication = NetworkCommunication()
     var searchListPages: [SearchListPage] = []
-    let testImages = [UIImage(systemName: "cloud")!, UIImage(systemName: "hammer")!]
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,16 +26,11 @@ class ViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
         getProductsListData()
     }
     
     @IBAction func tapSegmentedControl(_ sender: UISegmentedControl) {
-        if sender.selectedSegmentIndex == 0 {
-            settingCollectionViewLayoutList()
-        } else {
-            settingCollectionViewLayoutGrid()
-        }
+        sender.selectedSegmentIndex == 0 ? settingCollectionViewLayoutList() : settingCollectionViewLayoutGrid()
     }
     
     private func getCollectionViewCellNib() {

--- a/OpenMarket/OpenMarket/Model/ApiUrl.swift.swift
+++ b/OpenMarket/OpenMarket/Model/ApiUrl.swift.swift
@@ -6,12 +6,15 @@
 //
 
 enum ApiUrl {
+    static let host = "https://openmarket.yagom-academy.kr"
+
     enum Path {
         static let healthChecker = "https://openmarket.yagom-academy.kr/healthChecker"
         static let products = "https://openmarket.yagom-academy.kr/api/products"
         static let detailProduct = "https://openmarket.yagom-academy.kr/api/products/"
+        static let uriInquery = "/archived"
     }
-    
+
     enum Query {
         static let pageNumber = "?page_no="
         static let itemsPerPage = "&items_per_page="

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
@@ -79,7 +79,12 @@ class CustomCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    func configureImage(imageSource: String) {
+    private func stopLoadingIndicator() {
+        loadingIndicator.stopAnimating()
+        loadingIndicator.removeFromSuperview()
+    }
+    
+    private func configureImage(imageSource: String) {
         let fileManager = FileManager()
         let imageCacheKey = NSString(string: imageSource)
         
@@ -91,18 +96,19 @@ class CustomCollectionViewCell: UICollectionViewCell {
         filePath.appendPathComponent(imageUrl.lastPathComponent)
         
         if let imageCacheValue = ImageCacheManager.shared.object(forKey: imageCacheKey) {
+            stopLoadingIndicator()
             thumbnail.image = imageCacheValue
         } else if let loadedImageData = try? Data(contentsOf: filePath) {
             guard let image = UIImage(data: loadedImageData) else { return }
             ImageCacheManager.shared.setObject(image, forKey: imageCacheKey)
+            stopLoadingIndicator()
             thumbnail.image = image
         } else {
             networkCommunication.requestImageData(url: imageUrl) { [weak self] data in
                 switch data {
                 case .success(let data):
                     DispatchQueue.main.async {
-                        self?.loadingIndicator.stopAnimating()
-                        self?.loadingIndicator.removeFromSuperview()
+                        self?.stopLoadingIndicator()
                         self?.thumbnail.image = UIImage(data: data)
                     }
                     guard let image = UIImage(data: data) else { return }

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
@@ -14,6 +14,13 @@ class CustomCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var bargainPrice: UILabel!
     @IBOutlet weak var stock: UILabel!
     
+    let loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView()
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        indicator.style = .medium
+        return indicator
+    }()
     let networkCommunication = NetworkCommunication()
     
     override func prepareForReuse() {
@@ -35,6 +42,11 @@ class CustomCollectionViewCell: UICollectionViewCell {
         
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
+        
+        thumbnail.addSubview(loadingIndicator)
+        loadingIndicator.centerXAnchor.constraint(equalTo: thumbnail.centerXAnchor).isActive = true
+        loadingIndicator.centerYAnchor.constraint(equalTo: thumbnail.centerYAnchor).isActive = true
+        loadingIndicator.startAnimating()
         configureImage(imageSource: imageSource)
         
         guard let priceText = numberFormatter.string(for: price),
@@ -81,6 +93,8 @@ class CustomCollectionViewCell: UICollectionViewCell {
                 switch data {
                 case .success(let data):
                     DispatchQueue.main.async {
+                        self?.loadingIndicator.stopAnimating()
+                        self?.loadingIndicator.removeFromSuperview()
                         self?.thumbnail.image = UIImage(data: data)
                     }
                     fileManager.createFile(atPath: filePath.path,

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
@@ -7,21 +7,21 @@
 
 import UIKit
 
-class CustomCollectionViewCell: UICollectionViewCell {
-    @IBOutlet weak var thumbnail: UIImageView!
-    @IBOutlet weak var name: UILabel!
-    @IBOutlet weak var price: UILabel!
-    @IBOutlet weak var bargainPrice: UILabel!
-    @IBOutlet weak var stock: UILabel!
+final class CustomCollectionViewCell: UICollectionViewCell {
+    @IBOutlet private weak var thumbnail: UIImageView!
+    @IBOutlet private weak var name: UILabel!
+    @IBOutlet private weak var price: UILabel!
+    @IBOutlet private weak var bargainPrice: UILabel!
+    @IBOutlet private weak var stock: UILabel!
     
-    let loadingIndicator: UIActivityIndicatorView = {
+    private let loadingIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView()
         indicator.translatesAutoresizingMaskIntoConstraints = false
         indicator.hidesWhenStopped = true
         indicator.style = .medium
         return indicator
     }()
-    var networkCommunication = NetworkCommunication()
+    private var networkCommunication = NetworkCommunication()
     
     override func prepareForReuse() {
         networkCommunication.imageTask?.cancel()

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
@@ -38,21 +38,16 @@ final class CustomCollectionViewCell: UICollectionViewCell {
                        currency: Currency,
                        price: Double,
                        bargainPrice: Double,
-                       stock: Int
-    ) {
-        
+                       stock: Int) {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
-        
         thumbnail.addSubview(loadingIndicator)
         loadingIndicator.centerXAnchor.constraint(equalTo: thumbnail.centerXAnchor).isActive = true
         loadingIndicator.centerYAnchor.constraint(equalTo: thumbnail.centerYAnchor).isActive = true
         loadingIndicator.startAnimating()
         configureImage(imageSource: imageSource)
-        
         guard let priceText = numberFormatter.string(for: price),
               let bargainPriceText = numberFormatter.string(for: bargainPrice) else { return }
-        
         self.name.text = name
         self.price.text = "\(currency) \(priceText)"
         
@@ -69,7 +64,6 @@ final class CustomCollectionViewCell: UICollectionViewCell {
             self.bargainPrice.text = "\(currency) \(bargainPriceText)"
             self.price.textColor = UIColor.systemRed
         }
-        
         if stock > 0 {
             self.stock.text = "잔여수량 : \(stock)"
             self.stock.textColor = UIColor.systemGray
@@ -87,14 +81,12 @@ final class CustomCollectionViewCell: UICollectionViewCell {
     private func configureImage(imageSource: String) {
         let fileManager = FileManager()
         let imageCacheKey = NSString(string: imageSource)
-        
         guard let imageUrl = URL(string: imageSource) else { return }
         guard let path = NSSearchPathForDirectoriesInDomains(.cachesDirectory,
                                                              .userDomainMask,
                                                              true).first else { return }
         var filePath = URL(fileURLWithPath: path)
         filePath.appendPathComponent(imageUrl.lastPathComponent)
-        
         if let imageCacheValue = ImageCacheManager.shared.object(forKey: imageCacheKey) {
             stopLoadingIndicator()
             thumbnail.image = imageCacheValue

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewCell.swift
@@ -21,9 +21,10 @@ class CustomCollectionViewCell: UICollectionViewCell {
         indicator.style = .medium
         return indicator
     }()
-    let networkCommunication = NetworkCommunication()
+    var networkCommunication = NetworkCommunication()
     
     override func prepareForReuse() {
+        networkCommunication.imageTask?.cancel()
         thumbnail.image = nil
         name.text = nil
         price.attributedText = nil

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-class CustomCollectionViewPageCell: UICollectionViewCell {
-    @IBOutlet weak var productImage: UIImageView!
-    @IBOutlet weak var imageOrderLabel: UILabel!
+final class CustomCollectionViewPageCell: UICollectionViewCell {
+    @IBOutlet private weak var productImage: UIImageView!
+    @IBOutlet private weak var imageOrderLabel: UILabel!
 
-    var networkCommunication = NetworkCommunication()
+    private var networkCommunication = NetworkCommunication()
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
@@ -2,7 +2,7 @@
 //  CustomCollectionViewPageCell.swift
 //  OpenMarket
 //
-//  Created by 서현웅 on 2022/12/09.
+//  Created by Mangdi, Woong on 2022/12/09.
 //
 
 import UIKit
@@ -15,7 +15,6 @@ class CustomCollectionViewPageCell: UICollectionViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
     }
 
     func configureCell(image: Image, index: Int, totalCount: Int) {
@@ -39,7 +38,4 @@ class CustomCollectionViewPageCell: UICollectionViewCell {
             }
         }
     }
-    
-    
-    
 }

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
@@ -20,7 +20,7 @@ class CustomCollectionViewPageCell: UICollectionViewCell {
 
     func configureCell(image: Image, index: Int, totalCount: Int) {
         if let url = URL(string: image.thumbnailURL) {
-            imageOrderLabel.text = "(index+1)/(totalCount)"
+            imageOrderLabel.text = "\(index+1)/\(totalCount)"
             networkCommunication.requestImageData(url: url) { [weak self] data in
                 switch data {
                 case .success(let data):

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
@@ -22,7 +22,6 @@ final class CustomCollectionViewPageCell: UICollectionViewCell {
         let imageCacheKey = NSString(string: image.thumbnailURL)
         if let imageCacheValue = ImageCacheManager.shared.object(forKey: imageCacheKey) {
             productImage.image = imageCacheValue
-            
         } else if let url = URL(string: image.thumbnailURL) {
             networkCommunication.requestImageData(url: url) { [weak self] data in
                 switch data {

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
@@ -8,5 +8,32 @@
 import UIKit
 
 class CustomCollectionViewPageCell: UICollectionViewCell {
+    @IBOutlet weak var productImage: UIImageView!
+    @IBOutlet weak var imageOrderLabel: UILabel!
+
+    var networkCommunication = NetworkCommunication()
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    func configureCell(image: Image, index: Int, totalCount: Int) {
+        if let url = URL(string: image.thumbnailURL) {
+            imageOrderLabel.text = "(index+1)/(totalCount)"
+            networkCommunication.requestImageData(url: url) { [weak self] data in
+                switch data {
+                case .success(let data):
+                    DispatchQueue.main.async {
+                        self?.productImage.image = UIImage(data: data)
+                    }
+                case .failure(let error):
+                    print(error.rawValue)
+                }
+            }
+        }
+    }
+    
+    
     
 }

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
@@ -1,0 +1,12 @@
+//
+//  CustomCollectionViewPageCell.swift
+//  OpenMarket
+//
+//  Created by 서현웅 on 2022/12/09.
+//
+
+import UIKit
+
+class CustomCollectionViewPageCell: UICollectionViewCell {
+    
+}

--- a/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
+++ b/OpenMarket/OpenMarket/Model/CustomCollectionViewPageCell.swift
@@ -19,13 +19,19 @@ class CustomCollectionViewPageCell: UICollectionViewCell {
     }
 
     func configureCell(image: Image, index: Int, totalCount: Int) {
-        if let url = URL(string: image.thumbnailURL) {
-            imageOrderLabel.text = "\(index+1)/\(totalCount)"
+        imageOrderLabel.text = "\(index+1)/\(totalCount)"
+        let imageCacheKey = NSString(string: image.thumbnailURL)
+        if let imageCacheValue = ImageCacheManager.shared.object(forKey: imageCacheKey) {
+            productImage.image = imageCacheValue
+            
+        } else if let url = URL(string: image.thumbnailURL) {
             networkCommunication.requestImageData(url: url) { [weak self] data in
                 switch data {
                 case .success(let data):
                     DispatchQueue.main.async {
                         self?.productImage.image = UIImage(data: data)
+                        guard let image = UIImage(data: data) else { return }
+                        ImageCacheManager.shared.setObject(image, forKey: imageCacheKey)
                     }
                 case .failure(let error):
                     print(error.rawValue)

--- a/OpenMarket/OpenMarket/Model/Data+Extensions.swift
+++ b/OpenMarket/OpenMarket/Model/Data+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  Data+Extensions.swift
+//  OpenMarket
+//
+//  Created by Mangdi on 2022/12/01.
+//
+
+import Foundation
+
+extension Data {
+    mutating func append(_ string: String) {
+        if let data = string.data(using: .utf8) {
+            self.append(data)
+        }
+    }
+}

--- a/OpenMarket/OpenMarket/Model/Data+Extensions.swift
+++ b/OpenMarket/OpenMarket/Model/Data+Extensions.swift
@@ -2,7 +2,7 @@
 //  Data+Extensions.swift
 //  OpenMarket
 //
-//  Created by Mangdi on 2022/12/01.
+//  Created by Mangdi, woong on 2022/12/02.
 //
 
 import Foundation

--- a/OpenMarket/OpenMarket/Model/DetailProduct.swift
+++ b/OpenMarket/OpenMarket/Model/DetailProduct.swift
@@ -8,12 +8,10 @@
 import Foundation
 
 struct DetailProduct: Codable {
-    let id, vendorID: Int
-    let name, welcomeDescription: String
-    let thumbnail: String
-    let currency: String
-    let price, bargainPrice, discountedPrice, stock: Int
-    let createdAt, issuedAt: String
+    let id, vendorID, stock: Int
+    let name, description, thumbnail, createdAt, issuedAt: String
+    let currency: Currency
+    let price, bargainPrice, discountedPrice: Double
     let images: [Image]
     let vendors: Vendors
 
@@ -21,7 +19,7 @@ struct DetailProduct: Codable {
         case id
         case vendorID = "vendor_id"
         case name
-        case welcomeDescription = "description"
+        case description
         case thumbnail, currency, price
         case bargainPrice = "bargain_price"
         case discountedPrice = "discounted_price"

--- a/OpenMarket/OpenMarket/Model/ImageCacheManager.swift
+++ b/OpenMarket/OpenMarket/Model/ImageCacheManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-class ImageCacheManager {
+final class ImageCacheManager {
     static let shared = NSCache<NSString, UIImage>()
     private init() {}
 }

--- a/OpenMarket/OpenMarket/Model/ImageCacheManager.swift
+++ b/OpenMarket/OpenMarket/Model/ImageCacheManager.swift
@@ -1,0 +1,14 @@
+//
+//  ImageCacheManager.swift
+//  OpenMarket
+//
+//  Created by Mangdi,Woong on 2022/12/06.
+//
+
+import Foundation
+import UIKit
+
+class ImageCacheManager {
+    static let shared = NSCache<NSString, UIImage>()
+    private init() {}
+}

--- a/OpenMarket/OpenMarket/Model/Mode.swift.swift
+++ b/OpenMarket/OpenMarket/Model/Mode.swift.swift
@@ -1,0 +1,13 @@
+//
+//  Mode.swift.swift
+//  OpenMarket
+//
+//  Created by Mangdi on 2022/12/10.
+//
+
+import Foundation
+
+enum Mode {
+    case post
+    case patch
+}

--- a/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
+++ b/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
@@ -9,8 +9,8 @@ import Foundation
 import UIKit
 
 struct NetworkCommunication {
-    let session = URLSession(configuration: .default)
-    let boundary = "boundary-\(UUID().uuidString)"
+    private let session = URLSession(configuration: .default)
+    private let boundary = "boundary-\(UUID().uuidString)"
     var imageTask: URLSessionDataTask?
     
     func requestHealthChecker(

--- a/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
+++ b/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
@@ -102,6 +102,69 @@ struct NetworkCommunication {
     }
 }
 
+// MARK: -DeleteRequest
+extension NetworkCommunication {
+    func requestDeleteData(url: String,
+                           completionHandler: @escaping (Result<String, APIError>) -> Void) {
+        guard let url: URL = URL(string: url) else { return }
+        
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "DELETE"
+        urlRequest.setValue(Secret.vendorID, forHTTPHeaderField: "identifier")
+        
+        let task: URLSessionDataTask = session.dataTask(with: urlRequest) { _, response, error in
+            if error != nil { return }
+            
+            if let response = response as? HTTPURLResponse {
+                if !(200...299).contains(response.statusCode) {
+                    print("DELETE CODE Error : <<\(response.statusCode)>>")
+                    completionHandler(.failure(.statusCodeError))
+                } else {
+                    completionHandler(.success("DELETE CODE : \(response.statusCode)"))
+                }
+            }
+        }
+        task.resume()
+    }
+}
+
+// MARK: -PostUriInqueryRequest
+extension NetworkCommunication {
+    func requestPostUriInqueryData(url: String,
+                                   secret: String,
+                                   completionHandler: @escaping (Result<Data, APIError>) -> Void) {
+        guard let url: URL = URL(string: url) else { return }
+        
+        var body = Data()
+        body.append("{ \"secret\" : \"\(secret)\" }")
+        
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.addValue(Secret.vendorID, forHTTPHeaderField: "identifier")
+        urlRequest.httpBody = body
+        
+        let task: URLSessionDataTask = session.dataTask(with: urlRequest) { data, response, error in
+            if error != nil { return }
+            
+            if let response = response as? HTTPURLResponse {
+                if !(200...299).contains(response.statusCode) {
+                    // 오류 발생
+                    print("POST CODE Error : <<\(response.statusCode)>>")
+                    completionHandler(.failure(.statusCodeError))
+                }
+            }
+            
+            if let data = data {
+                completionHandler(.success(data))
+            } else {
+                completionHandler(.failure(.unkownError))
+            }
+        }
+        task.resume()
+    }
+}
+
 // MARK: -PostRequest
 extension NetworkCommunication {
     func requestPostData(url: String,

--- a/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
+++ b/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
@@ -221,10 +221,10 @@ extension NetworkCommunication {
 
             if let response = response as? HTTPURLResponse {
                 if !(200...299).contains(response.statusCode) {
-                    print("PATCH CODE Error : <<(response.statusCode)>>")
+                    print("PATCH CODE Error : <<\(response.statusCode)>>")
                     completionHandler(.failure(.statusCodeError))
                 } else {
-                    completionHandler(.success("PATCH CODE : (response.statusCode)"))
+                    completionHandler(.success("PATCH CODE : \(response.statusCode)"))
                 }
             }
         }

--- a/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
+++ b/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
@@ -111,9 +111,15 @@ extension NetworkCommunication {
                          discountPrice: Int,
                          stock: Int,
                          secret: String,
-                         completionHandler: @escaping () -> Void) {
+                         completionHandler: @escaping (Result<String, APIError>) -> Void) {
         guard let url: URL = URL(string: url) else { return }
-        let postRequestParams = PostRequestParams(name: name, description: description, secret: secret, price: price, discountedPrice: discountPrice, stock: stock, currency: currency)
+        let postRequestParams = PostRequestParams(name: name,
+                                                  description: description,
+                                                  secret: secret,
+                                                  price: price,
+                                                  discountedPrice: discountPrice,
+                                                  stock: stock,
+                                                  currency: currency)
         let urlRequest = generatePostRequest(url: url,
                                              images: images,
                                              params: postRequestParams)
@@ -122,8 +128,12 @@ extension NetworkCommunication {
             if error != nil { return }
             
             if let response = response as? HTTPURLResponse {
-                print("POST CODE : <<\(response.statusCode)>>") // 수정요망!!<<<<--------
-                completionHandler()
+                if !(200...299).contains(response.statusCode) {
+                    print("POST CODE Error : <<\(response.statusCode)>>")
+                    completionHandler(.failure(.statusCodeError))
+                } else {
+                    completionHandler(.success("POST CODE : \(response.statusCode)"))
+                }
             }
         }
         task.resume()
@@ -175,7 +185,7 @@ extension NetworkCommunication {
     
     private func compressQualityImage(image: UIImage, value: Double) -> Data? {
         guard let imageData = image.jpegData(compressionQuality: value) else { return nil }
-        if imageData.count >= 307200 {
+        if imageData.count >= 300000 {
             return compressQualityImage(image: image, value: value - 0.01)
         }
         return imageData

--- a/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
+++ b/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
@@ -6,9 +6,11 @@
 //
 
 import Foundation
+import UIKit
 
 struct NetworkCommunication {
     let session = URLSession(configuration: .default)
+    let boundary = "boundary-\(UUID().uuidString)"
     
     func requestHealthChecker(
         url: String,
@@ -95,5 +97,65 @@ struct NetworkCommunication {
             }
         }
         task.resume()
+    }
+}
+
+// MARK: -PostRequest
+extension NetworkCommunication {
+    func requestPostData(url: String) {
+        guard let url: URL = URL(string: url) else { return }
+        let urlRequest = generatePostRequest(url: url)
+        let task: URLSessionDataTask = session.dataTask(with: urlRequest) { data, response, error in
+            if error != nil { return }
+            
+            if let response = response as? HTTPURLResponse {
+                print("POST CODE : <<\(response.statusCode)>>") // 수정요망!!<<<<--------
+            }
+        }
+        task.resume()
+    }
+    
+    func generatePostRequest(url: URL) -> URLRequest {
+        var urlRequest = URLRequest(url: url)
+        
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        urlRequest.addValue("0d3776e1-6942-11ed-a917-1925ee1c13db", forHTTPHeaderField: "identifier")
+        urlRequest.httpBody = multipartFormDataBody()
+        
+        let str = String(decoding: multipartFormDataBody(), as: UTF8.self)
+        print(str) // 수정요망!!<<<<--------
+        
+        return urlRequest
+    }
+    
+    private func multipartFormDataBody() -> Data {
+        let cloudImage: UIImage = UIImage(systemName: "cloud")!
+        let carImage: UIImage = UIImage(systemName: "car")!
+        let lineBreak = "\r\n"
+        var body = Data()
+        
+        body.append("--\(boundary + lineBreak)")
+        body.append("Content-Disposition: form-data; name=\"params\" \(lineBreak + lineBreak)")
+        body.append("{ \"name\": \"testtest\", \"description\": \"t1t1t1\", \"price\": 10000, \"currency\": \"KRW\", \"discounted_price\": 500, \"stock\": 1, \"secret\": \"pdb9mscczgcyt7wr\" }")
+        body.append("\(lineBreak)")
+        
+        body.append("--\(boundary + lineBreak)")
+        body.append("Content-Disposition: form-data; name=\"images\"; filename=\"one.jpeg\" \(lineBreak)")
+        body.append("Content-Type: image/jpeg")
+        body.append("\(lineBreak + lineBreak)")
+        body.append(cloudImage.jpegData(compressionQuality: 0.99)!)
+        body.append("\(lineBreak)")
+        
+        body.append("--\(boundary + lineBreak)")
+        body.append("Content-Disposition: form-data; name=\"images\"; filename=\"two.jpeg\" \(lineBreak)")
+        body.append("Content-Type: image/jpeg")
+        body.append("\(lineBreak + lineBreak)")
+        body.append(carImage.jpegData(compressionQuality: 0.99)!)
+        body.append("\(lineBreak)")
+        
+        body.append("--\(boundary)--")
+        
+        return body
     }
 }

--- a/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
+++ b/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
@@ -13,21 +13,17 @@ struct NetworkCommunication {
     private let boundary = "boundary-\(UUID().uuidString)"
     var imageTask: URLSessionDataTask?
     
-    func requestHealthChecker(
-        url: String,
-        completionHandler: @escaping (Result<HTTPURLResponse, APIError>) -> Void
-    ) {
+    func requestHealthChecker(url: String,
+                              completionHandler: @escaping (Result<HTTPURLResponse, APIError>) -> Void) {
         guard let url: URL = URL(string: url) else {
             completionHandler(.failure(.wrongUrlError))
             return
         }
-        
         let task: URLSessionDataTask = session.dataTask(with: url) { _, response, error in
             if error != nil {
                 completionHandler(.failure(.unkownError))
                 return
             }
-            
             if let response = response as? HTTPURLResponse {
                 if !(200...299).contains(response.statusCode) {
                     print("URL요청 실패 : 코드\(response.statusCode)")
@@ -40,22 +36,18 @@ struct NetworkCommunication {
         task.resume()
     }
     
-    func requestProductsInformation<T: Decodable>(
-        url: String,
-        type: T.Type,
-        completionHandler: @escaping (Result<T, APIError>) -> Void
-    ) {
+    func requestProductsInformation<T: Decodable>(url: String,
+                                                  type: T.Type,
+                                                  completionHandler: @escaping (Result<T, APIError>) -> Void) {
         guard let url: URL = URL(string: url) else {
             completionHandler(.failure(.wrongUrlError))
             return
         }
-        
         let task: URLSessionDataTask = session.dataTask(with: url) { data, response, error in
             if error != nil {
                 completionHandler(.failure(.unkownError))
                 return
             }
-            
             if let response = response as? HTTPURLResponse {
                 if !(200...299).contains(response.statusCode) {
                     print("URL요청 실패 : 코드\(response.statusCode)")
@@ -63,7 +55,6 @@ struct NetworkCommunication {
                     return
                 }
             }
-            
             if let data = data {
                 do {
                     let decodingData = try JSONDecoder().decode(type.self, from: data)
@@ -83,7 +74,6 @@ struct NetworkCommunication {
                 completionHandler(.failure(.unkownError))
                 return
             }
-            
             if let response = response as? HTTPURLResponse {
                 if !(200...299).contains(response.statusCode) {
                     print("URL요청 실패 : 코드\(response.statusCode)")
@@ -91,7 +81,6 @@ struct NetworkCommunication {
                     return
                 }
             }
-            
             if let data = data {
                 completionHandler(.success(data))
             } else {
@@ -107,14 +96,11 @@ extension NetworkCommunication {
     func requestDeleteData(url: String,
                            completionHandler: @escaping (Result<String, APIError>) -> Void) {
         guard let url: URL = URL(string: url) else { return }
-        
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "DELETE"
         urlRequest.setValue(Secret.vendorID, forHTTPHeaderField: "identifier")
-        
         let task: URLSessionDataTask = session.dataTask(with: urlRequest) { _, response, error in
             if error != nil { return }
-            
             if let response = response as? HTTPURLResponse {
                 if !(200...299).contains(response.statusCode) {
                     print("DELETE CODE Error : <<\(response.statusCode)>>")
@@ -134,16 +120,13 @@ extension NetworkCommunication {
                                    secret: String,
                                    completionHandler: @escaping (Result<Data, APIError>) -> Void) {
         guard let url: URL = URL(string: url) else { return }
-        
         var body = Data()
         body.append("{ \"secret\" : \"\(secret)\" }")
-        
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.addValue(Secret.vendorID, forHTTPHeaderField: "identifier")
         urlRequest.httpBody = body
-        
         let task: URLSessionDataTask = session.dataTask(with: urlRequest) { data, response, error in
             if error != nil { return }
             
@@ -154,7 +137,6 @@ extension NetworkCommunication {
                     completionHandler(.failure(.statusCodeError))
                 }
             }
-            
             if let data = data {
                 completionHandler(.success(data))
             } else {
@@ -188,10 +170,8 @@ extension NetworkCommunication {
         let urlRequest = generatePostRequest(url: url,
                                              images: images,
                                              params: postRequestParams)
-        
         let task: URLSessionDataTask = session.dataTask(with: urlRequest) { _, response, error in
             if error != nil { return }
-            
             if let response = response as? HTTPURLResponse {
                 if !(200...299).contains(response.statusCode) {
                     print("POST CODE Error : <<\(response.statusCode)>>")
@@ -207,7 +187,6 @@ extension NetworkCommunication {
     func generatePostRequest(url: URL,
                              images: [UIImage],
                              params: PostRequestParams) -> URLRequest {
-        
         let bodyData = multipartFormDataBody(images: images,
                                              params: params)
         var urlRequest = URLRequest(url: url)
@@ -215,19 +194,15 @@ extension NetworkCommunication {
         urlRequest.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         urlRequest.addValue(Secret.vendorID, forHTTPHeaderField: "identifier")
         urlRequest.httpBody = bodyData
-  
         return urlRequest
     }
     
     private func multipartFormDataBody(images: [UIImage],
                                        params: PostRequestParams) -> Data? {
-        
         let postRequestParams = params
         guard let jsonParams = try? JSONEncoder().encode(postRequestParams) else { return nil }
-        
         let lineBreak = "\r\n"
         var body = Data()
-        
         body.append("--\(boundary + lineBreak)")
         body.append("Content-Disposition: form-data; name=\"params\" \(lineBreak + lineBreak)")
         body.append(jsonParams)
@@ -244,7 +219,6 @@ extension NetworkCommunication {
             }
         }
         body.append("--\(boundary)--")
-        
         return body
     }
     
@@ -281,7 +255,6 @@ extension NetworkCommunication {
         guard let urlRequest = generatePatchRequest(url: url, patchRequestParams) else { return }
         let task: URLSessionDataTask = session.dataTask(with: urlRequest) { data, response, error in
             if error != nil { return }
-
             if let response = response as? HTTPURLResponse {
                 if !(200...299).contains(response.statusCode) {
                     print("PATCH CODE Error : <<\(response.statusCode)>>")
@@ -296,9 +269,7 @@ extension NetworkCommunication {
 
     private func generatePatchRequest(url: URL, _ patchRequestParams: PatchRequestParams) -> URLRequest? {
         var urlRequest: URLRequest = URLRequest(url: url)
-
         guard let jsonParams = try? JSONEncoder().encode(patchRequestParams) else { return nil }
-
         urlRequest.httpMethod = "PATCH"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.addValue(Secret.vendorID, forHTTPHeaderField: "identifier")

--- a/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
+++ b/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
@@ -11,6 +11,7 @@ import UIKit
 struct NetworkCommunication {
     let session = URLSession(configuration: .default)
     let boundary = "boundary-\(UUID().uuidString)"
+    var imageTask: URLSessionDataTask?
     
     func requestHealthChecker(
         url: String,
@@ -75,8 +76,9 @@ struct NetworkCommunication {
         task.resume()
     }
     
-    func requestImageData(url: URL, completionHandler: @escaping (Result<Data, APIError>) -> Void) {
-        let task: URLSessionDataTask = session.dataTask(with: url) { data, response, error in
+    mutating func requestImageData(url: URL,
+                                   completionHandler: @escaping (Result<Data, APIError>) -> Void) {
+        imageTask = session.dataTask(with: url) { data, response, error in
             if error != nil {
                 completionHandler(.failure(.unkownError))
                 return
@@ -96,7 +98,7 @@ struct NetworkCommunication {
                 completionHandler(.failure(.imageDataConvertError))
             }
         }
-        task.resume()
+        imageTask?.resume()
     }
 }
 

--- a/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
+++ b/OpenMarket/OpenMarket/Model/NetworkCommunication.swift
@@ -112,15 +112,10 @@ extension NetworkCommunication {
                          stock: Int,
                          secret: String) {
         guard let url: URL = URL(string: url) else { return }
+        let postRequestParams = PostRequestParams(name: name, description: description, secret: secret, price: price, discountedPrice: discountPrice, stock: stock, currency: currency)
         let urlRequest = generatePostRequest(url: url,
                                              images: images,
-                                             name: name,
-                                             description: description,
-                                             price: price,
-                                             currency: currency,
-                                             discountPrice: discountPrice,
-                                             stock: stock,
-                                             secret: secret)
+                                             params: postRequestParams)
         
         let task: URLSessionDataTask = session.dataTask(with: urlRequest) { _, response, error in
             if error != nil { return }
@@ -134,22 +129,10 @@ extension NetworkCommunication {
     
     func generatePostRequest(url: URL,
                              images: [UIImage],
-                             name: String,
-                             description: String,
-                             price: Int,
-                             currency: Currency,
-                             discountPrice: Int,
-                             stock: Int,
-                             secret: String) -> URLRequest {
+                             params: PostRequestParams) -> URLRequest {
         
         let bodyData = multipartFormDataBody(images: images,
-                                             name: name,
-                                             description: description,
-                                             price: price,
-                                             currency: currency,
-                                             discountPrice: discountPrice,
-                                             stock: stock,
-                                             secret: secret)
+                                             params: params)
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
@@ -160,21 +143,9 @@ extension NetworkCommunication {
     }
     
     private func multipartFormDataBody(images: [UIImage],
-                                       name: String,
-                                       description: String,
-                                       price: Int,
-                                       currency: Currency,
-                                       discountPrice: Int,
-                                       stock: Int,
-                                       secret: String) -> Data? {
+                                       params: PostRequestParams) -> Data? {
         
-        let postRequestParams = PostRequestParams(name: name,
-                            description: description,
-                            secret: secret,
-                            price: price,
-                            discountedPrice: discountPrice,
-                            stock: stock,
-                            currency: currency)
+        let postRequestParams = params
         guard let jsonParams = try? JSONEncoder().encode(postRequestParams) else { return nil }
         
         let lineBreak = "\r\n"
@@ -186,12 +157,13 @@ extension NetworkCommunication {
         body.append("\(lineBreak)")
         
         for image in images {
-            if let imageData = image.jpegData(compressionQuality: 0.99) {
+            if let imageData = image.jpegData(compressionQuality: 0.2) {
                 body.append("--\(boundary + lineBreak)")
                 body.append("Content-Disposition: form-data; name=\"images\"; filename=\"\(arc4random()).jpeg\" \(lineBreak)")
                 body.append("Content-Type: image/jpeg \(lineBreak + lineBreak)")
                 body.append(imageData)
                 body.append("\(lineBreak)")
+                print(imageData)
             }
         }
         body.append("--\(boundary)--")

--- a/OpenMarket/OpenMarket/Model/PatchRequestParams.swift
+++ b/OpenMarket/OpenMarket/Model/PatchRequestParams.swift
@@ -1,0 +1,24 @@
+//
+//  PatchRequestParams.swift
+//  OpenMarket
+//
+//  Created by 서현웅 on 2022/12/09.
+//
+
+import Foundation
+
+struct PatchRequestParams: Encodable {
+    let name, description, secret: String
+    let price, discountedPrice: Double
+    let stock, thumbnailID: Int
+    let currency: Currency
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case description
+        case thumbnailID = "thumbnail_id"
+        case price, currency
+        case discountedPrice = "discounted_price"
+        case stock, secret
+    }
+}

--- a/OpenMarket/OpenMarket/Model/PatchRequestParams.swift
+++ b/OpenMarket/OpenMarket/Model/PatchRequestParams.swift
@@ -2,7 +2,7 @@
 //  PatchRequestParams.swift
 //  OpenMarket
 //
-//  Created by 서현웅 on 2022/12/09.
+//  Created by Mangdi, Woong on 2022/12/09.
 //
 
 import Foundation

--- a/OpenMarket/OpenMarket/Model/PostRequestParams.swift
+++ b/OpenMarket/OpenMarket/Model/PostRequestParams.swift
@@ -2,7 +2,7 @@
 //  PostRequestParams.swift
 //  OpenMarket
 //
-//  Created by 서현웅 on 2022/12/01.
+//  Created by Mangdi, woong on 2022/12/02.
 //
 
 import Foundation

--- a/OpenMarket/OpenMarket/Model/PostRequestParams.swift
+++ b/OpenMarket/OpenMarket/Model/PostRequestParams.swift
@@ -1,0 +1,19 @@
+//
+//  PostRequestParams.swift
+//  OpenMarket
+//
+//  Created by 서현웅 on 2022/12/01.
+//
+
+import Foundation
+
+struct PostRequestParams: Encodable {
+    let name, description, secret: String
+    let price, discountedPrice, stock: Int
+    let currency: Currency
+
+    enum CodingKeys: String, CodingKey {
+        case name, description, price, currency, stock, secret
+        case discountedPrice = "discounted_price"
+    }
+}

--- a/OpenMarket/OpenMarket/Model/Secret.swift
+++ b/OpenMarket/OpenMarket/Model/Secret.swift
@@ -2,7 +2,7 @@
 //  Secret.swift
 //  OpenMarket
 //
-//  Created by 서현웅 on 2022/12/09.
+//  Created by Mangdi, Woong on 2022/12/09.
 //
 
 import Foundation

--- a/OpenMarket/OpenMarket/Model/Secret.swift
+++ b/OpenMarket/OpenMarket/Model/Secret.swift
@@ -1,0 +1,13 @@
+//
+//  Secret.swift
+//  OpenMarket
+//
+//  Created by 서현웅 on 2022/12/09.
+//
+
+import Foundation
+
+enum Secret {
+    static let vendorID = "70e4e3d7-6942-11ed-a917-6d2a7e9f7538"
+    static let password = "fne3fgu2k6a4r9wu"
+}

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -116,7 +116,7 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vc5-5U-yx3">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vc5-5U-yx3">
                                 <rect key="frame" x="10" y="98" width="394" height="122.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-wg-qQg">
@@ -219,9 +219,11 @@
                         <outlet property="doneBarButtonItem" destination="t1B-yL-M7v" id="qrs-Cp-fGk"/>
                         <outlet property="imagePlusButton" destination="0Y1-Os-tRY" id="45t-nC-g8c"/>
                         <outlet property="imageStackView" destination="eVC-wg-qQg" id="wYh-Kf-SQZ"/>
+                        <outlet property="navigationBar" destination="pVa-QY-cqJ" id="Sfz-P1-C7I"/>
                         <outlet property="productCurrencySegmentedControl" destination="gfU-9z-pRp" id="nXF-hz-BQZ"/>
                         <outlet property="productDescriptionTextView" destination="NAL-HZ-RjB" id="6l6-Gb-UXr"/>
                         <outlet property="productDiscountedPriceTextField" destination="SS8-rv-iXo" id="XBq-MY-xnn"/>
+                        <outlet property="productInformationStackView" destination="Vh1-EO-9Nd" id="GxN-U3-Uue"/>
                         <outlet property="productNameTextField" destination="j87-S8-zQP" id="cLF-Yj-LZk"/>
                         <outlet property="productPriceTextField" destination="674-SV-anw" id="3NT-tx-Ocs"/>
                         <outlet property="productStockTextField" destination="jId-FK-d4p" id="7Xu-L0-Kad"/>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -212,9 +212,9 @@
                         <outlet property="imagePlusButton" destination="0Y1-Os-tRY" id="45t-nC-g8c"/>
                         <outlet property="imageStackView" destination="eVC-wg-qQg" id="wYh-Kf-SQZ"/>
                         <outlet property="navigationBar" destination="pVa-QY-cqJ" id="Sfz-P1-C7I"/>
+                        <outlet property="productBargainPriceTextField" destination="SS8-rv-iXo" id="XBq-MY-xnn"/>
                         <outlet property="productCurrencySegmentedControl" destination="gfU-9z-pRp" id="nXF-hz-BQZ"/>
                         <outlet property="productDescriptionTextView" destination="NAL-HZ-RjB" id="6l6-Gb-UXr"/>
-                        <outlet property="productDiscountedPriceTextField" destination="SS8-rv-iXo" id="XBq-MY-xnn"/>
                         <outlet property="productInformationStackView" destination="Vh1-EO-9Nd" id="GxN-U3-Uue"/>
                         <outlet property="productNameTextField" destination="j87-S8-zQP" id="cLF-Yj-LZk"/>
                         <outlet property="productPriceTextField" destination="674-SV-anw" id="3NT-tx-Ocs"/>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -46,7 +46,7 @@
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title=""/>
                                         <connections>
-                                            <segue destination="AOr-IO-2Z8" kind="show" id="8de-Fc-UI9"/>
+                                            <segue destination="AOr-IO-2Z8" kind="presentation" modalPresentationStyle="automatic" id="8de-Fc-UI9"/>
                                         </connections>
                                     </button>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" hidesWhenStopped="YES" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="bJH-1T-XiE">
@@ -90,17 +90,37 @@
             </objects>
             <point key="canvasLocation" x="131.8840579710145" y="-34.151785714285715"/>
         </scene>
-        <!--View Controller-->
+        <!--Register Product View Controller-->
         <scene sceneID="xXI-Vl-qpu">
             <objects>
-                <viewController id="AOr-IO-2Z8" sceneMemberID="viewController">
+                <viewController id="AOr-IO-2Z8" customClass="RegisterProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Kd8-Qa-rrm">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pVa-QY-cqJ">
+                                <rect key="frame" x="0.0" y="44" width="414" height="56"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <items>
+                                    <navigationItem title="상품등록" id="rUu-JD-lQU">
+                                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="KCK-d4-50u"/>
+                                        <barButtonItem key="rightBarButtonItem" title="Done" id="t1B-yL-M7v"/>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="M5x-nH-cvu"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="pVa-QY-cqJ" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" id="NTh-Tp-osz"/>
+                            <constraint firstItem="pVa-QY-cqJ" firstAttribute="top" secondItem="M5x-nH-cvu" secondAttribute="top" id="hL0-8w-d78"/>
+                            <constraint firstItem="pVa-QY-cqJ" firstAttribute="trailing" secondItem="M5x-nH-cvu" secondAttribute="trailing" id="ibk-SU-NaL"/>
+                        </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="xAQ-qw-hSz"/>
+                    <connections>
+                        <outlet property="cancelBarButtonItem" destination="KCK-d4-50u" id="WAr-kJ-MFz"/>
+                        <outlet property="doneBarButtonItem" destination="t1B-yL-M7v" id="qrs-Cp-fGk"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Q5r-tu-hWo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DxO-ae-ikV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DxO-ae-ikV">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -85,13 +85,13 @@
         <!--Register Product View Controller-->
         <scene sceneID="xXI-Vl-qpu">
             <objects>
-                <viewController id="AOr-IO-2Z8" customClass="RegisterProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="registerProductViewController" id="AOr-IO-2Z8" customClass="RegisterProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Kd8-Qa-rrm">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pVa-QY-cqJ">
-                                <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <items>
                                     <navigationItem title="상품등록" id="rUu-JD-lQU">
@@ -109,13 +109,13 @@
                                 </items>
                             </navigationBar>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vc5-5U-yx3">
-                                <rect key="frame" x="10" y="102" width="394" height="122"/>
+                                <rect key="frame" x="10" y="98" width="394" height="122.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-wg-qQg">
-                                        <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Y1-Os-tRY">
-                                                <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="0Y1-Os-tRY" secondAttribute="height" multiplier="1:1" id="zb0-fT-fPF"/>
                                                 </constraints>
@@ -142,7 +142,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="dWO-et-Yhk"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vh1-EO-9Nd">
-                                <rect key="frame" x="10" y="234" width="394" height="160"/>
+                                <rect key="frame" x="10" y="230.5" width="394" height="160"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="j87-S8-zQP">
                                         <rect key="frame" x="0.0" y="0.0" width="394" height="34"/>
@@ -179,7 +179,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NAL-HZ-RjB">
-                                <rect key="frame" x="10" y="404" width="404" height="448"/>
+                                <rect key="frame" x="10" y="400.5" width="404" height="451.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -234,10 +234,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="7sA-Yt-PLF">
-                                <rect key="frame" x="8" y="8" width="398" height="325.5"/>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="BDk-m2-pFx">
+                                <rect key="frame" x="8" y="44" width="398" height="327"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="3e2-ts-P6P">
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="hJs-V1-X1o">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
@@ -245,34 +245,34 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WV-Js-eMw">
-                                <rect key="frame" x="8" y="442.5" width="398" height="453.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aDF-IL-ZQ6">
+                                <rect key="frame" x="8" y="379" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ayh-t3-lIj">
+                                <rect key="frame" x="364" y="379" width="42" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8aS-gO-7mZ">
+                                <rect key="frame" x="8" y="438.5" width="398" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="jH9-em-GcE">
+                                <rect key="frame" x="8" y="479.5" width="398" height="416.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia sum dolor sit er elit lamet, a commodo consequat. Duis </string>
+                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cng-IH-07i">
-                                <rect key="frame" x="8" y="341.5" width="42" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N82-S3-G9J">
-                                <rect key="frame" x="58" y="341.5" width="348" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dn4-lN-JSi">
-                                <rect key="frame" x="8" y="372.5" width="398" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FtI-b2-EsR">
-                                <rect key="frame" x="8" y="401.5" width="398" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FEM-xN-ip9">
+                                <rect key="frame" x="8" y="409.5" width="398" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -281,29 +281,33 @@
                         <viewLayoutGuide key="safeArea" id="tQB-5g-saW"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="dn4-lN-JSi" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="46r-2Y-wko"/>
-                            <constraint firstItem="3WV-Js-eMw" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="CPK-pv-lJO"/>
-                            <constraint firstAttribute="bottom" secondItem="3WV-Js-eMw" secondAttribute="bottom" id="IRx-9y-hGE"/>
-                            <constraint firstItem="N82-S3-G9J" firstAttribute="leading" secondItem="Cng-IH-07i" secondAttribute="trailing" constant="8" id="O5l-zp-rPa"/>
-                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="3WV-Js-eMw" secondAttribute="trailing" constant="8" id="PIf-oM-lp0"/>
-                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="FtI-b2-EsR" secondAttribute="trailing" constant="8" id="SxU-kt-As3"/>
-                            <constraint firstItem="7sA-Yt-PLF" firstAttribute="height" secondItem="tQB-5g-saW" secondAttribute="height" multiplier="0.4" id="Xxd-u4-q8X"/>
-                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="N82-S3-G9J" secondAttribute="trailing" constant="8" id="ZsS-y4-3S6"/>
-                            <constraint firstItem="Cng-IH-07i" firstAttribute="top" secondItem="7sA-Yt-PLF" secondAttribute="bottom" constant="8" id="bzP-2q-hvq"/>
-                            <constraint firstItem="Cng-IH-07i" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="cQG-1W-WrO"/>
-                            <constraint firstItem="3WV-Js-eMw" firstAttribute="top" secondItem="FtI-b2-EsR" secondAttribute="bottom" constant="20" id="dBs-Sv-2WE"/>
-                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="7sA-Yt-PLF" secondAttribute="trailing" constant="8" id="eLA-Y6-MHd"/>
-                            <constraint firstItem="dn4-lN-JSi" firstAttribute="top" secondItem="N82-S3-G9J" secondAttribute="bottom" constant="10" id="gp9-aq-eeq"/>
-                            <constraint firstItem="7sA-Yt-PLF" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="gtf-aM-QEe"/>
-                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="dn4-lN-JSi" secondAttribute="trailing" constant="8" id="myR-Di-qb9"/>
-                            <constraint firstItem="7sA-Yt-PLF" firstAttribute="top" secondItem="edM-fs-0Ga" secondAttribute="top" constant="8" id="sa8-Le-Xhf"/>
-                            <constraint firstItem="FtI-b2-EsR" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="u8H-8f-Zwg"/>
-                            <constraint firstItem="FtI-b2-EsR" firstAttribute="top" secondItem="dn4-lN-JSi" secondAttribute="bottom" constant="8" id="xRy-2j-kZZ"/>
-                            <constraint firstItem="N82-S3-G9J" firstAttribute="firstBaseline" secondItem="Cng-IH-07i" secondAttribute="firstBaseline" id="zeL-7G-tVP"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="8aS-gO-7mZ" secondAttribute="trailing" constant="8" id="4Bs-78-YhB"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="jH9-em-GcE" secondAttribute="trailing" constant="8" id="5Ni-gd-KBt"/>
+                            <constraint firstItem="FEM-xN-ip9" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="6Lh-Sg-A6D"/>
+                            <constraint firstItem="8aS-gO-7mZ" firstAttribute="top" secondItem="FEM-xN-ip9" secondAttribute="bottom" constant="8" id="8fh-Pc-Mxt"/>
+                            <constraint firstAttribute="bottom" secondItem="jH9-em-GcE" secondAttribute="bottom" id="8zk-mk-Pn3"/>
+                            <constraint firstItem="BDk-m2-pFx" firstAttribute="top" secondItem="tQB-5g-saW" secondAttribute="top" id="9Ha-Ub-0TN"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="ayh-t3-lIj" secondAttribute="trailing" constant="8" id="AWd-XY-iA0"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="BDk-m2-pFx" secondAttribute="trailing" constant="8" id="EqE-dv-Rcc"/>
+                            <constraint firstItem="aDF-IL-ZQ6" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="TpM-MF-F8O"/>
+                            <constraint firstItem="ayh-t3-lIj" firstAttribute="firstBaseline" secondItem="aDF-IL-ZQ6" secondAttribute="firstBaseline" id="UfZ-oC-y7h"/>
+                            <constraint firstItem="aDF-IL-ZQ6" firstAttribute="top" secondItem="BDk-m2-pFx" secondAttribute="bottom" constant="8" id="bi1-jU-tsH"/>
+                            <constraint firstItem="BDk-m2-pFx" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="dHH-r0-fa7"/>
+                            <constraint firstItem="jH9-em-GcE" firstAttribute="top" secondItem="8aS-gO-7mZ" secondAttribute="bottom" constant="20" id="elv-Jb-Oe0"/>
+                            <constraint firstItem="BDk-m2-pFx" firstAttribute="height" secondItem="tQB-5g-saW" secondAttribute="height" multiplier="0.4" id="gM1-6t-ja4"/>
+                            <constraint firstItem="jH9-em-GcE" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="pxo-EE-pWF"/>
+                            <constraint firstItem="8aS-gO-7mZ" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="sLH-HD-43X"/>
+                            <constraint firstItem="FEM-xN-ip9" firstAttribute="top" secondItem="ayh-t3-lIj" secondAttribute="bottom" constant="10" id="vH8-I8-c8i"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="FEM-xN-ip9" secondAttribute="trailing" constant="8" id="zeg-WS-UjX"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="collectionView" destination="7sA-Yt-PLF" id="FK3-RK-o8S"/>
+                        <outlet property="bargainPrice" destination="8aS-gO-7mZ" id="F8b-xG-L69"/>
+                        <outlet property="collectionView" destination="BDk-m2-pFx" id="NrW-9L-PA1"/>
+                        <outlet property="price" destination="FEM-xN-ip9" id="r9b-n6-lZC"/>
+                        <outlet property="productDescription" destination="jH9-em-GcE" id="2nH-Cp-Y26"/>
+                        <outlet property="productName" destination="aDF-IL-ZQ6" id="rHa-b4-75c"/>
+                        <outlet property="stock" destination="ayh-t3-lIj" id="qqB-8I-IAx"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tNb-HJ-56e" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -316,7 +320,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DxO-ae-ikV" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="5Eh-iu-ihx">
-                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -332,7 +336,7 @@
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -263,7 +263,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="jH9-em-GcE">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jH9-em-GcE">
                                 <rect key="frame" x="8" y="479.5" width="398" height="416.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DxO-ae-ikV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DxO-ae-ikV">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -62,7 +62,7 @@
                         </segmentedControl>
                         <barButtonItem key="rightBarButtonItem" id="7iR-zo-TYF">
                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="8OE-DE-cya">
-                                <rect key="frame" x="350.5" y="6.5" width="43.5" height="31"/>
+                                <rect key="frame" x="347.5" y="5" width="46.5" height="34"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title=""/>
@@ -91,7 +91,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pVa-QY-cqJ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <items>
                                     <navigationItem title="상품등록" id="rUu-JD-lQU">
@@ -109,13 +109,13 @@
                                 </items>
                             </navigationBar>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vc5-5U-yx3">
-                                <rect key="frame" x="10" y="98" width="394" height="122.5"/>
+                                <rect key="frame" x="10" y="102" width="394" height="122"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-wg-qQg">
-                                        <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Y1-Os-tRY">
-                                                <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="0Y1-Os-tRY" secondAttribute="height" multiplier="1:1" id="zb0-fT-fPF"/>
                                                 </constraints>
@@ -142,7 +142,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="dWO-et-Yhk"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vh1-EO-9Nd">
-                                <rect key="frame" x="10" y="230.5" width="394" height="160"/>
+                                <rect key="frame" x="10" y="234" width="394" height="160"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="j87-S8-zQP">
                                         <rect key="frame" x="0.0" y="0.0" width="394" height="34"/>
@@ -179,7 +179,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NAL-HZ-RjB">
-                                <rect key="frame" x="10" y="400.5" width="404" height="451.5"/>
+                                <rect key="frame" x="10" y="404" width="404" height="448"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -235,7 +235,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="7sA-Yt-PLF">
-                                <rect key="frame" x="8" y="8" width="398" height="327"/>
+                                <rect key="frame" x="8" y="8" width="398" height="325.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="3e2-ts-P6P">
                                     <size key="itemSize" width="128" height="128"/>
@@ -246,7 +246,7 @@
                                 <cells/>
                             </collectionView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WV-Js-eMw">
-                                <rect key="frame" x="8" y="444" width="398" height="452"/>
+                                <rect key="frame" x="8" y="442.5" width="398" height="453.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia sum dolor sit er elit lamet, a commodo consequat. Duis </string>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -254,25 +254,25 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cng-IH-07i">
-                                <rect key="frame" x="8" y="343" width="42" height="21"/>
+                                <rect key="frame" x="8" y="341.5" width="42" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N82-S3-G9J">
-                                <rect key="frame" x="58" y="343" width="348" height="21"/>
+                                <rect key="frame" x="58" y="341.5" width="348" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dn4-lN-JSi">
-                                <rect key="frame" x="8" y="374" width="398" height="21"/>
+                                <rect key="frame" x="8" y="372.5" width="398" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FtI-b2-EsR">
-                                <rect key="frame" x="8" y="403" width="398" height="21"/>
+                                <rect key="frame" x="8" y="401.5" width="398" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -302,6 +302,9 @@
                             <constraint firstItem="N82-S3-G9J" firstAttribute="firstBaseline" secondItem="Cng-IH-07i" secondAttribute="firstBaseline" id="zeL-7G-tVP"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="collectionView" destination="7sA-Yt-PLF" id="FK3-RK-o8S"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tNb-HJ-56e" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -313,7 +316,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DxO-ae-ikV" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="5Eh-iu-ihx">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -329,7 +332,7 @@
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -46,7 +46,7 @@
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title=""/>
                                         <connections>
-                                            <segue destination="AOr-IO-2Z8" kind="presentation" modalPresentationStyle="automatic" id="8de-Fc-UI9"/>
+                                            <segue destination="AOr-IO-2Z8" kind="presentation" modalPresentationStyle="fullScreen" id="8de-Fc-UI9"/>
                                         </connections>
                                     </button>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" hidesWhenStopped="YES" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="bJH-1T-XiE">
@@ -95,11 +95,11 @@
             <objects>
                 <viewController id="AOr-IO-2Z8" customClass="RegisterProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Kd8-Qa-rrm">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pVa-QY-cqJ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="56"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <items>
                                     <navigationItem title="상품등록" id="rUu-JD-lQU">
@@ -117,13 +117,13 @@
                                 </items>
                             </navigationBar>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vc5-5U-yx3">
-                                <rect key="frame" x="10" y="110" width="394" height="119.5"/>
+                                <rect key="frame" x="10" y="98" width="394" height="122.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-wg-qQg">
-                                        <rect key="frame" x="0.0" y="0.0" width="119.5" height="119.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Y1-Os-tRY">
-                                                <rect key="frame" x="0.0" y="0.0" width="119.5" height="119.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="0Y1-Os-tRY" secondAttribute="height" multiplier="1:1" id="zb0-fT-fPF"/>
                                                 </constraints>
@@ -150,7 +150,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="dWO-et-Yhk"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vh1-EO-9Nd">
-                                <rect key="frame" x="10" y="239.5" width="394" height="160"/>
+                                <rect key="frame" x="10" y="230.5" width="394" height="160"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="j87-S8-zQP">
                                         <rect key="frame" x="0.0" y="0.0" width="394" height="34"/>
@@ -187,7 +187,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NAL-HZ-RjB">
-                                <rect key="frame" x="10" y="409.5" width="394" height="422.5"/>
+                                <rect key="frame" x="10" y="400.5" width="394" height="451.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -42,7 +42,7 @@
                                         </connections>
                                     </segmentedControl>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8OE-DE-cya">
-                                        <rect key="frame" x="359.5" y="49" width="46.5" height="34"/>
+                                        <rect key="frame" x="362.5" y="50.5" width="43.5" height="31"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title=""/>
                                         <connections>
@@ -95,11 +95,11 @@
             <objects>
                 <viewController id="AOr-IO-2Z8" customClass="RegisterProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Kd8-Qa-rrm">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pVa-QY-cqJ">
-                                <rect key="frame" x="0.0" y="48" width="414" height="56"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="56"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <items>
                                     <navigationItem title="상품등록" id="rUu-JD-lQU">
@@ -116,16 +116,41 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="u1C-mJ-fF9">
-                                <rect key="frame" x="10" y="284" width="394" height="574"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <mutableString key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non psunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civi</mutableString>
-                                <color key="textColor" systemColor="labelColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vc5-5U-yx3">
+                                <rect key="frame" x="10" y="110" width="394" height="119.5"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-wg-qQg">
+                                        <rect key="frame" x="0.0" y="0.0" width="119.5" height="119.5"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Y1-Os-tRY">
+                                                <rect key="frame" x="0.0" y="0.0" width="119.5" height="119.5"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="0Y1-Os-tRY" secondAttribute="height" multiplier="1:1" id="zb0-fT-fPF"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="filled" image="plus" catalog="system">
+                                                    <color key="baseForegroundColor" systemColor="systemBlueColor"/>
+                                                    <color key="baseBackgroundColor" systemColor="systemGray5Color"/>
+                                                </buttonConfiguration>
+                                                <connections>
+                                                    <action selector="touchUpImagePlusButton:" destination="AOr-IO-2Z8" eventType="touchUpInside" id="E6W-N3-EPz"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="eVC-wg-qQg" firstAttribute="top" secondItem="oXD-H5-8L6" secondAttribute="top" id="AIO-Y1-DxK"/>
+                                    <constraint firstItem="eVC-wg-qQg" firstAttribute="bottom" secondItem="oXD-H5-8L6" secondAttribute="bottom" id="WS4-WU-kCh"/>
+                                    <constraint firstItem="eVC-wg-qQg" firstAttribute="height" secondItem="dWO-et-Yhk" secondAttribute="height" id="dOA-oZ-KYf"/>
+                                    <constraint firstItem="eVC-wg-qQg" firstAttribute="trailing" secondItem="oXD-H5-8L6" secondAttribute="trailing" id="iTd-7M-t8k"/>
+                                    <constraint firstItem="eVC-wg-qQg" firstAttribute="leading" secondItem="oXD-H5-8L6" secondAttribute="leading" id="yyd-Vs-z3Q"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="oXD-H5-8L6"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="dWO-et-Yhk"/>
+                            </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vh1-EO-9Nd">
-                                <rect key="frame" x="10" y="114" width="394" height="160"/>
+                                <rect key="frame" x="10" y="239.5" width="394" height="160"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="j87-S8-zQP">
                                         <rect key="frame" x="0.0" y="0.0" width="394" height="34"/>
@@ -161,31 +186,46 @@
                                     </textField>
                                 </subviews>
                             </stackView>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NAL-HZ-RjB">
+                                <rect key="frame" x="10" y="409.5" width="394" height="422.5"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="M5x-nH-cvu"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="NAL-HZ-RjB" firstAttribute="top" secondItem="Vh1-EO-9Nd" secondAttribute="bottom" constant="10" id="3Uc-as-yzf"/>
+                            <constraint firstItem="NAL-HZ-RjB" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" constant="10" id="BOt-TR-gHk"/>
                             <constraint firstItem="pVa-QY-cqJ" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" id="NTh-Tp-osz"/>
                             <constraint firstItem="Vh1-EO-9Nd" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" constant="10" id="SsK-YE-Jnb"/>
-                            <constraint firstItem="u1C-mJ-fF9" firstAttribute="trailing" secondItem="M5x-nH-cvu" secondAttribute="trailing" constant="-10" id="WpF-DF-IYZ"/>
-                            <constraint firstItem="u1C-mJ-fF9" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" constant="10" id="f6F-lB-t8J"/>
+                            <constraint firstItem="M5x-nH-cvu" firstAttribute="trailing" secondItem="NAL-HZ-RjB" secondAttribute="trailing" constant="10" id="UA1-DK-xyi"/>
+                            <constraint firstItem="0Y1-Os-tRY" firstAttribute="height" secondItem="M5x-nH-cvu" secondAttribute="height" multiplier="0.15" id="VRJ-bH-R9S"/>
+                            <constraint firstItem="M5x-nH-cvu" firstAttribute="bottom" secondItem="NAL-HZ-RjB" secondAttribute="bottom" constant="10" id="cjy-L0-Hqm"/>
+                            <constraint firstItem="Vh1-EO-9Nd" firstAttribute="top" secondItem="vc5-5U-yx3" secondAttribute="bottom" constant="10" id="ePe-3l-hcE"/>
                             <constraint firstItem="pVa-QY-cqJ" firstAttribute="top" secondItem="M5x-nH-cvu" secondAttribute="top" id="hL0-8w-d78"/>
                             <constraint firstItem="pVa-QY-cqJ" firstAttribute="trailing" secondItem="M5x-nH-cvu" secondAttribute="trailing" id="ibk-SU-NaL"/>
-                            <constraint firstItem="Vh1-EO-9Nd" firstAttribute="top" secondItem="pVa-QY-cqJ" secondAttribute="bottom" constant="10" id="kjF-dc-1bn"/>
                             <constraint firstItem="M5x-nH-cvu" firstAttribute="trailing" secondItem="Vh1-EO-9Nd" secondAttribute="trailing" constant="10" id="ngy-Wt-iFi"/>
-                            <constraint firstItem="u1C-mJ-fF9" firstAttribute="top" secondItem="Vh1-EO-9Nd" secondAttribute="bottom" constant="10" id="zJN-Sm-P4f"/>
-                            <constraint firstItem="u1C-mJ-fF9" firstAttribute="bottom" secondItem="M5x-nH-cvu" secondAttribute="bottom" constant="20" id="ze0-bf-0f8"/>
+                            <constraint firstItem="M5x-nH-cvu" firstAttribute="trailing" secondItem="vc5-5U-yx3" secondAttribute="trailing" constant="10" id="p2o-HC-3Jt"/>
+                            <constraint firstItem="vc5-5U-yx3" firstAttribute="top" secondItem="pVa-QY-cqJ" secondAttribute="bottom" constant="10" id="pIr-bM-sTG"/>
+                            <constraint firstItem="vc5-5U-yx3" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" constant="10" id="uHr-oJ-t49"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="cancelBarButtonItem" destination="KCK-d4-50u" id="WAr-kJ-MFz"/>
                         <outlet property="doneBarButtonItem" destination="t1B-yL-M7v" id="qrs-Cp-fGk"/>
+                        <outlet property="imagePlusButton" destination="0Y1-Os-tRY" id="45t-nC-g8c"/>
+                        <outlet property="imageStackView" destination="eVC-wg-qQg" id="wYh-Kf-SQZ"/>
                         <outlet property="productCurrencySegmentedControl" destination="gfU-9z-pRp" id="nXF-hz-BQZ"/>
-                        <outlet property="productDescriptionTextView" destination="u1C-mJ-fF9" id="5Zw-V5-5IA"/>
+                        <outlet property="productDescriptionTextView" destination="NAL-HZ-RjB" id="6l6-Gb-UXr"/>
                         <outlet property="productDiscountedPriceTextField" destination="SS8-rv-iXo" id="XBq-MY-xnn"/>
                         <outlet property="productNameTextField" destination="j87-S8-zQP" id="cLF-Yj-LZk"/>
                         <outlet property="productPriceTextField" destination="674-SV-anw" id="3NT-tx-Ocs"/>
                         <outlet property="productStockTextField" destination="jId-FK-d4p" id="7Xu-L0-Kad"/>
+                        <outlet property="scrollView" destination="vc5-5U-yx3" id="P7I-kd-ra1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Q5r-tu-hWo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -196,10 +236,16 @@
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGray6Color">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DxO-ae-ikV">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -30,33 +30,7 @@
                             </collectionView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N0w-K7-nHs" userLabel="grayView">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="89.5"/>
-                                <subviews>
-                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="N2f-4M-XSf">
-                                        <rect key="frame" x="156.5" y="50.5" width="101" height="32"/>
-                                        <segments>
-                                            <segment title="LIST"/>
-                                            <segment title="GRID"/>
-                                        </segments>
-                                        <connections>
-                                            <action selector="tapSegmentedControl:" destination="BYZ-38-t0r" eventType="valueChanged" id="ehP-1f-YdV"/>
-                                        </connections>
-                                    </segmentedControl>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8OE-DE-cya">
-                                        <rect key="frame" x="362.5" y="50.5" width="43.5" height="31"/>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title=""/>
-                                        <connections>
-                                            <segue destination="AOr-IO-2Z8" kind="presentation" modalPresentationStyle="fullScreen" id="8de-Fc-UI9"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="8OE-DE-cya" secondAttribute="trailing" constant="8" id="0O3-Sx-J6j"/>
-                                    <constraint firstItem="8OE-DE-cya" firstAttribute="centerY" secondItem="N2f-4M-XSf" secondAttribute="centerY" id="N9U-W0-SWz"/>
-                                    <constraint firstAttribute="bottom" secondItem="N2f-4M-XSf" secondAttribute="bottom" constant="8" id="VE0-6a-tvX"/>
-                                    <constraint firstItem="N2f-4M-XSf" firstAttribute="centerX" secondItem="N0w-K7-nHs" secondAttribute="centerX" id="g2E-um-kX3"/>
-                                </constraints>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -73,6 +47,31 @@
                         </constraints>
                     </view>
                     <toolbarItems/>
+                    <navigationItem key="navigationItem" id="Nts-NJ-bOL">
+                        <nil key="title"/>
+                        <segmentedControl key="titleView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" id="N2f-4M-XSf">
+                            <rect key="frame" x="105" y="6" width="204" height="32"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <segments>
+                                <segment title="LIST"/>
+                                <segment title="GRID"/>
+                            </segments>
+                            <connections>
+                                <action selector="tapSegmentedControl:" destination="BYZ-38-t0r" eventType="valueChanged" id="ehP-1f-YdV"/>
+                            </connections>
+                        </segmentedControl>
+                        <barButtonItem key="rightBarButtonItem" id="7iR-zo-TYF">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="8OE-DE-cya">
+                                <rect key="frame" x="350.5" y="6.5" width="43.5" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title=""/>
+                                <connections>
+                                    <segue destination="AOr-IO-2Z8" kind="presentation" modalPresentationStyle="fullScreen" id="8de-Fc-UI9"/>
+                                </connections>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="collectionView" destination="Sgw-OQ-JvR" id="oab-S1-gtQ"/>
@@ -81,7 +80,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="131.8840579710145" y="-34.151785714285715"/>
+            <point key="canvasLocation" x="1042.0289855072465" y="-34.151785714285715"/>
         </scene>
         <!--Register Product View Controller-->
         <scene sceneID="xXI-Vl-qpu">
@@ -225,7 +224,106 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Q5r-tu-hWo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="895.6521739130435" y="-34.151785714285715"/>
+            <point key="canvasLocation" x="1939.1304347826087" y="-306.02678571428572"/>
+        </scene>
+        <!--Product Detail View Controller-->
+        <scene sceneID="Ba2-FW-ffs">
+            <objects>
+                <viewController storyboardIdentifier="productDetailViewController" id="GNO-P2-uqF" customClass="ProductDetailViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="edM-fs-0Ga">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="7sA-Yt-PLF">
+                                <rect key="frame" x="8" y="8" width="398" height="327"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="3e2-ts-P6P">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells/>
+                            </collectionView>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WV-Js-eMw">
+                                <rect key="frame" x="8" y="444" width="398" height="452"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia sum dolor sit er elit lamet, a commodo consequat. Duis </string>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cng-IH-07i">
+                                <rect key="frame" x="8" y="343" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N82-S3-G9J">
+                                <rect key="frame" x="58" y="343" width="348" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dn4-lN-JSi">
+                                <rect key="frame" x="8" y="374" width="398" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FtI-b2-EsR">
+                                <rect key="frame" x="8" y="403" width="398" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="tQB-5g-saW"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="dn4-lN-JSi" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="46r-2Y-wko"/>
+                            <constraint firstItem="3WV-Js-eMw" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="CPK-pv-lJO"/>
+                            <constraint firstAttribute="bottom" secondItem="3WV-Js-eMw" secondAttribute="bottom" id="IRx-9y-hGE"/>
+                            <constraint firstItem="N82-S3-G9J" firstAttribute="leading" secondItem="Cng-IH-07i" secondAttribute="trailing" constant="8" id="O5l-zp-rPa"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="3WV-Js-eMw" secondAttribute="trailing" constant="8" id="PIf-oM-lp0"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="FtI-b2-EsR" secondAttribute="trailing" constant="8" id="SxU-kt-As3"/>
+                            <constraint firstItem="7sA-Yt-PLF" firstAttribute="height" secondItem="tQB-5g-saW" secondAttribute="height" multiplier="0.4" id="Xxd-u4-q8X"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="N82-S3-G9J" secondAttribute="trailing" constant="8" id="ZsS-y4-3S6"/>
+                            <constraint firstItem="Cng-IH-07i" firstAttribute="top" secondItem="7sA-Yt-PLF" secondAttribute="bottom" constant="8" id="bzP-2q-hvq"/>
+                            <constraint firstItem="Cng-IH-07i" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="cQG-1W-WrO"/>
+                            <constraint firstItem="3WV-Js-eMw" firstAttribute="top" secondItem="FtI-b2-EsR" secondAttribute="bottom" constant="20" id="dBs-Sv-2WE"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="7sA-Yt-PLF" secondAttribute="trailing" constant="8" id="eLA-Y6-MHd"/>
+                            <constraint firstItem="dn4-lN-JSi" firstAttribute="top" secondItem="N82-S3-G9J" secondAttribute="bottom" constant="10" id="gp9-aq-eeq"/>
+                            <constraint firstItem="7sA-Yt-PLF" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="gtf-aM-QEe"/>
+                            <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="dn4-lN-JSi" secondAttribute="trailing" constant="8" id="myR-Di-qb9"/>
+                            <constraint firstItem="7sA-Yt-PLF" firstAttribute="top" secondItem="edM-fs-0Ga" secondAttribute="top" constant="8" id="sa8-Le-Xhf"/>
+                            <constraint firstItem="FtI-b2-EsR" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="u8H-8f-Zwg"/>
+                            <constraint firstItem="FtI-b2-EsR" firstAttribute="top" secondItem="dn4-lN-JSi" secondAttribute="bottom" constant="8" id="xRy-2j-kZZ"/>
+                            <constraint firstItem="N82-S3-G9J" firstAttribute="firstBaseline" secondItem="Cng-IH-07i" secondAttribute="firstBaseline" id="zeL-7G-tVP"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="tNb-HJ-56e" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1939.1304347826087" y="377.67857142857139"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Kdv-bQ-66X">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DxO-ae-ikV" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="5Eh-iu-ihx">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="za1-dW-Qbt"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Zqy-ml-6P3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="131.8840579710145" y="-34.151785714285715"/>
         </scene>
     </scenes>
     <resources>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DxO-ae-ikV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DxO-ae-ikV">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Product List View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ProductListViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -82,16 +82,16 @@
             </objects>
             <point key="canvasLocation" x="1042.0289855072465" y="-34.151785714285715"/>
         </scene>
-        <!--Register Product View Controller-->
+        <!--Product Post And Patch View Controller-->
         <scene sceneID="xXI-Vl-qpu">
             <objects>
-                <viewController storyboardIdentifier="registerProductViewController" id="AOr-IO-2Z8" customClass="RegisterProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="registerProductViewController" id="AOr-IO-2Z8" customClass="ProductPostAndPatchViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Kd8-Qa-rrm">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pVa-QY-cqJ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <items>
                                     <navigationItem title="상품등록" id="rUu-JD-lQU">
@@ -109,13 +109,13 @@
                                 </items>
                             </navigationBar>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vc5-5U-yx3">
-                                <rect key="frame" x="10" y="98" width="394" height="122.5"/>
+                                <rect key="frame" x="10" y="102" width="394" height="122"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-wg-qQg">
-                                        <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Y1-Os-tRY">
-                                                <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="0Y1-Os-tRY" secondAttribute="height" multiplier="1:1" id="zb0-fT-fPF"/>
                                                 </constraints>
@@ -142,7 +142,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="dWO-et-Yhk"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vh1-EO-9Nd">
-                                <rect key="frame" x="10" y="230.5" width="394" height="160"/>
+                                <rect key="frame" x="10" y="234" width="394" height="160"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="j87-S8-zQP">
                                         <rect key="frame" x="0.0" y="0.0" width="394" height="34"/>
@@ -179,7 +179,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NAL-HZ-RjB">
-                                <rect key="frame" x="10" y="400.5" width="404" height="451.5"/>
+                                <rect key="frame" x="10" y="404" width="404" height="448"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -235,7 +235,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="BDk-m2-pFx">
-                                <rect key="frame" x="8" y="44" width="398" height="327"/>
+                                <rect key="frame" x="8" y="48" width="398" height="325.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="hJs-V1-X1o">
                                     <size key="itemSize" width="128" height="128"/>
@@ -246,25 +246,25 @@
                                 <cells/>
                             </collectionView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aDF-IL-ZQ6">
-                                <rect key="frame" x="8" y="379" width="42" height="21"/>
+                                <rect key="frame" x="8" y="381.5" width="42" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ayh-t3-lIj">
-                                <rect key="frame" x="58" y="379" width="348" height="20.5"/>
+                                <rect key="frame" x="58" y="381.5" width="348" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8aS-gO-7mZ">
-                                <rect key="frame" x="8" y="438.5" width="398" height="21"/>
+                                <rect key="frame" x="8" y="441" width="398" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jH9-em-GcE">
-                                <rect key="frame" x="8" y="479.5" width="398" height="416.5"/>
+                                <rect key="frame" x="8" y="482" width="398" height="414"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -272,7 +272,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FEM-xN-ip9">
-                                <rect key="frame" x="8" y="409.5" width="398" height="21"/>
+                                <rect key="frame" x="8" y="412" width="398" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -321,7 +321,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DxO-ae-ikV" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="5Eh-iu-ihx">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -337,7 +337,7 @@
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -245,14 +245,14 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aDF-IL-ZQ6">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aDF-IL-ZQ6">
                                 <rect key="frame" x="8" y="379" width="42" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ayh-t3-lIj">
-                                <rect key="frame" x="364" y="379" width="42" height="20.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ayh-t3-lIj">
+                                <rect key="frame" x="58" y="379" width="348" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -281,6 +281,7 @@
                         <viewLayoutGuide key="safeArea" id="tQB-5g-saW"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="ayh-t3-lIj" firstAttribute="leading" secondItem="aDF-IL-ZQ6" secondAttribute="trailing" constant="8" id="0cm-7v-pjn"/>
                             <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="8aS-gO-7mZ" secondAttribute="trailing" constant="8" id="4Bs-78-YhB"/>
                             <constraint firstItem="tQB-5g-saW" firstAttribute="trailing" secondItem="jH9-em-GcE" secondAttribute="trailing" constant="8" id="5Ni-gd-KBt"/>
                             <constraint firstItem="FEM-xN-ip9" firstAttribute="leading" secondItem="tQB-5g-saW" secondAttribute="leading" constant="8" id="6Lh-Sg-A6D"/>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -42,7 +42,7 @@
                                         </connections>
                                     </segmentedControl>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8OE-DE-cya">
-                                        <rect key="frame" x="362.5" y="50.5" width="43.5" height="31"/>
+                                        <rect key="frame" x="359.5" y="49" width="46.5" height="34"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title=""/>
                                         <connections>
@@ -99,7 +99,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pVa-QY-cqJ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <items>
                                     <navigationItem title="상품등록" id="rUu-JD-lQU">
@@ -117,13 +117,13 @@
                                 </items>
                             </navigationBar>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vc5-5U-yx3">
-                                <rect key="frame" x="10" y="98" width="394" height="122.5"/>
+                                <rect key="frame" x="10" y="102" width="394" height="122"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-wg-qQg">
-                                        <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Y1-Os-tRY">
-                                                <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="0Y1-Os-tRY" secondAttribute="height" multiplier="1:1" id="zb0-fT-fPF"/>
                                                 </constraints>
@@ -150,7 +150,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="dWO-et-Yhk"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vh1-EO-9Nd">
-                                <rect key="frame" x="10" y="230.5" width="394" height="160"/>
+                                <rect key="frame" x="10" y="234" width="394" height="160"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="j87-S8-zQP">
                                         <rect key="frame" x="0.0" y="0.0" width="394" height="34"/>
@@ -187,7 +187,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NAL-HZ-RjB">
-                                <rect key="frame" x="10" y="400.5" width="394" height="451.5"/>
+                                <rect key="frame" x="10" y="404" width="404" height="448"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -202,7 +202,7 @@
                             <constraint firstItem="NAL-HZ-RjB" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" constant="10" id="BOt-TR-gHk"/>
                             <constraint firstItem="pVa-QY-cqJ" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" id="NTh-Tp-osz"/>
                             <constraint firstItem="Vh1-EO-9Nd" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" constant="10" id="SsK-YE-Jnb"/>
-                            <constraint firstItem="M5x-nH-cvu" firstAttribute="trailing" secondItem="NAL-HZ-RjB" secondAttribute="trailing" constant="10" id="UA1-DK-xyi"/>
+                            <constraint firstItem="M5x-nH-cvu" firstAttribute="trailing" secondItem="NAL-HZ-RjB" secondAttribute="trailing" id="UA1-DK-xyi"/>
                             <constraint firstItem="0Y1-Os-tRY" firstAttribute="height" secondItem="M5x-nH-cvu" secondAttribute="height" multiplier="0.15" id="VRJ-bH-R9S"/>
                             <constraint firstItem="M5x-nH-cvu" firstAttribute="bottom" secondItem="NAL-HZ-RjB" secondAttribute="bottom" constant="10" id="cjy-L0-Hqm"/>
                             <constraint firstItem="Vh1-EO-9Nd" firstAttribute="top" secondItem="vc5-5U-yx3" secondAttribute="bottom" constant="10" id="ePe-3l-hcE"/>
@@ -238,7 +238,7 @@
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -42,7 +42,7 @@
                                         </connections>
                                     </segmentedControl>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8OE-DE-cya">
-                                        <rect key="frame" x="362.5" y="50.5" width="43.5" height="31"/>
+                                        <rect key="frame" x="359.5" y="49" width="46.5" height="34"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title=""/>
                                         <connections>
@@ -95,40 +95,109 @@
             <objects>
                 <viewController id="AOr-IO-2Z8" customClass="RegisterProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Kd8-Qa-rrm">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pVa-QY-cqJ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="56"/>
+                                <rect key="frame" x="0.0" y="48" width="414" height="56"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <items>
                                     <navigationItem title="상품등록" id="rUu-JD-lQU">
-                                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="KCK-d4-50u"/>
-                                        <barButtonItem key="rightBarButtonItem" title="Done" id="t1B-yL-M7v"/>
+                                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="KCK-d4-50u">
+                                            <connections>
+                                                <action selector="touchUpCancelBarButtonItem:" destination="AOr-IO-2Z8" id="cmK-Lk-oaE"/>
+                                            </connections>
+                                        </barButtonItem>
+                                        <barButtonItem key="rightBarButtonItem" title="Done" id="t1B-yL-M7v">
+                                            <connections>
+                                                <action selector="touchUpDoneBarButtonItem:" destination="AOr-IO-2Z8" id="yKy-jg-gDj"/>
+                                            </connections>
+                                        </barButtonItem>
                                     </navigationItem>
                                 </items>
                             </navigationBar>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="u1C-mJ-fF9">
+                                <rect key="frame" x="10" y="284" width="394" height="574"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <mutableString key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non psunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civi</mutableString>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vh1-EO-9Nd">
+                                <rect key="frame" x="10" y="114" width="394" height="160"/>
+                                <subviews>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="j87-S8-zQP">
+                                        <rect key="frame" x="0.0" y="0.0" width="394" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9pB-jt-4jP">
+                                        <rect key="frame" x="0.0" y="42" width="394" height="34"/>
+                                        <subviews>
+                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품가격" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="674-SV-anw">
+                                                <rect key="frame" x="0.0" y="0.0" width="287" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                            </textField>
+                                            <segmentedControl opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="gfU-9z-pRp">
+                                                <rect key="frame" x="297" y="0.0" width="97" height="35"/>
+                                                <segments>
+                                                    <segment title="KRW"/>
+                                                    <segment title="USD"/>
+                                                </segments>
+                                            </segmentedControl>
+                                        </subviews>
+                                    </stackView>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="할인금액" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="SS8-rv-iXo">
+                                        <rect key="frame" x="0.0" y="84" width="394" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="재고수량" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jId-FK-d4p">
+                                        <rect key="frame" x="0.0" y="126" width="394" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="M5x-nH-cvu"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="pVa-QY-cqJ" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" id="NTh-Tp-osz"/>
+                            <constraint firstItem="Vh1-EO-9Nd" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" constant="10" id="SsK-YE-Jnb"/>
+                            <constraint firstItem="u1C-mJ-fF9" firstAttribute="trailing" secondItem="M5x-nH-cvu" secondAttribute="trailing" constant="-10" id="WpF-DF-IYZ"/>
+                            <constraint firstItem="u1C-mJ-fF9" firstAttribute="leading" secondItem="M5x-nH-cvu" secondAttribute="leading" constant="10" id="f6F-lB-t8J"/>
                             <constraint firstItem="pVa-QY-cqJ" firstAttribute="top" secondItem="M5x-nH-cvu" secondAttribute="top" id="hL0-8w-d78"/>
                             <constraint firstItem="pVa-QY-cqJ" firstAttribute="trailing" secondItem="M5x-nH-cvu" secondAttribute="trailing" id="ibk-SU-NaL"/>
+                            <constraint firstItem="Vh1-EO-9Nd" firstAttribute="top" secondItem="pVa-QY-cqJ" secondAttribute="bottom" constant="10" id="kjF-dc-1bn"/>
+                            <constraint firstItem="M5x-nH-cvu" firstAttribute="trailing" secondItem="Vh1-EO-9Nd" secondAttribute="trailing" constant="10" id="ngy-Wt-iFi"/>
+                            <constraint firstItem="u1C-mJ-fF9" firstAttribute="top" secondItem="Vh1-EO-9Nd" secondAttribute="bottom" constant="10" id="zJN-Sm-P4f"/>
+                            <constraint firstItem="u1C-mJ-fF9" firstAttribute="bottom" secondItem="M5x-nH-cvu" secondAttribute="bottom" constant="20" id="ze0-bf-0f8"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="cancelBarButtonItem" destination="KCK-d4-50u" id="WAr-kJ-MFz"/>
                         <outlet property="doneBarButtonItem" destination="t1B-yL-M7v" id="qrs-Cp-fGk"/>
+                        <outlet property="productCurrencySegmentedControl" destination="gfU-9z-pRp" id="nXF-hz-BQZ"/>
+                        <outlet property="productDescriptionTextView" destination="u1C-mJ-fF9" id="5Zw-V5-5IA"/>
+                        <outlet property="productDiscountedPriceTextField" destination="SS8-rv-iXo" id="XBq-MY-xnn"/>
+                        <outlet property="productNameTextField" destination="j87-S8-zQP" id="cLF-Yj-LZk"/>
+                        <outlet property="productPriceTextField" destination="674-SV-anw" id="3NT-tx-Ocs"/>
+                        <outlet property="productStockTextField" destination="jId-FK-d4p" id="7Xu-L0-Kad"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Q5r-tu-hWo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="897" y="-34"/>
+            <point key="canvasLocation" x="895.6521739130435" y="-34.151785714285715"/>
         </scene>
     </scenes>
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
+        <systemColor name="labelColor">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
+++ b/OpenMarket/OpenMarket/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -42,24 +42,18 @@
                                         </connections>
                                     </segmentedControl>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8OE-DE-cya">
-                                        <rect key="frame" x="359.5" y="49" width="46.5" height="34"/>
+                                        <rect key="frame" x="362.5" y="50.5" width="43.5" height="31"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title=""/>
                                         <connections>
                                             <segue destination="AOr-IO-2Z8" kind="presentation" modalPresentationStyle="fullScreen" id="8de-Fc-UI9"/>
                                         </connections>
                                     </button>
-                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" hidesWhenStopped="YES" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="bJH-1T-XiE">
-                                        <rect key="frame" x="50" y="56" width="20" height="20"/>
-                                    </activityIndicatorView>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="8OE-DE-cya" secondAttribute="trailing" constant="8" id="0O3-Sx-J6j"/>
-                                    <constraint firstItem="N2f-4M-XSf" firstAttribute="centerY" secondItem="bJH-1T-XiE" secondAttribute="centerY" id="IHe-pU-nEE"/>
-                                    <constraint firstItem="N2f-4M-XSf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="bJH-1T-XiE" secondAttribute="trailing" constant="30" id="Jjj-KB-4At"/>
                                     <constraint firstItem="8OE-DE-cya" firstAttribute="centerY" secondItem="N2f-4M-XSf" secondAttribute="centerY" id="N9U-W0-SWz"/>
-                                    <constraint firstItem="bJH-1T-XiE" firstAttribute="leading" secondItem="N0w-K7-nHs" secondAttribute="leading" priority="750" constant="50" id="T1o-zu-mnU"/>
                                     <constraint firstAttribute="bottom" secondItem="N2f-4M-XSf" secondAttribute="bottom" constant="8" id="VE0-6a-tvX"/>
                                     <constraint firstItem="N2f-4M-XSf" firstAttribute="centerX" secondItem="N0w-K7-nHs" secondAttribute="centerX" id="g2E-um-kX3"/>
                                 </constraints>
@@ -81,7 +75,6 @@
                     <toolbarItems/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="activityIndicatorView" destination="bJH-1T-XiE" id="pwk-HL-zZV"/>
                         <outlet property="collectionView" destination="Sgw-OQ-JvR" id="oab-S1-gtQ"/>
                         <outlet property="segmentedControl" destination="N2f-4M-XSf" id="2Hf-ro-svZ"/>
                     </connections>
@@ -99,7 +92,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pVa-QY-cqJ">
-                                <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <items>
                                     <navigationItem title="상품등록" id="rUu-JD-lQU">
@@ -117,13 +110,13 @@
                                 </items>
                             </navigationBar>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vc5-5U-yx3">
-                                <rect key="frame" x="10" y="102" width="394" height="122"/>
+                                <rect key="frame" x="10" y="98" width="394" height="122.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-wg-qQg">
-                                        <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Y1-Os-tRY">
-                                                <rect key="frame" x="0.0" y="0.0" width="122" height="122"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="122.5" height="122.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="0Y1-Os-tRY" secondAttribute="height" multiplier="1:1" id="zb0-fT-fPF"/>
                                                 </constraints>
@@ -150,7 +143,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="dWO-et-Yhk"/>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vh1-EO-9Nd">
-                                <rect key="frame" x="10" y="234" width="394" height="160"/>
+                                <rect key="frame" x="10" y="230.5" width="394" height="160"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="상품명" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="j87-S8-zQP">
                                         <rect key="frame" x="0.0" y="0.0" width="394" height="34"/>
@@ -187,7 +180,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NAL-HZ-RjB">
-                                <rect key="frame" x="10" y="404" width="404" height="448"/>
+                                <rect key="frame" x="10" y="400.5" width="404" height="451.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -238,7 +231,7 @@
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/OpenMarket/OpenMarket/View/CustomCollectionViewListCell.xib
+++ b/OpenMarket/OpenMarket/View/CustomCollectionViewListCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -20,34 +20,31 @@
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="j7K-LV-SCn">
                         <rect key="frame" x="8" y="8" width="84" height="84"/>
-                        <constraints>
-                            <constraint firstAttribute="width" secondItem="j7K-LV-SCn" secondAttribute="height" multiplier="1:1" id="4QT-Cc-xxr"/>
-                        </constraints>
                     </imageView>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="78o-uC-bTj">
-                        <rect key="frame" x="520" y="27" width="20" height="16.5"/>
+                        <rect key="frame" x="520" y="29.5" width="20" height="16.5"/>
                         <color key="tintColor" systemColor="systemGray2Color"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="78o-uC-bTj" secondAttribute="height" multiplier="1:1" id="6qF-Fu-CL8"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uMi-x0-QFB">
-                        <rect key="frame" x="100" y="33" width="373" height="17"/>
+                        <rect key="frame" x="100" y="29.5" width="366.5" height="20.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ebl-8t-U6y">
-                        <rect key="frame" x="100" y="50" width="452" height="17"/>
+                        <rect key="frame" x="100" y="50" width="452" height="20.5"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUi-wh-yCT">
-                                <rect key="frame" x="0.0" y="0.0" width="35.5" height="17"/>
+                                <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" systemColor="systemPinkColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bHw-MN-7vC">
-                                <rect key="frame" x="43.5" y="0.0" width="408.5" height="17"/>
+                                <rect key="frame" x="49.5" y="0.0" width="402.5" height="20.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" systemColor="systemGray2Color"/>
                                 <nil key="highlightedColor"/>
@@ -55,7 +52,7 @@
                         </subviews>
                     </stackView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bcH-Ay-7oF">
-                        <rect key="frame" x="481" y="29.5" width="31" height="20"/>
+                        <rect key="frame" x="474.5" y="29" width="37.5" height="20"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                         <color key="textColor" systemColor="systemGray2Color"/>
                         <nil key="highlightedColor"/>
@@ -102,7 +99,7 @@
         </collectionViewCell>
     </objects>
     <resources>
-        <image name="chevron.right" catalog="system" width="96" height="128"/>
+        <image name="chevron.right" catalog="system" width="97" height="128"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/OpenMarket/OpenMarket/View/CustomCollectionViewListCell.xib
+++ b/OpenMarket/OpenMarket/View/CustomCollectionViewListCell.xib
@@ -19,7 +19,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="j7K-LV-SCn">
-                        <rect key="frame" x="8" y="8" width="93.5" height="84"/>
+                        <rect key="frame" x="8" y="8" width="84" height="84"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="j7K-LV-SCn" secondAttribute="height" multiplier="1:1" id="4QT-Cc-xxr"/>
+                        </constraints>
                     </imageView>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="78o-uC-bTj">
                         <rect key="frame" x="520" y="27" width="20" height="16.5"/>
@@ -29,13 +32,13 @@
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uMi-x0-QFB">
-                        <rect key="frame" x="109.5" y="33" width="363.5" height="17"/>
+                        <rect key="frame" x="100" y="33" width="373" height="17"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ebl-8t-U6y">
-                        <rect key="frame" x="109.5" y="50" width="442.5" height="17"/>
+                        <rect key="frame" x="100" y="50" width="452" height="17"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUi-wh-yCT">
                                 <rect key="frame" x="0.0" y="0.0" width="35.5" height="17"/>
@@ -44,7 +47,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bHw-MN-7vC">
-                                <rect key="frame" x="43.5" y="0.0" width="399" height="17"/>
+                                <rect key="frame" x="43.5" y="0.0" width="408.5" height="17"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" systemColor="systemGray2Color"/>
                                 <nil key="highlightedColor"/>
@@ -82,7 +85,7 @@
                     <constraint firstAttribute="trailing" secondItem="0mu-0q-VCk" secondAttribute="trailing" id="h1g-Tz-3g4"/>
                     <constraint firstItem="0mu-0q-VCk" firstAttribute="leading" secondItem="L9w-Kf-z7I" secondAttribute="leading" constant="8" id="tbp-KE-l67"/>
                     <constraint firstAttribute="trailing" secondItem="78o-uC-bTj" secondAttribute="trailing" constant="20" id="wYp-eg-gKo"/>
-                    <constraint firstItem="j7K-LV-SCn" firstAttribute="width" secondItem="L9w-Kf-z7I" secondAttribute="width" multiplier="1:6" id="wlN-rr-9qu"/>
+                    <constraint firstItem="j7K-LV-SCn" firstAttribute="width" secondItem="L9w-Kf-z7I" secondAttribute="width" multiplier="0.15" id="wlN-rr-9qu"/>
                     <constraint firstItem="ebl-8t-U6y" firstAttribute="top" secondItem="L9w-Kf-z7I" secondAttribute="centerY" id="zsk-qv-nw5"/>
                 </constraints>
             </collectionViewCellContentView>

--- a/OpenMarket/OpenMarket/View/CustomCollectionViewPageCell.xib
+++ b/OpenMarket/OpenMarket/View/CustomCollectionViewPageCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_12" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,10 +18,10 @@
                 <rect key="frame" x="0.0" y="0.0" width="244" height="253"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZSr-w5-01r">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="ZSr-w5-01r">
                         <rect key="frame" x="0.0" y="0.0" width="244" height="216"/>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zjv-q5-mLb">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zjv-q5-mLb">
                         <rect key="frame" x="101" y="224" width="42" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>

--- a/OpenMarket/OpenMarket/View/CustomCollectionViewPageCell.xib
+++ b/OpenMarket/OpenMarket/View/CustomCollectionViewPageCell.xib
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="customCollectionViewPageCell" id="m6g-h3-d0y" customClass="CustomCollectionViewPageCell" customModule="OpenMarket" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="244" height="253"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="XQN-Rg-4Zv">
+                <rect key="frame" x="0.0" y="0.0" width="244" height="253"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZSr-w5-01r">
+                        <rect key="frame" x="0.0" y="0.0" width="244" height="216"/>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zjv-q5-mLb">
+                        <rect key="frame" x="101" y="224" width="42" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="zjv-q5-mLb" firstAttribute="centerX" secondItem="XQN-Rg-4Zv" secondAttribute="centerX" id="6mh-gW-aBg"/>
+                    <constraint firstItem="ZSr-w5-01r" firstAttribute="leading" secondItem="XQN-Rg-4Zv" secondAttribute="leading" id="Ge9-kc-fEB"/>
+                    <constraint firstItem="zjv-q5-mLb" firstAttribute="top" secondItem="ZSr-w5-01r" secondAttribute="bottom" constant="8" id="LWq-2b-iRS"/>
+                    <constraint firstAttribute="trailing" secondItem="ZSr-w5-01r" secondAttribute="trailing" id="Olt-7C-tcT"/>
+                    <constraint firstItem="ZSr-w5-01r" firstAttribute="top" secondItem="XQN-Rg-4Zv" secondAttribute="top" id="S2w-UW-0V6"/>
+                    <constraint firstAttribute="bottom" secondItem="zjv-q5-mLb" secondAttribute="bottom" constant="8" id="eQy-up-fHl"/>
+                </constraints>
+            </collectionViewCellContentView>
+            <size key="customSize" width="244" height="253"/>
+            <point key="canvasLocation" x="299.23664122137404" y="-29.929577464788736"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/OpenMarket/OpenMarket/View/CustomCollectionViewPageCell.xib
+++ b/OpenMarket/OpenMarket/View/CustomCollectionViewPageCell.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -36,8 +37,18 @@
                     <constraint firstAttribute="bottom" secondItem="zjv-q5-mLb" secondAttribute="bottom" constant="8" id="eQy-up-fHl"/>
                 </constraints>
             </collectionViewCellContentView>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <size key="customSize" width="244" height="253"/>
+            <connections>
+                <outlet property="imageOrderLabel" destination="zjv-q5-mLb" id="daO-NX-FAX"/>
+                <outlet property="productImage" destination="ZSr-w5-01r" id="d1N-Xi-LO8"/>
+            </connections>
             <point key="canvasLocation" x="299.23664122137404" y="-29.929577464788736"/>
         </collectionViewCell>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 - API서버와 통신해서 데이터를 조회,생성,수정,삭제 작업을 진행했습니다.
 - **KeyWords**
   - `URLSession`, `Codable`, `JsonDecoder`, `GCD`
-  - `@escaping` `dataTask(with:completionHandler:)` 
-  - `generic function` , `Result<Success, Failure>`
-  - `UICollectionView`, `multipart/form-data`
-  - `UIImagePickerController`
+  - `@escaping` `URLSessionDataTask`, `generic function`
+  - `Result<Success, Failure>`, `UICollectionView`
+  - `multipart/form-data`, `UIImagePickerController`
+  - `NotificationCenter`, `NSCache`, `FileManager`
 
 ## 💻 개발환경 및 라이브러리
 [![swift](https://img.shields.io/badge/swift-5.6-orange)]()
@@ -113,6 +113,15 @@
     - 상품등록화면 UI 구현
     - UIImagePickerController로 앨범에서 이미지 가져올수있도록 구현
     - 이미지 및 데이터 입력확인 후 정상적인 POST할수있게 구현
+- **22/12/03**
+    - multipart/form-data타입의 body가 받는 파라미터들을 따로 모델타입으로 구현
+- **22/12/04**
+    - 이미지용량이 최대 300kb가 넘지 않도록 구현 및 POST완료핸들러 구현
+- **22/12/05**
+    - 상품등록화면의 데이터를 입력할때 나타나는 키보드를 고려해서 뷰가 키보드에 가리지 않도록 구현 
+- **22/12/06**
+    - 기존 콜렉션뷰 로딩 indicator를 각각 셀의 이미지로딩 indicator로 변경 및 구현
+    - MemoryCache와 DiskCache 영역 둘 다 사용하도록 수정 및 구현
     
 </details>
 
@@ -121,9 +130,7 @@
 |:--:|:--:|
 |![Simulator Screen Recording - iPhone 11 - 2022-11-25 at 00 57 15](https://user-images.githubusercontent.com/49121469/203825802-c1a9679c-89b2-4506-917c-05cb88236e39.gif)|![Simulator Screen Recording - iPhone 11 - 2022-11-25 at 00 31 56](https://user-images.githubusercontent.com/49121469/203821039-8767d88d-eedb-492c-ab84-47fb8d534190.gif)|
 |**상품등록**|
-|![Simulator Screen Recording - iphone 11 - 2022-12-02 at 14 55 24](https://user-images.githubusercontent.com/96489602/205230054-5928bfb5-758c-4577-a9a2-e620b7365276.gif)||
-
-
+|![](https://i.imgur.com/TkWW9Yt.gif)||
 ## 👀 고민한 점
 
 ### Step 1
@@ -138,23 +145,35 @@
 ### Step 2
 
 - Modern CollectionView를 활용하여 두가지 레이아웃 활용
-    - segmentedControl에 따라 콜렉션뷰를 테이블뷰랑 같은 listLayout 형식, 그리고 gridLayout 형식으로 셀을 꾸며주어야했습니다.  
-    처음에 콜렉션뷰를 List전용으로 하나 Grid 전용으로 하나 2개를 만들어줘야하나 고민했었습니다. 그런데 좀 더 고민해보니 데이터만 공유하고 셀만 다르게 해줄수 있을거란 생각이 들었습니다.  
-    데이터를 담당하는 하나의 UICollectionViewCell class를 만들어놓고 List와 Grid 전용 custom셀을 생성해서 class를 적용했습니다. 
-    compositionalLayout을 이용해서 segmentedControl의 index값에 따라 List와 Grid셀을 로드하게 구현할수 있었습니다.
+    - segmentedControl에 따라 콜렉션뷰를 테이블뷰랑 같은 listLayout 형식, 그리고 gridLayout 형식으로 셀을 꾸며주어야했습니다.
+    - 처음에 콜렉션뷰를 List전용으로 하나 Grid 전용으로 하나 2개를 만들어줘야하나 고민했었습니다. 
+    - 그런데 좀 더 고민해보니 데이터만 공유하고 셀만 다르게 해줄수 있을거란 생각이 들었습니다. 
+    - 데이터를 담당하는 하나의 UICollectionViewCell class를 만들어놓고 List와 Grid 전용 custom셀을 생성해서 class를 적용했습니다. 
+    - compositionalLayout을 이용해서 segmentedControl의 index값에 따라 List와 Grid셀을 로드하게 구현할수 있었습니다.
 
 ### Step 3
 
 - POST 후, 셀을 업데이트 시켜주는 방법에 대한 고민
-    - ResisterProductVC에서 사용자가 입력한 데이터를 POST 후, ViewController의 Cell에서 어떤 방법으로 등록된 상품이 표시되도록 업데이트 해줄 것인지 고민하였습니다.  
-    고민해보니 ResisterProductVC에서 dismiss 메서드를 통해 ViewController로 돌아오면 viewWillAppear(:) 메서드가 실행되었고 해당 메서드가 호출 될 시점에 상품 리스트 데이터를 GET해오는 것으로 셀을 업데이트 해줄 수 있었습니다.
+    - ResisterProductViewController에서 사용자가 입력한 데이터를 POST 후, ViewController의 Cell에서 어떤 방법으로 등록된 상품이 표시되도록 업데이트 해줄 것인지 고민하였습니다. 
+    - 고민해보니 ResisterProductViewController에서 dismiss 메서드를 통해 ViewController로 돌아오면 viewWillAppear(:) 메서드가 실행되었고 해당 메서드가 호출 될 시점에 상품 리스트 데이터를 GET해오는 것으로 셀을 업데이트 해줄 수 있었습니다.
 
-- API 문서를 해석하여 명시된 요구사항 어떤 방법으로 준수하면 되는지에 대한 고민
-    1. 문서를 읽으며, Content-Type, Mime-Type, multipart/formdata, Request, Response, httpMethod, header, body, required 등 생소한 요구사항이 많았습니다.
-    2. MDN 및 공식문서, 기타 블로그 등을 참고하여 해당 용어의 의미를 찾아보려고 노력습니다.
-    3. 해당 용어에 대해 이해한 후에는 PostMan 프로그램을 활용하여 요구사항에 충족하도록 Key와 Value를 여러번 바꿔가면 시도해보았습니다. 결국, response의 statusCode가 200-299 얻을 수 있었습니다.
-    4. 이를 swift 환경에서 어떻게 구현하면 좋을지 생각해보았고, davBeck의 github 오픈소스 - MultipartForm을 참조하여 사전에 해당 오픈소스 내부 코드를 분석해 보았습니다.
-    5. 결과로 swift 환경에서 POST와 PATCH를 통해 네트워크에서 데이터를 불러오고 등록 할 수 있게 하였습니다.
+- API 문서를 해석하며 swift에 어떻게 구현할지에 대한 고민
+    1. 문서를 읽으며, Content-Type, Mime-Type, multipart/formdata, application/json, application/x-www-form-urlencoded, httpMethod 등 생소한 단어들이 많았습니다.
+    2. MDN 및 공식문서, 기타 블로그 등을 참고하여 해당 용어의 의미를 찾아보려고 노력했습니다.
+    3. 해당 용어에 대해 이해한 후에는 PostMan을 이용하여 데이터를 어떻게 주고 받는지 테스트를 시도해보았습니다.
+    4. API 통신으로 데이터를 어떻게 주고 받는지 이해한 후 오픈소스나 강의영상, 등 갖가지 매체를 통해 swift 환경에서 어떻게 적용하고 구현해야할지 찾아보았습니다.
+
+- 키보드가 올라올때, 화면을 보여주는 방식에 대한 고민
+    1. 사용자가 데이터를 입력하려고 할때 키보드가 올라오게되는데 키보드 위의 화면은 어디로 어떻게 사용자에게 보여줄지 고민했습니다.
+    2. textField부분은 4가지가 모여있고 textView는 하나만 구성되어 있기 때문에 textField를 터치했을경우랑 textView를 터치했을경우 두가지로 구분했습니다.
+    3. textField를 터치했을 경우 입력할 정보가 많기 때문에 입력란에 신경을 쓸 수 있도록 y축을 이동시켰습니다.
+    4. textView를 터치했을 경우 키보드가 정보를 가리지 않게 y축을 이동했습니다.
+
+|초기화면|텍스트필드 입력|텍스트뷰 입력|
+|:--:|:--:|:--:|
+![](https://i.imgur.com/qNtIytz.png)|![](https://i.imgur.com/3k4DaAV.png)|![](https://i.imgur.com/GPKSbfA.png)|
+    
+</details>
 
 ## ❓ 트러블 슈팅
 
@@ -176,10 +195,11 @@ json파일에 매칭해야할 자료형이 많을수록 오타가 나올 확률�
 <summary>Metatype & Generic함수를 활용하여 중복되는 코드 해결 </summary>
 
 통신해야할 네트워킹요소가 3가지(`GET:Application HealthChekcer`, `GET:상품리스트조회` ,`GET상품 상세 조회`)이며, 디코딩해야하는 요소는 2가지 였습니다.  
-따라서, 통신요소에 따라서 너무 많은 중복코드가 발생했고 이를 보완하려고 고민했습니다.  
+따라서, 통신요소에 따라서 너무 많은 중복코드가 발생했고 이를 보완하려고 고민했습니다. 
 하지만, JSONDecoder의 .decode 메서드는 `Decodable` 프로토콜을 준수하는 `타입자체`를 파라미터값으로 전달해주어야만 했습니다.  
 우리는 `타입자체`를 어떻게 함수의 `Placeholder`로 활용할 지 고민하였습니다.  
-결과적으로 제네릭과 메타타입을 공부하여 타입자체(메타타입)을 파라미터값과 Placehorder로 전달하여 이를 해결했습니다.  
+결과적으로 제네릭과 메타타입을 공부하여 타입자체(메타타입)을 파라미터값과 Placehorder로 전달하여 이를 해결했습니다. 
+
 ```swift
 JSONDecoder().decode(type: Decodable을 준수하는 타입, from: data)
 ```
@@ -192,21 +212,17 @@ JSONDecoder().decode(type: Decodable을 준수하는 타입, from: data)
     
 처음에 NSCache를 이용해서 각 셀의 이미지를 구현을했었습니다.  
 그런데 앱을 종료했다 키면 저장된 캐쉬데이터들이 사라져서 실행할때마다 모든 이미지들이 다 보이기까지 시간이 걸려서 비록 긴시간은 아니지만 조금이라도 기다려야하는 불편한 상황을 경험해야했습니다.  
-NSCache는 Memory Cache영역에 저장되기때문에 발생하게 된 문제인데 이를 해결하기 위해 FileManager로 Disk Cache영역에 저장하는 방식으로 바꾸었습니다.  
-Disk Cache 영역은 앱을 종료했다 켜도 지워지지않는 영역이기때문에 처음 의도한대로 구현할수있었습니다.  
+NSCache는 Memory Cache영역에 저장되기때문에 발생하게 된 문제인데 이를 해결하기 위해 FileManager로 Disk Cache영역에 저장하는 방식으로 바꾸었습니다. Disk Cache 영역은 앱을 종료했다 켜도 지워지지않는 영역이기때문에 처음 의도한대로 구현할수있었습니다. 
     
 </details>
 
 <details>
 <summary>네트워크 통신으로서 Data(contentsOf:)의 한계점 </summary>
     
-- 네트워크 통신으로 이미지를 가져올 때, 처음에 Data(contentsOf:)를 활용하였고 화면이 스크롤되는 속도와 성능이 매우 저하되었습니다.  
-    - 알고보니 이 메서드는 동기적으로 동작하는 메서드였고, 스크롤을 하게되면 현재 작업중인 모든 작업을 해당 작업을 수행하는 동안 멈추게 되고 심할 경우 앱이 종료될 수 있는 위험성이 잠재되어 있는 코드였습니다.  
-    따라서, 비동기로 동작하는 URLSession을 활용하도록 수정해주었고 결과적으로 속도와 성능이 다시 정상적으로 돌아오게 되었습니다.  
-    - 아래는 공식문서에서 권장하는 Data(contentsOf:) 메서드의 적합한 활용방법입니다.  
-    - 이 동기식 이니셜라이저를 사용하여 네트워크 기반 URL을 요청하지 마십시오.  
-    네트워크 기반 URL의 경우, 이 방법은 느린 네트워크에서 수십 초 동안 현재 스레드를 차단하여 사용자 환경이 좋지 않을 수 있으며, iOS에서는 앱이 종료될 수 있습니다.  
-    대신 파일이 아닌 URL의 경우 URL 세션 클래스의 dataTask(with:completionHandler:) 메서드를 사용해 보십시오. 예는 웹 사이트 데이터를 메모리로 가져오는 것을 참조하십시오.  
+- 네트워크 통신으로 이미지를 가져올 때, 처음에 Data(contentsOf:)를 활용하였고 화면이 스크롤되는 속도와 성능이 매우 저하되었습니다.
+- 알고보니 이 메서드는 동기적으로 동작하는 메서드였고, 스크롤을 하게되면 현재 작업중인 모든 작업을 해당 작업을 수행하는 동안 멈추게 되고 심할 경우 앱이 종료될 수 있는 위험성이 잠재되어 있는 코드였습니다.  
+따라서, 비동기로 동작하는 URLSession을 활용하도록 수정해주었고 결과적으로 속도와 성능이 다시 정상적으로 돌아오게 되었습니다.
+- 아래는 공식문서에서 권장하는 Data(contentsOf:) 메서드의 적합한 활용방법입니다.
 
 ![](https://i.imgur.com/b40E8mW.png)
 </details>
@@ -221,6 +237,34 @@ HTTP Request 구조에서 Content-Type중 multipart/form-data의 구조를 처�
 구조를 완전히 이해하는데 2-3일이 걸려 프로젝트에 착수하는데 시간이 많이 부족했었습니다.  
 HTTP Request 구조를 처음 접해보았고 multipart/form-data란 친구를 만났을때 사용 예시를 보고 당황했습니다.  
 이걸 내가 이해할수있을까 걱정되었지만 이해하려고 노력하고 공부하다보면 언젠간 결국 해내게 되는구나라는 깨달음을 얻게 되었습니다.  
+
+</details>
+
+<details>
+<summary>셀의 재사용과 이미지 관련 문제 해결</summary>
+
+- 컬렉션뷰의 셀이 예를 들어서 100개가 있다고 가정했을때, 앱을 처음 실행했을때 셀의 이미지 로딩이 덜 된 상태에서 밑으로 스크롤을 내리다가 15번셀에 15라는 이미지가 들어와야하는데 5,10이라는 엉뚱한 이미지가 들어왔다가 정상적인 이미지로 변경되는 기이한 현상을 목격했습니다.
+- 왜 이런일이 발생하게 된건지 알아본 결과, 각각의 셀마다 이미지를 비동기로 요청하는데 밑으로 스크롤을 내려서 재사용되는 셀로 전환하게 된다면 비동기요청이 완료되는 시점에 이미지를 보여줄때 재사용된 셀로 이미지를 보여주게되어서 이런 현상이 일어나게 된 것이라 생각했습니다.
+- 왜 이런 일이 발생하게 되었는지에 대한 답을 알아냈으니 어떻게 고치야 하는지 고민했습니다.  
+    생각보다 고치는 방법은 간단했습니다.
+- URLSessionDataTask 인스턴스를 resume() 해서 실행하듯이, 셀이 재사용될때 cancel()해서 비동기작업을 멈추게 하는 식으로 구현해주었다.
+
+</details>
+
+<details>
+<summary>이미지를 캐싱하는 여러 방법</summary>
+
+1. 기존에는 메모리캐시와 디스크캐시영역 중 어느걸 사용할지 고민해서 디스크캐시영역을 선택하여 구현했습니다.
+2. 이후에 메모리캐시와 디스크캐시 둘 다 동시에 구현할 수 있다고 듣게 되어서 왜 처음에 둘 다 구현할 생각을 하지 못했을까 하는 깨우침을 얻었습니다. 
+3. 어떻게 구현하면 좋을지 고민 해 본 결과, 앱을 실행 할 때 이와같은 순서로 작동할 수 있게 구성했습니다.
+    (1) 메모리캐쉬에 데이터를 가져온다 없다면 2번으로 이동
+    (2) 디스크캐쉬에 데이터를 가져온다 없다면 3번으로 이동, 있다면 추가로 메모리캐쉬에 저장
+    (3) 디스크캐쉬에 해당하는 데이터가 없다면 API통신으로 데이터를 받아온다. 그리고 디스크캐쉬와 메모리캐쉬에 저장
+    
+|앱 처음 실행했을때|앱 다시 실행했을때|
+|:--:|:--:|
+|![networkandmemory](https://user-images.githubusercontent.com/96489602/205856689-dbb21584-19d7-4cae-9e57-8ed76d160127.gif)|![diskandMemory](https://user-images.githubusercontent.com/96489602/205856739-4f8c44cf-fe36-4112-b871-8aa32f94628f.gif)|
+    
 </details>
 
 ## 🔗 참고 링크

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - `URLSession`, `Codable`, `JsonDecoder`, `GCD`
   - `@escaping` `URLSessionDataTask`, `generic function`
   - `Result<Success, Failure>`, `UICollectionView`
+  - `UICollectionViewCompositionalLayout`, `UICollectionViewFlowLayout`
   - `multipart/form-data`, `UIImagePickerController`
   - `NotificationCenter`, `NSCache`, `FileManager`
 
@@ -36,8 +37,9 @@
 ├── OpenMarket
 │   ├── AppDelegate.swift
 │   ├── Controller
-│   │   ├── RegisterProductViewController.swift
-│   │   └── ViewController.swift
+│   │   ├── ProductDetailViewController.swift
+│   │   ├── ProductListViewController.swift
+│   │   └── ProductPostAndPatchViewController.swift
 │   ├── Info.plist
 │   ├── Model
 │   │   ├── APIError.swift.swift
@@ -52,11 +54,16 @@
 │   │   │       ├── Contents.json
 │   │   │       └── step1_testdata.json
 │   │   ├── CustomCollectionViewCell.swift
+│   │   ├── CustomCollectionViewPageCell.swift
 │   │   ├── Data+Extensions.swift
 │   │   ├── DetailProduct.swift
+│   │   ├── ImageCacheManager.swift
+│   │   ├── Mode.swift.swift
 │   │   ├── NetworkCommunication.swift
+│   │   ├── PatchRequestParams.swift
 │   │   ├── PostRequestParams.swift
 │   │   ├── SearchListProducts.swift
+│   │   ├── Secret.swift
 │   │   └── TestJsonProducts.swift
 │   ├── SceneDelegate.swift
 │   └── View
@@ -64,7 +71,8 @@
 │       │   ├── LaunchScreen.storyboard
 │       │   └── Main.storyboard
 │       ├── CustomCollectionViewGridCell.xib
-│       └── CustomCollectionViewListCell.xib
+│       ├── CustomCollectionViewListCell.xib
+│       └── CustomCollectionViewPageCell.xib
 ```
  
 ## ⏰ 타임라인
@@ -125,9 +133,33 @@
     
 </details>
 
+<details>
+<summary>Step 4 타임라인</summary>
+    
+- **22/12/09**
+    - 상품상세화면 UI 구현
+    - CustomCollectionViewPageCell 구현 및 flowlayout 적용
+    - 상품수정화면 UI 구현
+    - API서버의 데이터를 PATCH 할수있도록 구현 
+    - 패스워드 입력 가능한 알람 구현
+    - 고유삭제주소를 가져오기위한 POST 구현
+    - API서버의 데이터를 DELETE 할수있도록 구현
+
+- **22/12/10**
+    - 상품상세화면 및 수정화면에 메모리캐시 적용
+    - 갖가지 버그와 오토레이아웃 수정 및 컨벤션 정리
+    
+</details>
+
 ## 📱 실행 화면
 
-step4 구현 후 추가예정입니다.
+|List&GridCell|상품등록|
+|:--:|:--:|
+|![Simulator Screen Recording - iphone 11 - 2022-12-10 at 18 04 46](https://user-images.githubusercontent.com/96489602/206843215-e72b9dbd-7aa7-48f4-8749-4a9aa7a1dea5.gif)[](https://i.imgur.com/A1SFfVz.gif)|![Simulator Screen Recording - iphone 11 - 2022-12-10 at 18 17 06](https://user-images.githubusercontent.com/96489602/206843233-99c9bc22-78a9-41c7-b7f5-9b453135806e.gif)|
+|**상품수정**|**상품삭제**|
+|![Simulator Screen Recording - iphone 11 - 2022-12-10 at 18 20 25](https://user-images.githubusercontent.com/96489602/206843241-f26236dc-64ea-4227-9885-762e11d36ac6.gif)|![Simulator Screen Recording - iphone 11 - 2022-12-10 at 18 31 29](https://user-images.githubusercontent.com/96489602/206843681-e97a137b-fa7b-47db-9c4c-551a987d2434.gif)|
+
+
 
 ## 👀 고민한 점
 
@@ -156,22 +188,28 @@ step4 구현 후 추가예정입니다.
     - 고민해보니 ResisterProductViewController에서 dismiss 메서드를 통해 ViewController로 돌아오면 viewWillAppear(:) 메서드가 실행되었고 해당 메서드가 호출 될 시점에 상품 리스트 데이터를 GET해오는 것으로 셀을 업데이트 해줄 수 있었습니다.
 
 - API 문서를 해석하며 swift에 어떻게 구현할지에 대한 고민
-    1. 문서를 읽으며, Content-Type, Mime-Type, multipart/formdata, application/json, application/x-www-form-urlencoded, httpMethod 등 생소한 단어들이 많았습니다.
-    2. MDN 및 공식문서, 기타 블로그 등을 참고하여 해당 용어의 의미를 찾아보려고 노력했습니다.
-    3. 해당 용어에 대해 이해한 후에는 PostMan을 이용하여 데이터를 어떻게 주고 받는지 테스트를 시도해보았습니다.
-    4. API 통신으로 데이터를 어떻게 주고 받는지 이해한 후 오픈소스나 강의영상, 등 갖가지 매체를 통해 swift 환경에서 어떻게 적용하고 구현해야할지 찾아보았습니다.
+    - 문서를 읽으며, Content-Type, Mime-Type, multipart/formdata, application/json, application/x-www-form-urlencoded, httpMethod 등 생소한 단어들이 많았습니다.
+    - MDN 및 공식문서, 기타 블로그 등을 참고하여 해당 용어의 의미를 찾아보려고 노력했습니다.
+    - 해당 용어에 대해 이해한 후에는 PostMan을 이용하여 데이터를 어떻게 주고 받는지 테스트를 시도해보았습니다.
+    - API 통신으로 데이터를 어떻게 주고 받는지 이해한 후 오픈소스나 강의영상, 등 갖가지 매체를 통해 swift 환경에서 어떻게 적용하고 구현해야할지 찾아보았습니다.
 
 - 키보드가 올라올때, 화면을 보여주는 방식에 대한 고민
-    1. 사용자가 데이터를 입력하려고 할때 키보드가 올라오게되는데 키보드 위의 화면은 어디로 어떻게 사용자에게 보여줄지 고민했습니다.
-    2. textField부분은 4가지가 모여있고 textView는 하나만 구성되어 있기 때문에 textField를 터치했을경우랑 textView를 터치했을경우 두가지로 구분했습니다.
-    3. textField를 터치했을 경우 입력할 정보가 많기 때문에 입력란에 신경을 쓸 수 있도록 y축을 이동시켰습니다.
-    4. textView를 터치했을 경우 키보드가 정보를 가리지 않게 y축을 이동했습니다.
+    - 사용자가 데이터를 입력하려고 할때 키보드가 올라오게되는데 키보드 위의 화면은 어디로 어떻게 사용자에게 보여줄지 고민했습니다.
+    - textField부분은 4가지가 모여있고 textView는 하나만 구성되어 있기 때문에 textField를 터치했을경우랑 textView를 터치했을경우 두가지로 구분했습니다.
+    - textField를 터치했을 경우 입력할 정보가 많기 때문에 입력란에 신경을 쓸 수 있도록 y축을 이동시켰습니다.
+    - textView를 터치했을 경우 키보드가 정보를 가리지 않게 y축을 이동했습니다.
 
 |초기화면|텍스트필드 입력|텍스트뷰 입력|
 |:--:|:--:|:--:|
 ![](https://i.imgur.com/qNtIytz.png)|![](https://i.imgur.com/3k4DaAV.png)|![](https://i.imgur.com/GPKSbfA.png)|
     
-</details>
+### Step 4
+
+- 상세화면에 이미지나 데이터들을 전달하는 방법에 대한 고민
+    - 메인화면에서 셀을 클릭하여 상제화면으로 이동할 때 어떤식으로 이미지와 데이터들을 전달해야 할지 고민해보았습니다.
+    - 처음에 프로퍼티로 값을 전달하면 쉽게 구현할 수 있겠다고 생각했습니다.
+    - 그런데 상세화면에서 수정화면으로 갔다가 값을 수정하고 다시 상세화면으로 돌아왔을 때, 수정된 값으로 갱신되지 않을거라는 생각을 하게 되었습니다.
+    - 그래서 productID만 전달하여 그 ID값으로 API통신으로 값을 받아 올 수 있게 설계하였습니다.
 
 ## ❓ 트러블 슈팅
 
@@ -180,23 +218,23 @@ step4 구현 후 추가예정입니다.
 <details>
     <summary>parsing 모델 타입 구현</summary>
 
-Asset에 저장된 json파일을 파싱하는 타입과 API서버와 통신하여 가져오는 json을 파싱하는 타입을 구현할때 오타가 있었습니다.  
-단위 테스트를 통해 오타가 있었다는것을 뒤늦게 확인할수있었습니다.  
-json파일에 매칭해야할 자료형이 많을수록 오타가 나올 확률이 높을것이란 생각이 들었습니다.  
-[json을 swift모델로 바꿔주는사이트](https://app.quicktype.io/)  
+- Asset에 저장된 json파일을 파싱하는 타입과 API서버와 통신하여 가져오는 json을 파싱하는 타입을 구현할때 오타가 있었습니다.  
+- 단위 테스트를 통해 오타가 있었다는것을 뒤늦게 확인할수있었습니다.  
+- json파일에 매칭해야할 자료형이 많을수록 오타가 나올 확률이 높을것이란 생각이 들었습니다.  
+- [json을 swift모델로 바꿔주는사이트](https://app.quicktype.io/)  
 이 사이트를 이용해서 json파일을 swift 모델로 바꾸어서 사용했습니다.  
-시간도 절약하고 오타를 유발할일이 없기때문에 유용하게 이용했습니다.  
+- 시간도 절약하고 오타를 유발할일이 없기때문에 유용하게 이용했습니다.  
     
 </details>
 
 <details>
 <summary>Metatype & Generic함수를 활용하여 중복되는 코드 해결 </summary>
 
-통신해야할 네트워킹요소가 3가지(`GET:Application HealthChekcer`, `GET:상품리스트조회` ,`GET상품 상세 조회`)이며, 디코딩해야하는 요소는 2가지 였습니다.  
-따라서, 통신요소에 따라서 너무 많은 중복코드가 발생했고 이를 보완하려고 고민했습니다. 
-하지만, JSONDecoder의 .decode 메서드는 `Decodable` 프로토콜을 준수하는 `타입자체`를 파라미터값으로 전달해주어야만 했습니다.  
-우리는 `타입자체`를 어떻게 함수의 `Placeholder`로 활용할 지 고민하였습니다.  
-결과적으로 제네릭과 메타타입을 공부하여 타입자체(메타타입)을 파라미터값과 Placehorder로 전달하여 이를 해결했습니다. 
+- 통신해야할 네트워킹요소가 3가지(`GET:Application HealthChekcer`, `GET:상품리스트조회` ,`GET상품 상세 조회`)이며, 디코딩해야하는 요소는 2가지 였습니다.  
+- 따라서, 통신요소에 따라서 너무 많은 중복코드가 발생했고 이를 보완하려고 고민했습니다. 
+- 하지만, JSONDecoder의 .decode 메서드는 `Decodable` 프로토콜을 준수하는 `타입자체`를 파라미터값으로 전달해주어야만 했습니다.  
+- 우리는 `타입자체`를 어떻게 함수의 `Placeholder`로 활용할 지 고민하였습니다. 
+- 결과적으로 제네릭과 메타타입을 공부하여 타입자체(메타타입)을 파라미터값과 Placehorder로 전달하여 이를 해결했습니다. 
 
 ```swift
 JSONDecoder().decode(type: Decodable을 준수하는 타입, from: data)
@@ -208,9 +246,9 @@ JSONDecoder().decode(type: Decodable을 준수하는 타입, from: data)
 <details>
 <summary>NSCache의 한계</summary>
     
-처음에 NSCache를 이용해서 각 셀의 이미지를 구현을했었습니다.  
-그런데 앱을 종료했다 키면 저장된 캐쉬데이터들이 사라져서 실행할때마다 모든 이미지들이 다 보이기까지 시간이 걸려서 비록 긴시간은 아니지만 조금이라도 기다려야하는 불편한 상황을 경험해야했습니다.  
-NSCache는 Memory Cache영역에 저장되기때문에 발생하게 된 문제인데 이를 해결하기 위해 FileManager로 Disk Cache영역에 저장하는 방식으로 바꾸었습니다. Disk Cache 영역은 앱을 종료했다 켜도 지워지지않는 영역이기때문에 처음 의도한대로 구현할수있었습니다. 
+- 처음에 NSCache를 이용해서 각 셀의 이미지를 구현을했었습니다.  
+- 그런데 앱을 종료했다 키면 저장된 캐쉬데이터들이 사라져서 실행할때마다 모든 이미지들이 다 보이기까지 시간이 걸려서 비록 긴시간은 아니지만 조금이라도 기다려야하는 불편한 상황을 경험해야했습니다.  
+- NSCache는 Memory Cache영역에 저장되기때문에 발생하게 된 문제인데 이를 해결하기 위해 FileManager로 Disk Cache영역에 저장하는 방식으로 바꾸었습니다. - Disk Cache 영역은 앱을 종료했다 켜도 지워지지않는 영역이기때문에 처음 의도한대로 구현할수있었습니다. 
     
 </details>
 
@@ -230,11 +268,11 @@ NSCache는 Memory Cache영역에 저장되기때문에 발생하게 된 문제�
 <details>
 <summary>multipart/form-data 구조 파악</summary>
     
-HTTP Request 구조에서 Content-Type중 multipart/form-data의 구조를 처음에 파악하기가 어려웠습니다.  
-가장 기본적이고 많이 쓰이는 application/x-www-form-urlencoded, application/json Content-Type과 무엇이 다른지 하나씩 비교해보면서 학습했습니다.  
-구조를 완전히 이해하는데 2-3일이 걸려 프로젝트에 착수하는데 시간이 많이 부족했었습니다.  
-HTTP Request 구조를 처음 접해보았고 multipart/form-data란 친구를 만났을때 사용 예시를 보고 당황했습니다.  
-이걸 내가 이해할수있을까 걱정되었지만 이해하려고 노력하고 공부하다보면 언젠간 결국 해내게 되는구나라는 깨달음을 얻게 되었습니다.  
+- HTTP Request 구조에서 Content-Type중 multipart/form-data의 구조를 처음에 파악하기가 어려웠습니다.  
+- 가장 기본적이고 많이 쓰이는 application/x-www-form-urlencoded, application/json Content-Type과 무엇이 다른지 하나씩 비교해보면서 학습했습니다.  
+- 구조를 완전히 이해하는데 2-3일이 걸려 프로젝트에 착수하는데 시간이 많이 부족했었습니다.  
+- HTTP Request 구조를 처음 접해보았고 multipart/form-data란 친구를 만났을때 사용 예시를 보고 당황했습니다.  
+- 이걸 내가 이해할수있을까 걱정되었지만 이해하려고 노력하고 공부하다보면 언젠간 결국 해내게 되는구나라는 깨달음을 얻게 되었습니다.  
 
 </details>
 
@@ -252,9 +290,9 @@ HTTP Request 구조를 처음 접해보았고 multipart/form-data란 친구를 �
 <details>
 <summary>이미지를 캐싱하는 여러 방법</summary>
 
-1. 기존에는 메모리캐시와 디스크캐시영역 중 어느걸 사용할지 고민해서 디스크캐시영역을 선택하여 구현했습니다.
-2. 이후에 메모리캐시와 디스크캐시 둘 다 동시에 구현할 수 있다고 듣게 되어서 왜 처음에 둘 다 구현할 생각을 하지 못했을까 하는 깨우침을 얻었습니다. 
-3. 어떻게 구현하면 좋을지 고민 해 본 결과, 앱을 실행 할 때 이와같은 순서로 작동할 수 있게 구성했습니다.
+- 기존에는 메모리캐시와 디스크캐시영역 중 어느걸 사용할지 고민해서 디스크캐시영역을 선택하여 구현했습니다.
+- 이후에 메모리캐시와 디스크캐시 둘 다 동시에 구현할 수 있다고 듣게 되어서 왜 처음에 둘 다 구현할 생각을 하지 못했을까 하는 깨우침을 얻었습니다. 
+- 어떻게 구현하면 좋을지 고민 해 본 결과, 앱을 실행 할 때 이와같은 순서로 작동할 수 있게 구성했습니다.
     (1) 메모리캐쉬에 데이터를 가져온다 없다면 2번으로 이동
     (2) 디스크캐쉬에 데이터를 가져온다 없다면 3번으로 이동, 있다면 추가로 메모리캐쉬에 저장
     (3) 디스크캐쉬에 해당하는 데이터가 없다면 API통신으로 데이터를 받아온다. 그리고 디스크캐쉬와 메모리캐쉬에 저장
@@ -264,6 +302,18 @@ HTTP Request 구조를 처음 접해보았고 multipart/form-data란 친구를 �
 |![networkandmemory](https://user-images.githubusercontent.com/96489602/205856689-dbb21584-19d7-4cae-9e57-8ed76d160127.gif)|![diskandMemory](https://user-images.githubusercontent.com/96489602/205856739-4f8c44cf-fe36-4112-b871-8aa32f94628f.gif)|
     
 </details>
+
+### STEP4
+
+<details>
+<summary>이미지가 엉뚱한이미지로 바뀌는 문제 해결</summary>
+
+- 앱을 처음 실행시킬 때, 정상적인 이미지가 보여야 할 셀에 다른 엉뚱한 이미지가 들어오는것을 확인했습니다.
+- 이 현상이 발생하게 된 이유는 각각의 셀마다 비동기로 이미지를 받아오도록 처리했는데 이미지를 받아오기도 전에 셀이 재사용이되어서 재사용된 셀 위치에 비동기 처리를 끝내고 받아온 이미지를 보여주어서 엉뚱한 이미지가 들어오게 된 것이었습니다. 
+- 그래서 이미지를 비동기로 받아오는 URLSessionDataTask를 셀이  prepareReuse() 메서드에서 재사용될때 캔슬을 하여 해결했습니다.
+
+</details>
+
 
 ## 🔗 참고 링크
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@
 ## 🌱 소개
 
 `Mangdi`와 `woong`이 만든 오픈마켓 앱입니다.
-- API서버와 통신해서 데이터를 주고받습니다.
+- API서버와 통신해서 데이터를 조회,생성,수정,삭제 작업을 진행했습니다.
 - **KeyWords**
-  - `URL Session`, `Codable`, `JsonDecoder`, `GCD`
+  - `URLSession`, `Codable`, `JsonDecoder`, `GCD`
   - `@escaping` `dataTask(with:completionHandler:)` 
   - `generic function` , `Result<Success, Failure>`
-  - `UICollectionView(step2추가작성)`
+  - `UICollectionView`, `multipart/form-data`
+  - `UIImagePickerController`
 
 ## 💻 개발환경 및 라이브러리
 [![swift](https://img.shields.io/badge/swift-5.6-orange)]()
@@ -35,6 +36,7 @@
 ├── OpenMarket
 │   ├── AppDelegate.swift
 │   ├── Controller
+│   │   ├── RegisterProductViewController.swift
 │   │   └── ViewController.swift
 │   ├── Info.plist
 │   ├── Model
@@ -50,8 +52,10 @@
 │   │   │       ├── Contents.json
 │   │   │       └── step1_testdata.json
 │   │   ├── CustomCollectionViewCell.swift
+│   │   ├── Data+Extensions.swift
 │   │   ├── DetailProduct.swift
 │   │   ├── NetworkCommunication.swift
+│   │   ├── PostRequestParams.swift
 │   │   ├── SearchListProducts.swift
 │   │   └── TestJsonProducts.swift
 │   ├── SceneDelegate.swift
@@ -99,11 +103,27 @@
     
 </details>
 
+<details>
+<summary>Step 3 타임라인</summary>
+    
+- **22/12/01**
+    - POST를 보내기위한 multipart/form-data의 구조 파악
+    - POST 메서드 구현
+- **22/12/02**
+    - 상품등록화면 UI 구현
+    - UIImagePickerController로 앨범에서 이미지 가져올수있도록 구현
+    - 이미지 및 데이터 입력확인 후 정상적인 POST할수있게 구현
+    
+</details>
+
 ## 📱 실행 화면
 |처음설치|종료후다시실행|
 |:--:|:--:|
 |![Simulator Screen Recording - iPhone 11 - 2022-11-25 at 00 57 15](https://user-images.githubusercontent.com/49121469/203825802-c1a9679c-89b2-4506-917c-05cb88236e39.gif)|![Simulator Screen Recording - iPhone 11 - 2022-11-25 at 00 31 56](https://user-images.githubusercontent.com/49121469/203821039-8767d88d-eedb-492c-ab84-47fb8d534190.gif)|
- 
+|**상품등록**|
+|![Simulator Screen Recording - iphone 11 - 2022-12-02 at 14 55 24](https://user-images.githubusercontent.com/96489602/205230054-5928bfb5-758c-4577-a9a2-e620b7365276.gif)||
+
+
 ## 👀 고민한 점
 
 ### Step 1
@@ -118,7 +138,23 @@
 ### Step 2
 
 - Modern CollectionView를 활용하여 두가지 레이아웃 활용
-    - segmentedControl에 따라 콜렉션뷰를 테이블뷰랑 같은 listLayout 형식, 그리고 gridLayout 형식으로 셀을 꾸며주어야했습니다. 처음에 콜렉션뷰를 List전용으로 하나 Grid 전용으로 하나 2개를 만들어줘야하나 고민했었습니다. 그런데 좀 더 고민해보니 데이터만 공유하고 셀만 다르게 해줄수 있을거란 생각이 들었습니다. 데이터를 담당하는 하나의 UICollectionViewCell class를 만들어놓고 List와 Grid 전용 custom셀을 생성해서 class를 적용했습니다. compositionalLayout을 이용해서 segmentedControl의 index값에 따라 List와 Grid셀을 로드하게 구현할수 있었습니다.
+    - segmentedControl에 따라 콜렉션뷰를 테이블뷰랑 같은 listLayout 형식, 그리고 gridLayout 형식으로 셀을 꾸며주어야했습니다.  
+    처음에 콜렉션뷰를 List전용으로 하나 Grid 전용으로 하나 2개를 만들어줘야하나 고민했었습니다. 그런데 좀 더 고민해보니 데이터만 공유하고 셀만 다르게 해줄수 있을거란 생각이 들었습니다.  
+    데이터를 담당하는 하나의 UICollectionViewCell class를 만들어놓고 List와 Grid 전용 custom셀을 생성해서 class를 적용했습니다. 
+    compositionalLayout을 이용해서 segmentedControl의 index값에 따라 List와 Grid셀을 로드하게 구현할수 있었습니다.
+
+### Step 3
+
+- POST 후, 셀을 업데이트 시켜주는 방법에 대한 고민
+    - ResisterProductVC에서 사용자가 입력한 데이터를 POST 후, ViewController의 Cell에서 어떤 방법으로 등록된 상품이 표시되도록 업데이트 해줄 것인지 고민하였습니다.  
+    고민해보니 ResisterProductVC에서 dismiss 메서드를 통해 ViewController로 돌아오면 viewWillAppear(:) 메서드가 실행되었고 해당 메서드가 호출 될 시점에 상품 리스트 데이터를 GET해오는 것으로 셀을 업데이트 해줄 수 있었습니다.
+
+- API 문서를 해석하여 명시된 요구사항 어떤 방법으로 준수하면 되는지에 대한 고민
+    1. 문서를 읽으며, Content-Type, Mime-Type, multipart/formdata, Request, Response, httpMethod, header, body, required 등 생소한 요구사항이 많았습니다.
+    2. MDN 및 공식문서, 기타 블로그 등을 참고하여 해당 용어의 의미를 찾아보려고 노력습니다.
+    3. 해당 용어에 대해 이해한 후에는 PostMan 프로그램을 활용하여 요구사항에 충족하도록 Key와 Value를 여러번 바꿔가면 시도해보았습니다. 결국, response의 statusCode가 200-299 얻을 수 있었습니다.
+    4. 이를 swift 환경에서 어떻게 구현하면 좋을지 생각해보았고, davBeck의 github 오픈소스 - MultipartForm을 참조하여 사전에 해당 오픈소스 내부 코드를 분석해 보았습니다.
+    5. 결과로 swift 환경에서 POST와 PATCH를 통해 네트워크에서 데이터를 불러오고 등록 할 수 있게 하였습니다.
 
 ## ❓ 트러블 슈팅
 
@@ -127,21 +163,23 @@
 <details>
     <summary>parsing 모델 타입 구현</summary>
 
-Asset에 저장된 json파일을 파싱하는 타입과 API서버와 통신하여 가져오는 json을 파싱하는 타입을 구현할때 오타가 있었습니다. 
-단위 테스트를 통해 오타가 있었다는것을 뒤늦게 확인할수있었습니다.
-json파일에 매칭해야할 자료형이 많을수록 오타가 나올 확률이 높을것이란 생각이 들었습니다. 
-[json을 swift모델로 바꿔주는사이트](https://app.quicktype.io/)
-이 사이트를 이용해서 json파일을 swift 모델로 바꾸어서 사용했습니다.
-시간도 절약하고 오타를 유발할일이 없기때문에 유용하게 이용했습니다.
+Asset에 저장된 json파일을 파싱하는 타입과 API서버와 통신하여 가져오는 json을 파싱하는 타입을 구현할때 오타가 있었습니다.  
+단위 테스트를 통해 오타가 있었다는것을 뒤늦게 확인할수있었습니다.  
+json파일에 매칭해야할 자료형이 많을수록 오타가 나올 확률이 높을것이란 생각이 들었습니다.  
+[json을 swift모델로 바꿔주는사이트](https://app.quicktype.io/)  
+이 사이트를 이용해서 json파일을 swift 모델로 바꾸어서 사용했습니다.  
+시간도 절약하고 오타를 유발할일이 없기때문에 유용하게 이용했습니다.  
     
 </details>
 
 <details>
 <summary>Metatype & Generic함수를 활용하여 중복되는 코드 해결 </summary>
 
-통신해야할 네트워킹요소가 3가지(`GET:Application HealthChekcer`, `GET:상품리스트조회` ,`GET상품 상세 조회`)이며, 디코딩해야하는 요소는 2가지 였습니다. 따라서, 통신요소에 따라서 너무 많은 중복코드가 발생했고 이를 보완하려고 고민했습니다. 
-하지만, JSONDecoder의 .decode 메서드는 `Decodable` 프로토콜을 준수하는 `타입자체`를 파라미터값으로 전달해주어야만 했습니다. 우리는 `타입자체`를 어떻게 함수의 `Placeholder`로 활용할 지 고민하였습니다.
-결과적으로 제네릭과 메타타입을 공부하여 타입자체(메타타입)을 파라미터값과 Placehorder로 전달하여 이를 해결했습니다. 
+통신해야할 네트워킹요소가 3가지(`GET:Application HealthChekcer`, `GET:상품리스트조회` ,`GET상품 상세 조회`)이며, 디코딩해야하는 요소는 2가지 였습니다.  
+따라서, 통신요소에 따라서 너무 많은 중복코드가 발생했고 이를 보완하려고 고민했습니다.  
+하지만, JSONDecoder의 .decode 메서드는 `Decodable` 프로토콜을 준수하는 `타입자체`를 파라미터값으로 전달해주어야만 했습니다.  
+우리는 `타입자체`를 어떻게 함수의 `Placeholder`로 활용할 지 고민하였습니다.  
+결과적으로 제네릭과 메타타입을 공부하여 타입자체(메타타입)을 파라미터값과 Placehorder로 전달하여 이를 해결했습니다.  
 ```swift
 JSONDecoder().decode(type: Decodable을 준수하는 타입, from: data)
 ```
@@ -152,22 +190,38 @@ JSONDecoder().decode(type: Decodable을 준수하는 타입, from: data)
 <details>
 <summary>NSCache의 한계</summary>
     
-처음에 NSCache를 이용해서 각 셀의 이미지를 구현을했었습니다. 그런데 앱을 종료했다 키면 저장된 캐쉬데이터들이 사라져서 실행할때마다 모든 이미지들이 다 보이기까지 시간이 걸려서 비록 긴시간은 아니지만 조금이라도 기다려야하는 불편한 상황을 경험해야했습니다. NSCache는 Memory Cache영역에 저장되기때문에 발생하게 된 문제인데 이를 해결하기 위해 FileManager로 Disk Cache영역에 저장하는 방식으로 바꾸었습니다. Disk Cache 영역은 앱을 종료했다 켜도 지워지지않는 영역이기때문에 처음 의도한대로 구현할수있었습니다.   
-
+처음에 NSCache를 이용해서 각 셀의 이미지를 구현을했었습니다.  
+그런데 앱을 종료했다 키면 저장된 캐쉬데이터들이 사라져서 실행할때마다 모든 이미지들이 다 보이기까지 시간이 걸려서 비록 긴시간은 아니지만 조금이라도 기다려야하는 불편한 상황을 경험해야했습니다.  
+NSCache는 Memory Cache영역에 저장되기때문에 발생하게 된 문제인데 이를 해결하기 위해 FileManager로 Disk Cache영역에 저장하는 방식으로 바꾸었습니다.  
+Disk Cache 영역은 앱을 종료했다 켜도 지워지지않는 영역이기때문에 처음 의도한대로 구현할수있었습니다.  
+    
 </details>
 
 <details>
 <summary>네트워크 통신으로서 Data(contentsOf:)의 한계점 </summary>
     
-- 네트워크 통신으로 이미지를 가져올 때, 처음에 Data(contentsOf:)를 활용하였고 화면이 스크롤되는 속도와 성능이 매우 저하되었습니다.
-    - 알고보니 이 메서드는 동기적으로 동작하는 메서드였고, 스크롤을 하게되면 현재 작업중인 모든 작업을 해당 작업을 수행하는 동안 멈추게 되고 심할 경우 앱이 종료될 수 있는 위험성이 잠재되어 있는 코드였습니다. 따라서, 비동기로 동작하는 URLSession을 활용하도록 수정해주었고 결과적으로 속도와 성능이 다시 정상적으로 돌아오게 되었습니다. 
-    - 아래는 공식문서에서 권장하는 Data(contentsOf:) 메서드의 적합한 활용방법입니다.
-    - 이 동기식 이니셜라이저를 사용하여 네트워크 기반 URL을 요청하지 마십시오. 네트워크 기반 URL의 경우, 이 방법은 느린 네트워크에서 수십 초 동안 현재 스레드를 차단하여 사용자 환경이 좋지 않을 수 있으며, iOS에서는 앱이 종료될 수 있습니다.대신 파일이 아닌 URL의 경우 URL 세션 클래스의 dataTask(with:completionHandler:) 메서드를 사용해 보십시오. 예는 웹 사이트 데이터를 메모리로 가져오는 것을 참조하십시오.
+- 네트워크 통신으로 이미지를 가져올 때, 처음에 Data(contentsOf:)를 활용하였고 화면이 스크롤되는 속도와 성능이 매우 저하되었습니다.  
+    - 알고보니 이 메서드는 동기적으로 동작하는 메서드였고, 스크롤을 하게되면 현재 작업중인 모든 작업을 해당 작업을 수행하는 동안 멈추게 되고 심할 경우 앱이 종료될 수 있는 위험성이 잠재되어 있는 코드였습니다.  
+    따라서, 비동기로 동작하는 URLSession을 활용하도록 수정해주었고 결과적으로 속도와 성능이 다시 정상적으로 돌아오게 되었습니다.  
+    - 아래는 공식문서에서 권장하는 Data(contentsOf:) 메서드의 적합한 활용방법입니다.  
+    - 이 동기식 이니셜라이저를 사용하여 네트워크 기반 URL을 요청하지 마십시오.  
+    네트워크 기반 URL의 경우, 이 방법은 느린 네트워크에서 수십 초 동안 현재 스레드를 차단하여 사용자 환경이 좋지 않을 수 있으며, iOS에서는 앱이 종료될 수 있습니다.  
+    대신 파일이 아닌 URL의 경우 URL 세션 클래스의 dataTask(with:completionHandler:) 메서드를 사용해 보십시오. 예는 웹 사이트 데이터를 메모리로 가져오는 것을 참조하십시오.  
 
 ![](https://i.imgur.com/b40E8mW.png)
 </details>
 
+### STEP3
 
+<details>
+<summary>multipart/form-data 구조 파악</summary>
+    
+HTTP Request 구조에서 Content-Type중 multipart/form-data의 구조를 처음에 파악하기가 어려웠습니다.  
+가장 기본적이고 많이 쓰이는 application/x-www-form-urlencoded, application/json Content-Type과 무엇이 다른지 하나씩 비교해보면서 학습했습니다.  
+구조를 완전히 이해하는데 2-3일이 걸려 프로젝트에 착수하는데 시간이 많이 부족했었습니다.  
+HTTP Request 구조를 처음 접해보았고 multipart/form-data란 친구를 만났을때 사용 예시를 보고 당황했습니다.  
+이걸 내가 이해할수있을까 걱정되었지만 이해하려고 노력하고 공부하다보면 언젠간 결국 해내게 되는구나라는 깨달음을 얻게 되었습니다.  
+</details>
 
 ## 🔗 참고 링크
 
@@ -175,6 +229,11 @@ JSONDecoder().decode(type: Decodable을 준수하는 타입, from: data)
 [부스트코스 - IOS App Programming](https://www.boostcourse.org/mo326/lecture/16863?isDesc=false)    
 [야곰 닷넷 - 동시성 프로그래밍](https://yagom.net/courses/%eb%8f%99%ec%8b%9c%ec%84%b1-%ed%94%84%eb%a1%9c%ea%b7%b8%eb%9e%98%eb%b0%8d-concurrency-programming/)  
 [Swift 공식문서 - Closures](https://docs.swift.org/swift-book/LanguageGuide/Closures.html)
+[블로그 레나참나 - HTTP multipart/form-data 이해하기](https://lena-chamna.netlify.app/post/http_multipart_form-data/)
+[YouTube - How to send Images in Post Requests w/ Swift (Multipart Form Data)](https://www.youtube.com/watch?v=xhZiKdb68SM&t=14s)
+[YouTube - Image upload example using urlsession in swift ios](https://www.youtube.com/watch?v=qhoL1lp4kiY)
+[Github Opensource: davBeck - MultipartForm](https://github.com/davbeck/MultipartForm)
+[Apple Developer Documentation - UIImagePickerController](https://developer.apple.com/documentation/uikit/uiimagepickercontroller/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -126,11 +126,9 @@
 </details>
 
 ## 📱 실행 화면
-|처음설치|종료후다시실행|
-|:--:|:--:|
-|![Simulator Screen Recording - iPhone 11 - 2022-11-25 at 00 57 15](https://user-images.githubusercontent.com/49121469/203825802-c1a9679c-89b2-4506-917c-05cb88236e39.gif)|![Simulator Screen Recording - iPhone 11 - 2022-11-25 at 00 31 56](https://user-images.githubusercontent.com/49121469/203821039-8767d88d-eedb-492c-ab84-47fb8d534190.gif)|
-|**상품등록**|
-|![](https://i.imgur.com/TkWW9Yt.gif)||
+
+step4 구현 후 추가예정입니다.
+
 ## 👀 고민한 점
 
 ### Step 1


### PR DESCRIPTION
@SungPyo  안녕하세요 웨더! 드디어 오픈마켓 마지막STEP PR을 보내게 되었습니다. STEP 초반에 어려운개념들을 익히느라 많이 애썼는데 후반으로 갈수록 점점 할만하다고 느껴져서 이번 마지막 STEP 진행할때 별 어려움 없이 즐겁게? 코딩한 것 같습니다 ㅎㅎ 
주말에도 PR 날릴 수 있게 허락해 주셔서 감사합니다!

## 🤔 고민했던 점
- 상세화면에 이미지나 데이터들을 전달하는 방법
    - 메인화면에서 셀을 클릭하여 상제화면으로 이동할 때 어떤식으로 이미지와 데이터들을 전달해야 할지 고민해보았습니다.
    - 처음에 프로퍼티로 값을 전달하면 쉽게 구현할 수 있겠다고 생각했습니다.
    - 그런데 상세화면에서 수정화면으로 갔다가 값을 수정하고 다시 상세화면으로 돌아왔을 때, 수정된 값으로 갱신되지 않을거라는 생각을 하게 되었습니다.
    - 그래서 productID만 전달하여 그 ID값으로 API통신으로 값을 받아 올 수 있게 설계하였습니다.

- 썸네일 이미지 변경 기능 부재
    - [서버 API 문서](https://documenter.getpostman.com/view/21303036/2s83znq2Pa#70eadb7c-e766-467e-8db7-c17807e80999)
    - 위 문서의 PATCH 부분에 thumbnail_id라고 썸네일 이미지를 변경가능한 프로퍼티가 있는데 Postman으로 이미지가 바뀌는지 테스트를 해보았습니다. 그런데 동작을 하지 않는 것을 확인했습니다. 
    - 그래서 프로젝트에는 썸네일 이미지 변경 기능을 구현하지 않았습니다.

- 하나의 뷰컨에서 등록과 수정 둘다 기능하도록 구현
    - STEP을 다 구현하고 나서 요구사항 맨 밑으로 스크롤해보니 프로젝트 수행 중 핵심 경험에 '상속 혹은 프로토콜 기본구현을 통해 (수정/등록 과정의) 공통기능 구현' 이런 내용을 뒤늦게 발견했습니다.
    - 결론적으로 이렇게 구현을 하지 못했습니다.
    - 등록화면과 수정화면의 구성이 매우 비슷하다 생각해서 등록화면 따로 수정화면 따로 이렇게 만들 생각을 하지 않고 
    - ProductPostAndPatchViewController 처럼 하나의 뷰컨이 등록과 수정을 할수 있게 만들면 되겠다고 생각하고 구현했습니다.